### PR TITLE
Add artwork mode to Library Filter

### DIFF
--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -26,6 +26,7 @@
 
 class QColor;
 class QDir;
+class QHeaderView;
 class QIcon;
 class QImage;
 class QKeySequence;
@@ -62,6 +63,8 @@ FYUTILS_EXPORT QPixmap changePixmapColour(const QPixmap& orig, const QColor& col
 FYUTILS_EXPORT QMainWindow* getMainWindow();
 FYUTILS_EXPORT void showMessageBox(const QString& text, const QString& infoText);
 FYUTILS_EXPORT void appendMenuActions(QMenu* originalMenu, QMenu* menu);
+FYUTILS_EXPORT int visibleSectionCount(const QHeaderView* headerView);
+FYUTILS_EXPORT int realVisualIndex(const QHeaderView* headerView, int logicalIndex);
 
 FYUTILS_EXPORT bool isDarkMode();
 FYUTILS_EXPORT QIcon iconFromTheme(const QString& icon);

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -64,6 +64,7 @@ FYUTILS_EXPORT QMainWindow* getMainWindow();
 FYUTILS_EXPORT void showMessageBox(const QString& text, const QString& infoText);
 FYUTILS_EXPORT void appendMenuActions(QMenu* originalMenu, QMenu* menu);
 FYUTILS_EXPORT int visibleSectionCount(const QHeaderView* headerView);
+FYUTILS_EXPORT int firstVisualIndex(const QHeaderView* headerView);
 FYUTILS_EXPORT int realVisualIndex(const QHeaderView* headerView, int logicalIndex);
 
 FYUTILS_EXPORT bool isDarkMode();

--- a/include/utils/widgets/expandedtreeview.h
+++ b/include/utils/widgets/expandedtreeview.h
@@ -57,9 +57,7 @@ public:
     [[nodiscard]] bool uniformRowHeights() const;
     void setUniformRowHeights(bool enabled);
 
-    [[nodiscard]] int itemWidth() const;
-    void setItemWidth(int width);
-    void setIconSize(const QSize& size);
+    void changeIconSize(const QSize& size);
 
     [[nodiscard]] QRect visualRect(const QModelIndex& index) const override;
     [[nodiscard]] int sizeHintForColumn(int column) const override;

--- a/include/utils/widgets/expandedtreeview.h
+++ b/include/utils/widgets/expandedtreeview.h
@@ -84,6 +84,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
     void timerEvent(QTimerEvent* event) override;

--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -1153,9 +1153,7 @@ bool PlaylistModel::removeColumn(int column)
     beginRemoveColumns({}, column, column);
 
     m_columns.erase(m_columns.cbegin() + column);
-    if(std::cmp_less(column, m_columns.size())) {
-        m_columnAlignments.erase(m_columnAlignments.cbegin() + column);
-    }
+    resetColumnAlignment(column);
 
     for(auto& [_, node] : m_nodes) {
         node.removeColumn(column);

--- a/src/plugins/filters/CMakeLists.txt
+++ b/src/plugins/filters/CMakeLists.txt
@@ -15,4 +15,5 @@ create_fooyin_plugin_internal(
             settings/filtersettings.cpp
             settings/filterscolumnpage.cpp
             settings/filtersgeneralpage.cpp
+            settings/filtersguipage.cpp
 )

--- a/src/plugins/filters/filterdelegate.cpp
+++ b/src/plugins/filters/filterdelegate.cpp
@@ -49,10 +49,8 @@ QSize FilterDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelI
 
     opt.decorationSize = option.decorationSize;
 
-    const QWidget* widget = opt.widget;
-    const QStyle* style   = widget ? widget->style() : QApplication::style();
-
-    QSize size = style->sizeFromContents(QStyle::CT_ItemViewItem, &opt, {}, widget);
+    const QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
+    QSize size          = style->sizeFromContents(QStyle::CT_ItemViewItem, &opt, {}, opt.widget);
 
     const QSize sizeHint = index.data(Qt::SizeHintRole).toSize();
     if(sizeHint.height() > 0) {

--- a/src/plugins/filters/filteritem.cpp
+++ b/src/plugins/filters/filteritem.cpp
@@ -32,6 +32,13 @@ bool sort(const QCollator& collator, int column, Qt::SortOrder order, const Fooy
         return false;
     }
 
+    if(lhs->isSummary() && !rhs->isSummary()) {
+        return true;
+    }
+    if(!lhs->isSummary() && rhs->isSummary()) {
+        return false;
+    }
+
     const auto cmp = collator.compare(lhs->column(column), rhs->column(column));
 
     if(cmp == 0) {
@@ -54,6 +61,7 @@ FilterItem::FilterItem(QString key, QStringList columns, FilterItem* parent)
     : TreeItem{parent}
     , m_key{std::move(key)}
     , m_columns{std::move(columns)}
+    , m_isSummary{false}
 { }
 
 QString FilterItem::key() const
@@ -92,6 +100,16 @@ void FilterItem::setColumns(const QStringList& columns)
 void FilterItem::removeColumn(int column)
 {
     m_columns.remove(column);
+}
+
+bool FilterItem::isSummary() const
+{
+    return m_isSummary;
+}
+
+void FilterItem::setIsSummary(bool isSummary)
+{
+    m_isSummary = isSummary;
 }
 
 void FilterItem::addTrack(const Track& track)

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -33,6 +33,7 @@ public:
     enum FilterItemRole
     {
         Tracks = Qt::UserRole,
+        IsSummary
     };
 
     FilterItem() = default;
@@ -49,6 +50,9 @@ public:
     void setColumns(const QStringList& columns);
     void removeColumn(int column);
 
+    [[nodiscard]] bool isSummary() const;
+    void setIsSummary(bool isSummary);
+
     void addTrack(const Track& track);
     void addTracks(const TrackList& tracks);
     void removeTrack(const Track& track);
@@ -61,5 +65,6 @@ private:
     QString m_key;
     QStringList m_columns;
     TrackList m_tracks;
+    bool m_isSummary;
 };
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -453,6 +453,20 @@ void FilterModel::changeColumnAlignment(int column, Qt::Alignment alignment)
     p->m_columnAlignments[column] = alignment;
 }
 
+void FilterModel::resetColumnAlignment(int column)
+{
+    if(column < 0 || std::cmp_greater_equal(column, p->m_columnAlignments.size())) {
+        return;
+    }
+
+    p->m_columnAlignments.erase(p->m_columnAlignments.begin() + column);
+}
+
+void FilterModel::resetColumnAlignments()
+{
+    p->m_columnAlignments.clear();
+}
+
 QModelIndexList FilterModel::indexesForValues(const QStringList& values, int column) const
 {
     QModelIndexList indexes;
@@ -570,9 +584,7 @@ bool FilterModel::removeColumn(int column)
     beginRemoveColumns({}, column, column);
 
     p->m_columns.erase(p->m_columns.cbegin() + column);
-    if(std::cmp_less(column, p->m_columns.size())) {
-        p->m_columnAlignments.erase(p->m_columnAlignments.cbegin() + column);
-    }
+    resetColumnAlignment(column);
 
     for(auto& [_, node] : p->m_nodes) {
         node.removeColumn(column);

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -24,12 +24,12 @@
 #include "filterpopulator.h"
 
 #include <core/track.h>
+#include <gui/coverprovider.h>
 #include <gui/guiconstants.h>
 #include <utils/widgets/autoheaderview.h>
 
 #include <QColor>
 #include <QFont>
-#include <QFontMetrics>
 #include <QIODevice>
 #include <QMimeData>
 #include <QSize>
@@ -68,28 +68,35 @@ struct FilterModel::Private
 
     QThread m_populatorThread;
     FilterPopulator m_populator;
+    CoverProvider m_coverProvider;
 
-    FilterItem m_allNode;
+    FilterItem m_summaryNode;
     ItemKeyMap m_nodes;
     TrackIdNodeMap m_trackParents;
 
     FilterColumnList m_columns;
     int m_sortColumn{0};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
+    bool m_showDecoration{false};
 
     using ColumnAlignments = std::vector<Qt::Alignment>;
     mutable ColumnAlignments m_columnAlignments;
 
+    bool m_showSummary{true};
     int m_rowHeight{0};
     QFont m_font;
     QColor m_colour;
 
     TrackList m_tracksPendingRemoval;
 
-    explicit Private(FilterModel* self)
+    explicit Private(FilterModel* self, SettingsManager* settings)
         : m_self{self}
+        , m_coverProvider{settings}
     {
         m_populator.moveToThread(&m_populatorThread);
+
+        QObject::connect(&m_coverProvider, &CoverProvider::coverAdded, m_self,
+                         [this](const Track& track) { coverUpdated(track); });
     }
 
     void beginReset()
@@ -98,8 +105,23 @@ struct FilterModel::Private
         m_nodes.clear();
         m_trackParents.clear();
 
-        m_allNode = FilterItem{QStringLiteral(""), {}, m_self->rootItem()};
-        m_self->rootItem()->appendChild(&m_allNode);
+        if(m_showSummary) {
+            addSummary();
+        }
+    }
+
+    void addSummary()
+    {
+        m_summaryNode = FilterItem{QStringLiteral(""), {}, m_self->rootItem()};
+        m_summaryNode.setIsSummary(true);
+        m_self->rootItem()->insertChild(0, &m_summaryNode);
+    }
+
+    void removeSummary()
+    {
+        const int row = m_summaryNode.row();
+        m_self->rootItem()->removeChild(row);
+        m_summaryNode = {};
     }
 
     void batchFinished(PendingTreeData data)
@@ -123,21 +145,27 @@ struct FilterModel::Private
         QMetaObject::invokeMethod(m_self, &FilterModel::modelUpdated);
     }
 
-    int uniqueValues(int column)
+    int uniqueValues(int column) const
     {
         std::set<QString> columnUniques;
 
-        const auto children = m_allNode.children();
+        const auto children = m_self->rootItem()->children();
 
         for(FilterItem* item : children) {
-            columnUniques.emplace(item->column(column));
+            if(!item->isSummary()) {
+                columnUniques.emplace(item->column(column));
+            }
         }
 
         return static_cast<int>(columnUniques.size());
     }
 
-    void updateAllNode()
+    void updateSummary()
     {
+        if(!m_showSummary) {
+            return;
+        }
+
         const int columnCount = m_self->columnCount({});
 
         QStringList nodeColumns;
@@ -146,23 +174,25 @@ struct FilterModel::Private
                 QString{tr("All (%1 %2s)")}.arg(uniqueValues(column)).arg(m_columns.at(column).name.toLower()));
         }
 
-        m_allNode.setColumns(nodeColumns);
+        m_summaryNode.setColumns(nodeColumns);
     }
 
     void populateModel(PendingTreeData& data)
     {
+        auto* parent = m_self->rootItem();
+
         for(const auto& [key, item] : data.items) {
             if(m_nodes.contains(key)) {
                 m_nodes.at(key).addTracks(item.tracks());
             }
             else {
                 if(!m_resetting) {
-                    const int row = m_allNode.childCount();
-                    m_self->beginInsertRows(m_self->indexOfItem(&m_allNode), row, row);
+                    const int row = parent->childCount();
+                    m_self->beginInsertRows(m_self->indexOfItem(parent), row, row);
                 }
 
                 FilterItem* child = &m_nodes.emplace(key, item).first->second;
-                m_allNode.appendChild(child);
+                parent->appendChild(child);
 
                 if(!m_resetting) {
                     m_self->endInsertRows();
@@ -171,14 +201,32 @@ struct FilterModel::Private
         }
         m_trackParents.merge(data.trackParents);
 
-        m_allNode.sortChildren(m_sortColumn, m_sortOrder);
-        updateAllNode();
+        parent->sortChildren(m_sortColumn, m_sortOrder);
+        updateSummary();
+    }
+
+    void coverUpdated(const Track& track)
+    {
+        if(!m_trackParents.contains(track.id())) {
+            return;
+        }
+
+        const auto parents = m_trackParents.at(track.id());
+
+        for(const QString& parentKey : parents) {
+            if(m_nodes.contains(parentKey)) {
+                auto* parentItem = &m_nodes.at(parentKey);
+
+                const QModelIndex nodeIndex = m_self->indexOfItem(parentItem);
+                emit m_self->dataChanged(nodeIndex, nodeIndex, {Qt::DecorationRole});
+            }
+        }
     }
 };
 
-FilterModel::FilterModel(QObject* parent)
+FilterModel::FilterModel(SettingsManager* settings, QObject* parent)
     : TreeModel{parent}
-    , p{std::make_unique<Private>(this)}
+    , p{std::make_unique<Private>(this, settings)}
 {
     QObject::connect(&p->m_populator, &FilterPopulator::populated, this,
                      [this](const PendingTreeData& data) { p->batchFinished(data); });
@@ -212,8 +260,13 @@ void FilterModel::sortOnColumn(int column, Qt::SortOrder order)
     p->m_sortOrder  = order;
 
     emit layoutAboutToBeChanged();
-    p->m_allNode.sortChildren(column, order);
+    rootItem()->sortChildren(column, order);
     emit layoutChanged();
+}
+
+bool FilterModel::showSummary() const
+{
+    return p->m_showSummary;
 }
 
 void FilterModel::setFont(const QString& font)
@@ -240,10 +293,37 @@ void FilterModel::setRowHeight(int height)
     emit dataChanged({}, {});
 }
 
+void FilterModel::setShowSummary(bool show)
+{
+    const bool prev = std::exchange(p->m_showSummary, show);
+    if(prev == show) {
+        return;
+    }
+
+    if(show) {
+        beginInsertRows({}, 0, 0);
+        p->addSummary();
+        p->updateSummary();
+        endInsertRows();
+    }
+    else {
+        const int row = p->m_summaryNode.row();
+        beginRemoveRows({}, row, row);
+        p->removeSummary();
+        endRemoveRows();
+    }
+}
+
+void FilterModel::setShowDecoration(bool show)
+{
+    p->m_showDecoration = show;
+}
+
 Qt::ItemFlags FilterModel::flags(const QModelIndex& index) const
 {
     Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index);
     defaultFlags |= Qt::ItemIsDragEnabled;
+
     return defaultFlags;
 }
 
@@ -305,6 +385,16 @@ QVariant FilterModel::data(const QModelIndex& index, int role) const
         }
         case(FilterItem::Tracks):
             return QVariant::fromValue(item->tracks());
+        case(FilterItem::IsSummary):
+            return item->isSummary();
+        case(Qt::DecorationRole):
+            if(p->m_showDecoration) {
+                if(item->trackCount() > 0) {
+                    return p->m_coverProvider.trackCoverThumbnail(item->tracks().front());
+                }
+                return p->m_coverProvider.trackCoverThumbnail({});
+            }
+            break;
         case(Qt::SizeHintRole):
             return QSize{0, p->m_rowHeight};
         case(Qt::FontRole):
@@ -367,15 +457,7 @@ QModelIndexList FilterModel::indexesForValues(const QStringList& values, int col
 {
     QModelIndexList indexes;
 
-    if(values.contains(QStringLiteral(""))) {
-        indexes.append(indexOfItem(&p->m_allNode));
-
-        if(values.size() == 1) {
-            return indexes;
-        }
-    }
-
-    const auto rows = p->m_allNode.children();
+    const auto rows = rootItem()->children();
     for(const auto& child : rows) {
         if(values.contains(child->column(column))) {
             indexes.append(indexOfItem(child));
@@ -462,19 +544,21 @@ void FilterModel::removeTracks(const TrackList& tracks)
         }
     }
 
+    auto* parent = rootItem();
+
     for(FilterItem* item : items) {
         if(item->trackCount() == 0) {
-            const QModelIndex parentIndex = indexOfItem(&p->m_allNode);
-            const int row                 = item->row();
+            const QModelIndex parentIndex;
+            const int row = item->row();
             beginRemoveRows(parentIndex, row, row);
-            p->m_allNode.removeChild(row);
-            p->m_allNode.resetChildren();
+            parent->removeChild(row);
+            parent->resetChildren();
             endRemoveRows();
             p->m_nodes.erase(item->key());
         }
     }
 
-    p->updateAllNode();
+    p->updateSummary();
 }
 
 bool FilterModel::removeColumn(int column)

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -25,7 +25,10 @@
 #include <core/track.h>
 #include <utils/treemodel.h>
 
-namespace Fooyin::Filters {
+namespace Fooyin {
+class SettingsManager;
+
+namespace Filters {
 struct FilterOptions;
 
 class FilterModel : public TreeModel<FilterItem>
@@ -33,16 +36,19 @@ class FilterModel : public TreeModel<FilterItem>
     Q_OBJECT
 
 public:
-    explicit FilterModel(QObject* parent = nullptr);
+    explicit FilterModel(SettingsManager* settings, QObject* parent = nullptr);
     ~FilterModel() override;
 
     [[nodiscard]] int sortColumn() const;
     [[nodiscard]] Qt::SortOrder sortOrder() const;
     void sortOnColumn(int column, Qt::SortOrder order);
+    [[nodiscard]] bool showSummary() const;
 
     void setFont(const QString& font);
     void setColour(const QColor& colour);
     void setRowHeight(int height);
+    void setShowSummary(bool show);
+    void setShowDecoration(bool show);
 
     [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
     [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
@@ -54,7 +60,7 @@ public:
     [[nodiscard]] Qt::DropActions supportedDragActions() const override;
     [[nodiscard]] QMimeData* mimeData(const QModelIndexList& indexes) const override;
 
-    Qt::Alignment columnAlignment(int column) const;
+    [[nodiscard]] Qt::Alignment columnAlignment(int column) const;
     void changeColumnAlignment(int column, Qt::Alignment alignment);
 
     [[nodiscard]] QModelIndexList indexesForValues(const QStringList& values, int column = 0) const;
@@ -74,4 +80,5 @@ private:
     struct Private;
     std::unique_ptr<Private> p;
 };
-} // namespace Fooyin::Filters
+} // namespace Filters
+} // namespace Fooyin

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -62,6 +62,8 @@ public:
 
     [[nodiscard]] Qt::Alignment columnAlignment(int column) const;
     void changeColumnAlignment(int column, Qt::Alignment alignment);
+    void resetColumnAlignment(int column);
+    void resetColumnAlignments();
 
     [[nodiscard]] QModelIndexList indexesForValues(const QStringList& values, int column = 0) const;
 

--- a/src/plugins/filters/filtersplugin.cpp
+++ b/src/plugins/filters/filtersplugin.cpp
@@ -24,6 +24,7 @@
 #include "settings/filterscolumnpage.h"
 #include "settings/filtersettings.h"
 #include "settings/filtersgeneralpage.h"
+#include "settings/filtersguipage.h"
 
 #include <gui/editablelayout.h>
 #include <gui/layoutprovider.h>
@@ -46,6 +47,7 @@ struct FiltersPlugin::Private
     std::unique_ptr<FiltersSettings> filterSettings;
 
     std::unique_ptr<FiltersGeneralPage> generalPage;
+    std::unique_ptr<FiltersGuiPage> guiPage;
     std::unique_ptr<FiltersColumnPage> columnsPage;
 
     void registerLayouts() const
@@ -108,6 +110,7 @@ void FiltersPlugin::initialise(const GuiPluginContext& context)
         tr("Library Filter"));
 
     p->generalPage = std::make_unique<FiltersGeneralPage>(p->settings);
+    p->guiPage     = std::make_unique<FiltersGuiPage>(p->settings);
     p->columnsPage = std::make_unique<FiltersColumnPage>(p->actionManager, p->settings);
 
     p->registerLayouts();

--- a/src/plugins/filters/filterview.cpp
+++ b/src/plugins/filters/filterview.cpp
@@ -37,7 +37,7 @@ FilterView::FilterView(QWidget* parent)
     setDragDropMode(QAbstractItemView::DragOnly);
     setDefaultDropAction(Qt::CopyAction);
     setDropIndicatorShown(true);
-    // setUniformRowHeights(true);
+    setUniformRowHeights(true);
 }
 
 void FilterView::mousePressEvent(QMouseEvent* event)

--- a/src/plugins/filters/filterview.cpp
+++ b/src/plugins/filters/filterview.cpp
@@ -22,27 +22,22 @@
 #include <QHeaderView>
 #include <QMenu>
 #include <QMouseEvent>
+#include <QPainter>
 
 namespace Fooyin::Filters {
 FilterView::FilterView(QWidget* parent)
-    : QTreeView(parent)
+    : ExpandedTreeView{parent}
 {
     setObjectName(QStringLiteral("FilterView"));
 
     setSelectionBehavior(QAbstractItemView::SelectRows);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
-    setMouseTracking(true);
-    setRootIsDecorated(false);
-    setItemsExpandable(false);
-    setIndentation(0);
-    setExpandsOnDoubleClick(false);
     setTextElideMode(Qt::ElideRight);
     setDragEnabled(true);
     setDragDropMode(QAbstractItemView::DragOnly);
     setDefaultDropAction(Qt::CopyAction);
     setDropIndicatorShown(true);
-    setSortingEnabled(false);
-    setUniformRowHeights(true);
+    // setUniformRowHeights(true);
 }
 
 void FilterView::mousePressEvent(QMouseEvent* event)
@@ -54,7 +49,7 @@ void FilterView::mousePressEvent(QMouseEvent* event)
         setDragEnabled(selectionModel()->isSelected(index));
     }
 
-    QTreeView::mousePressEvent(event);
+    ExpandedTreeView::mousePressEvent(event);
 
     if(!index.isValid()) {
         clearSelection();
@@ -71,12 +66,12 @@ void FilterView::mouseDoubleClickEvent(QMouseEvent* event)
         return;
     }
 
-    QTreeView::mouseDoubleClickEvent(event);
+    ExpandedTreeView::mouseDoubleClickEvent(event);
 }
 
 void FilterView::keyPressEvent(QKeyEvent* event)
 {
-    QTreeView::keyPressEvent(event);
+    ExpandedTreeView::keyPressEvent(event);
 
     const auto key = event->key();
     if(key == Qt::Key_Enter || key == Qt::Key_Return) { }

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -134,8 +134,7 @@ struct FilterWidget::Private
         hideHeader(!m_settings->value<Settings::Filters::FilterHeader>());
         setScrollbarEnabled(m_settings->value<Settings::Filters::FilterScrollBar>());
         m_view->setAlternatingRowColors(m_settings->value<Settings::Filters::FilterAltColours>());
-        m_view->setItemWidth(m_settings->value<Settings::Filters::FilterIconItemWidth>());
-        m_view->setIconSize(m_settings->value<Settings::Filters::FilterIconSize>().toSize());
+        m_view->changeIconSize(m_settings->value<Settings::Filters::FilterIconSize>().toSize());
 
         setupConnections();
 
@@ -151,10 +150,8 @@ struct FilterWidget::Private
             m_model->setRowHeight(height);
             QMetaObject::invokeMethod(m_view->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
         });
-        m_settings->subscribe<Settings::Filters::FilterIconItemWidth>(
-            m_self, [this](const int width) { m_view->setItemWidth(width); });
         m_settings->subscribe<Settings::Filters::FilterIconSize>(
-            m_self, [this](const auto& size) { m_view->setIconSize(size.toSize()); });
+            m_self, [this](const auto& size) { m_view->changeIconSize(size.toSize()); });
     }
 
     void setupConnections()

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -238,8 +238,8 @@ struct FilterWidget::Private
         auto* displayMenu  = new QMenu(tr("Display"), menu);
         auto* displayGroup = new QActionGroup(displayMenu);
 
-        auto* displayList = new QAction(tr("List"), displayGroup);
-        auto* displayIcon = new QAction(tr("Icon"), displayGroup);
+        auto* displayList = new QAction(tr("Columns"), displayGroup);
+        auto* displayIcon = new QAction(tr("Artwork"), displayGroup);
 
         displayList->setCheckable(true);
         displayIcon->setCheckable(true);

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -113,8 +113,6 @@ struct FilterWidget::Private
     {
         m_view->setModel(m_model);
         m_view->setHeader(m_header);
-        m_view->setUniformRowHeights(true);
-        m_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         m_view->setItemDelegate(new FilterDelegate(m_self));
         m_view->viewport()->installEventFilter(new ToolTipFilter(m_self));
 

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -167,6 +167,8 @@ struct FilterWidget::Private
         QObject::connect(m_view, &ExpandedTreeView::viewModeChanged, m_self, [this](ExpandedTreeView::ViewMode mode) {
             m_model->setShowDecoration(mode == ExpandedTreeView::ViewMode::Icon);
         });
+        QObject::connect(m_view, &QAbstractItemView::iconSizeChanged, m_self,
+                         [this](const QSize& size) { m_settings->set<Settings::Filters::FilterIconSize>(size); });
         QObject::connect(m_view, &FilterView::doubleClicked, m_self,
                          [this]() { emit m_self->doubleClicked(playlistNameFromSelection()); });
         QObject::connect(m_view, &FilterView::middleClicked, m_self,

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -32,6 +32,7 @@
 #include <core/track.h>
 #include <utils/actions/widgetcontext.h>
 #include <utils/async.h>
+#include <utils/enum.h>
 #include <utils/settings/settingsmanager.h>
 #include <utils/tooltipfilter.h>
 #include <utils/widgets/autoheaderview.h>
@@ -46,26 +47,29 @@
 #include <set>
 
 namespace {
-Fooyin::TrackList fetchAllTracks(QTreeView* view)
+Fooyin::TrackList fetchAllTracks(QAbstractItemView* view)
 {
     std::set<int> ids;
     Fooyin::TrackList tracks;
 
-    const QModelIndex parent = view->model()->index(0, 0, {});
-    const int rowCount       = view->model()->rowCount(parent);
+    const QModelIndex parent;
+    const int rowCount = view->model()->rowCount(parent);
 
-    for(int row = 0; row < rowCount; ++row) {
+    for(int row{0}; row < rowCount; ++row) {
         const QModelIndex index = view->model()->index(row, 0, parent);
-        const auto indexTracks  = index.data(Fooyin::Filters::FilterItem::Tracks).value<Fooyin::TrackList>();
+        if(!index.data(Fooyin::Filters::FilterItem::IsSummary).toBool()) {
+            const auto indexTracks = index.data(Fooyin::Filters::FilterItem::Tracks).value<Fooyin::TrackList>();
 
-        for(const Fooyin::Track& track : indexTracks) {
-            const int id = track.id();
-            if(!ids.contains(id)) {
-                ids.emplace(id);
-                tracks.push_back(track);
+            for(const Fooyin::Track& track : indexTracks) {
+                const int id = track.id();
+                if(!ids.contains(id)) {
+                    ids.emplace(id);
+                    tracks.push_back(track);
+                }
             }
         }
     }
+
     return tracks;
 }
 } // namespace
@@ -103,12 +107,16 @@ struct FilterWidget::Private
         , m_settings{settings}
         , m_view{new FilterView(m_self)}
         , m_header{new AutoHeaderView(Qt::Horizontal, m_self)}
-        , m_model{new FilterModel(m_self)}
+        , m_model{new FilterModel(m_settings, m_self)}
         , m_widgetContext{
               new WidgetContext(m_self, Context{Id{"Fooyin.Context.FilterWidget."}.append(m_self->id())}, m_self)}
     {
+        m_view->setModel(m_model);
         m_view->setHeader(m_header);
+        m_view->setUniformRowHeights(true);
         m_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        m_view->setItemDelegate(new FilterDelegate(m_self));
+        m_view->viewport()->installEventFilter(new ToolTipFilter(m_self));
 
         m_header->setStretchEnabled(true);
         m_header->setSortIndicatorShown(true);
@@ -124,6 +132,50 @@ struct FilterWidget::Private
         m_model->setFont(m_settings->value<Settings::Filters::FilterFont>());
         m_model->setColour(m_settings->value<Settings::Filters::FilterColour>());
         m_model->setRowHeight(m_settings->value<Settings::Filters::FilterRowHeight>());
+
+        hideHeader(!m_settings->value<Settings::Filters::FilterHeader>());
+        setScrollbarEnabled(m_settings->value<Settings::Filters::FilterScrollBar>());
+        m_view->setAlternatingRowColors(m_settings->value<Settings::Filters::FilterAltColours>());
+        m_view->setItemWidth(m_settings->value<Settings::Filters::FilterIconItemWidth>());
+        m_view->setIconSize(m_settings->value<Settings::Filters::FilterIconSize>().toSize());
+
+        setupConnections();
+
+        m_settings->subscribe<Settings::Filters::FilterAltColours>(m_view, &QAbstractItemView::setAlternatingRowColors);
+        m_settings->subscribe<Settings::Filters::FilterHeader>(m_self, [this](bool enabled) { hideHeader(!enabled); });
+        m_settings->subscribe<Settings::Filters::FilterScrollBar>(
+            m_self, [this](bool enabled) { setScrollbarEnabled(enabled); });
+        m_settings->subscribe<Settings::Filters::FilterFont>(m_self,
+                                                             [this](const QString& font) { m_model->setFont(font); });
+        m_settings->subscribe<Settings::Filters::FilterColour>(
+            m_self, [this](const QString& colour) { m_model->setColour(colour); });
+        m_settings->subscribe<Settings::Filters::FilterRowHeight>(m_self, [this](const int height) {
+            m_model->setRowHeight(height);
+            QMetaObject::invokeMethod(m_view->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
+        });
+        m_settings->subscribe<Settings::Filters::FilterIconItemWidth>(
+            m_self, [this](const int width) { m_view->setItemWidth(width); });
+        m_settings->subscribe<Settings::Filters::FilterIconSize>(
+            m_self, [this](const auto& size) { m_view->setIconSize(size.toSize()); });
+    }
+
+    void setupConnections()
+    {
+        QObject::connect(&m_columnRegistry, &FilterColumnRegistry::columnChanged, m_self,
+                         [this](const Filters::FilterColumn& column) { columnChanged(column); });
+
+        QObject::connect(m_header, &QHeaderView::sortIndicatorChanged, m_model, &FilterModel::sortOnColumn);
+        QObject::connect(m_header, &FilterView::customContextMenuRequested, m_self,
+                         [this](const QPoint& pos) { filterHeaderMenu(pos); });
+        QObject::connect(m_view->selectionModel(), &QItemSelectionModel::selectionChanged, m_self,
+                         [this]() { selectionChanged(); });
+        QObject::connect(m_view, &ExpandedTreeView::viewModeChanged, m_self, [this](ExpandedTreeView::ViewMode mode) {
+            m_model->setShowDecoration(mode == ExpandedTreeView::ViewMode::Icon);
+        });
+        QObject::connect(m_view, &FilterView::doubleClicked, m_self,
+                         [this]() { emit m_self->doubleClicked(playlistNameFromSelection()); });
+        QObject::connect(m_view, &FilterView::middleClicked, m_self,
+                         [this]() { emit m_self->middleClicked(playlistNameFromSelection()); });
     }
 
     [[nodiscard]] QString playlistNameFromSelection() const
@@ -148,7 +200,7 @@ struct FilterWidget::Private
         TrackList selectedTracks;
 
         for(const auto& selectedIndex : selected) {
-            if(!selectedIndex.parent().isValid()) {
+            if(selectedIndex.data(FilterItem::IsSummary).toBool()) {
                 selectedTracks = fetchAllTracks(m_view);
                 break;
             }
@@ -174,6 +226,49 @@ struct FilterWidget::Private
     {
         m_header->setFixedHeight(hide ? 0 : QWIDGETSIZE_MAX);
         m_header->adjustSize();
+    }
+
+    void setScrollbarEnabled(bool enabled) const
+    {
+        m_view->setVerticalScrollBarPolicy(enabled ? Qt::ScrollBarAsNeeded : Qt::ScrollBarAlwaysOff);
+    }
+
+    void addDisplayMenu(QMenu* menu)
+    {
+        auto* displayMenu  = new QMenu(tr("Display"), menu);
+        auto* displayGroup = new QActionGroup(displayMenu);
+
+        auto* displayList = new QAction(tr("List"), displayGroup);
+        auto* displayIcon = new QAction(tr("Icon"), displayGroup);
+
+        displayList->setCheckable(true);
+        displayIcon->setCheckable(true);
+
+        const auto currentMode = m_view->viewMode();
+        if(currentMode == ExpandedTreeView::ViewMode::Tree) {
+            displayList->setChecked(true);
+        }
+        else {
+            displayIcon->setChecked(true);
+        }
+
+        QObject::connect(displayList, &QAction::triggered, m_self,
+                         [this]() { m_view->setViewMode(ExpandedTreeView::ViewMode::Tree); });
+        QObject::connect(displayIcon, &QAction::triggered, m_self,
+                         [this]() { m_view->setViewMode(ExpandedTreeView::ViewMode::Icon); });
+
+        auto* displaySummary = new QAction(tr("Summary item"), displayMenu);
+        displaySummary->setCheckable(true);
+        displaySummary->setChecked(m_model->showSummary());
+        QObject::connect(displaySummary, &QAction::triggered, m_self,
+                         [this](bool checked) { m_model->setShowSummary(checked); });
+
+        displayMenu->addAction(displayList);
+        displayMenu->addAction(displayIcon);
+        displayMenu->addSeparator();
+        displayMenu->addAction(displaySummary);
+
+        menu->addMenu(displayMenu);
     }
 
     void filterHeaderMenu(const QPoint& pos)
@@ -236,6 +331,8 @@ struct FilterWidget::Private
         menu->addSeparator();
         m_header->addHeaderAlignmentMenu(menu, m_self->mapToGlobal(pos));
 
+        addDisplayMenu(menu);
+
         menu->addSeparator();
         auto* manageConnections = new QAction(tr("Manage Groups"), menu);
         QObject::connect(manageConnections, &QAction::triggered, m_self,
@@ -245,7 +342,7 @@ struct FilterWidget::Private
         menu->popup(m_self->mapToGlobal(pos));
     }
 
-    bool hasColumn(int id) const
+    [[nodiscard]] bool hasColumn(int id) const
     {
         return std::ranges::any_of(m_columns, [id](const FilterColumn& column) { return column.id == id; });
     }
@@ -272,43 +369,7 @@ FilterWidget::FilterWidget(SettingsManager* settings, QWidget* parent)
     auto* layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
-    p->m_view->setModel(p->m_model);
-    p->m_view->setItemDelegate(new FilterDelegate(this));
-    p->m_view->viewport()->installEventFilter(new ToolTipFilter(this));
-
     layout->addWidget(p->m_view);
-
-    p->hideHeader(!p->m_settings->value<Settings::Filters::FilterHeader>());
-    setScrollbarEnabled(p->m_settings->value<Settings::Filters::FilterScrollBar>());
-    p->m_view->setAlternatingRowColors(p->m_settings->value<Settings::Filters::FilterAltColours>());
-
-    QObject::connect(&p->m_columnRegistry, &FilterColumnRegistry::columnChanged, this,
-                     [this](const Filters::FilterColumn& column) { p->columnChanged(column); });
-
-    QObject::connect(p->m_model, &QAbstractItemModel::modelReset, this, [this]() { p->m_view->expandAll(); });
-    QObject::connect(p->m_header, &QHeaderView::sortIndicatorChanged, p->m_model, &FilterModel::sortOnColumn);
-    QObject::connect(p->m_header, &FilterView::customContextMenuRequested, this,
-                     [this](const QPoint& pos) { p->filterHeaderMenu(pos); });
-    QObject::connect(p->m_view->selectionModel(), &QItemSelectionModel::selectionChanged, this,
-                     [this]() { p->selectionChanged(); });
-
-    QObject::connect(p->m_view, &FilterView::doubleClicked, this,
-                     [this]() { emit doubleClicked(p->playlistNameFromSelection()); });
-    QObject::connect(p->m_view, &FilterView::middleClicked, this,
-                     [this]() { emit middleClicked(p->playlistNameFromSelection()); });
-
-    p->m_settings->subscribe<Settings::Filters::FilterAltColours>(p->m_view,
-                                                                  &QAbstractItemView::setAlternatingRowColors);
-    p->m_settings->subscribe<Settings::Filters::FilterHeader>(this, [this](bool enabled) { p->hideHeader(!enabled); });
-    p->m_settings->subscribe<Settings::Filters::FilterScrollBar>(this, &FilterWidget::setScrollbarEnabled);
-    p->m_settings->subscribe<Settings::Filters::FilterFont>(this,
-                                                            [this](const QString& font) { p->m_model->setFont(font); });
-    p->m_settings->subscribe<Settings::Filters::FilterColour>(
-        this, [this](const QString& colour) { p->m_model->setColour(colour); });
-    p->m_settings->subscribe<Settings::Filters::FilterRowHeight>(this, [this](const int height) {
-        p->m_model->setRowHeight(height);
-        QMetaObject::invokeMethod(p->m_view->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
-    });
 }
 
 FilterWidget::~FilterWidget()
@@ -422,11 +483,6 @@ void FilterWidget::softReset(const TrackList& tracks)
         Qt::SingleShotConnection);
 }
 
-void FilterWidget::setScrollbarEnabled(bool enabled)
-{
-    p->m_view->setVerticalScrollBarPolicy(enabled ? Qt::ScrollBarAsNeeded : Qt::ScrollBarAlwaysOff);
-}
-
 QString FilterWidget::name() const
 {
     return tr("Library Filter");
@@ -452,22 +508,24 @@ void FilterWidget::saveLayoutData(QJsonObject& layout)
         columns.push_back(colStr);
     }
 
-    layout[QStringLiteral("Columns")] = columns.join(QStringLiteral("|"));
+    layout[u"Columns"]     = columns.join(QStringLiteral("|"));
+    layout[u"Display"]     = static_cast<int>(p->m_view->viewMode());
+    layout[u"ShowSummary"] = p->m_model->showSummary();
 
     QByteArray state = p->m_header->saveHeaderState();
     state            = qCompress(state, 9);
 
-    layout[QStringLiteral("Group")] = p->m_group.name();
-    layout[QStringLiteral("Index")] = p->m_index;
-    layout[QStringLiteral("State")] = QString::fromUtf8(state.toBase64());
+    layout[u"Group"] = p->m_group.name();
+    layout[u"Index"] = p->m_index;
+    layout[u"State"] = QString::fromUtf8(state.toBase64());
 }
 
 void FilterWidget::loadLayoutData(const QJsonObject& layout)
 {
-    if(layout.contains(QStringLiteral("Columns"))) {
+    if(layout.contains(u"Columns")) {
         p->m_columns.clear();
 
-        const QString columnData    = layout.value(QStringLiteral("Columns")).toString();
+        const QString columnData    = layout.value(u"Columns").toString();
         const QStringList columnIds = columnData.split(QStringLiteral("|"));
 
         for(int i{0}; const auto& columnId : columnIds) {
@@ -487,18 +545,26 @@ void FilterWidget::loadLayoutData(const QJsonObject& layout)
         }
     }
 
-    if(layout.contains(QStringLiteral("Group"))) {
-        p->m_group = Id{layout.value(QStringLiteral("Group")).toString()};
+    if(layout.contains(u"Display")) {
+        p->m_view->setViewMode(static_cast<ExpandedTreeView::ViewMode>(layout.value(u"Display").toInt()));
     }
 
-    if(layout.contains(QStringLiteral("Index"))) {
-        p->m_index = layout.value(QStringLiteral("Index")).toInt();
+    if(layout.contains(u"ShowSummary")) {
+        p->m_model->setShowSummary(layout.value(u"ShowSummary").toBool());
+    }
+
+    if(layout.contains(u"Group")) {
+        p->m_group = Id{layout.value(u"Group").toString()};
+    }
+
+    if(layout.contains(u"Index")) {
+        p->m_index = layout.value(u"Index").toInt();
     }
 
     emit filterUpdated();
 
-    if(layout.contains(QStringLiteral("State"))) {
-        auto state = QByteArray::fromBase64(layout.value(QStringLiteral("State")).toString().toUtf8());
+    if(layout.contains(u"State")) {
+        auto state = QByteArray::fromBase64(layout.value(u"State").toString().toUtf8());
 
         if(state.isEmpty()) {
             return;

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -55,8 +55,6 @@ public:
     void reset(const TrackList& tracks);
     void softReset(const TrackList& tracks);
 
-    void setScrollbarEnabled(bool enabled);
-
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
     void saveLayoutData(QJsonObject& layout) override;

--- a/src/plugins/filters/settings/filtersettings.cpp
+++ b/src/plugins/filters/settings/filtersettings.cpp
@@ -45,7 +45,6 @@ FiltersSettings::FiltersSettings(SettingsManager* settingsManager)
     m_settings->createSetting<FilterRowHeight>(0, QStringLiteral("Filters/RowHeight"));
     m_settings->createSetting<FilterSendPlayback>(true, QStringLiteral("Filters/StartPlaybackOnSend"));
     m_settings->createSetting<FilterKeepAlive>(false, QStringLiteral("Filters/KeepAlive"));
-    m_settings->createSetting<FilterIconItemWidth>(100, QStringLiteral("Filters/IconItemWidth"));
     m_settings->createSetting<FilterIconSize>(QSize{100, 100}, QStringLiteral("Filters/IconSize"));
 }
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/settings/filtersettings.cpp
+++ b/src/plugins/filters/settings/filtersettings.cpp
@@ -45,6 +45,8 @@ FiltersSettings::FiltersSettings(SettingsManager* settingsManager)
     m_settings->createSetting<FilterRowHeight>(0, QStringLiteral("Filters/RowHeight"));
     m_settings->createSetting<FilterSendPlayback>(true, QStringLiteral("Filters/StartPlaybackOnSend"));
     m_settings->createSetting<FilterKeepAlive>(false, QStringLiteral("Filters/KeepAlive"));
+    m_settings->createSetting<FilterIconItemWidth>(180, QStringLiteral("Filters/IconItemWidth"));
+    m_settings->createSetting<FilterIconSize>(QSize{180, 180}, QStringLiteral("Filters/IconSize"));
 }
 } // namespace Fooyin::Filters
 

--- a/src/plugins/filters/settings/filtersettings.cpp
+++ b/src/plugins/filters/settings/filtersettings.cpp
@@ -45,8 +45,8 @@ FiltersSettings::FiltersSettings(SettingsManager* settingsManager)
     m_settings->createSetting<FilterRowHeight>(0, QStringLiteral("Filters/RowHeight"));
     m_settings->createSetting<FilterSendPlayback>(true, QStringLiteral("Filters/StartPlaybackOnSend"));
     m_settings->createSetting<FilterKeepAlive>(false, QStringLiteral("Filters/KeepAlive"));
-    m_settings->createSetting<FilterIconItemWidth>(180, QStringLiteral("Filters/IconItemWidth"));
-    m_settings->createSetting<FilterIconSize>(QSize{180, 180}, QStringLiteral("Filters/IconSize"));
+    m_settings->createSetting<FilterIconItemWidth>(100, QStringLiteral("Filters/IconItemWidth"));
+    m_settings->createSetting<FilterIconSize>(QSize{100, 100}, QStringLiteral("Filters/IconSize"));
 }
 } // namespace Fooyin::Filters
 

--- a/src/plugins/filters/settings/filtersettings.h
+++ b/src/plugins/filters/settings/filtersettings.h
@@ -42,8 +42,9 @@ enum FiltersSettings : uint32_t
     FilterColour          = 10 | Type::String,
     FilterRowHeight       = 11 | Type::Int,
     FilterSendPlayback    = 12 | Type::Bool,
-    FilterKeepAlive       = 13 | Type::Bool
-
+    FilterKeepAlive       = 13 | Type::Bool,
+    FilterIconItemWidth   = 14 | Type::Int,
+    FilterIconSize        = 15 | Type::Variant
 };
 Q_ENUM_NS(FiltersSettings)
 } // namespace Settings::Filters

--- a/src/plugins/filters/settings/filtersettings.h
+++ b/src/plugins/filters/settings/filtersettings.h
@@ -43,8 +43,7 @@ enum FiltersSettings : uint32_t
     FilterRowHeight       = 11 | Type::Int,
     FilterSendPlayback    = 12 | Type::Bool,
     FilterKeepAlive       = 13 | Type::Bool,
-    FilterIconItemWidth   = 14 | Type::Int,
-    FilterIconSize        = 15 | Type::Variant
+    FilterIconSize        = 14 | Type::Variant
 };
 Q_ENUM_NS(FiltersSettings)
 } // namespace Settings::Filters

--- a/src/plugins/filters/settings/filtersguipage.cpp
+++ b/src/plugins/filters/settings/filtersguipage.cpp
@@ -100,9 +100,9 @@ FiltersGuiPageWidget::FiltersGuiPageWidget(SettingsManager* settings)
     m_iconWidth->setMaximum(2048);
     m_iconHeight->setMaximum(2048);
 
-    m_itemWidth->setSingleStep(25);
-    m_iconWidth->setSingleStep(25);
-    m_iconHeight->setSingleStep(25);
+    m_itemWidth->setSingleStep(20);
+    m_iconWidth->setSingleStep(20);
+    m_iconHeight->setSingleStep(20);
 
     widthLabel->setIndent(25);
     heightLabel->setIndent(25);

--- a/src/plugins/filters/settings/filtersguipage.cpp
+++ b/src/plugins/filters/settings/filtersguipage.cpp
@@ -1,0 +1,207 @@
+/*
+ * Fooyin
+ * Copyright © 2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filtersguipage.h"
+
+#include "constants.h"
+#include "filtersettings.h"
+
+#include <gui/guiconstants.h>
+#include <utils/settings/settingsmanager.h>
+#include <utils/utils.h>
+#include <utils/widgets/colourbutton.h>
+#include <utils/widgets/fontbutton.h>
+
+#include <QCheckBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QSpinBox>
+
+namespace Fooyin::Filters {
+class FiltersGuiPageWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    explicit FiltersGuiPageWidget(SettingsManager* settings);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    SettingsManager* m_settings;
+
+    QCheckBox* m_filterHeaders;
+    QCheckBox* m_filterScrollBars;
+    QCheckBox* m_altRowColours;
+
+    FontButton* m_fontButton;
+    ColourButton* m_colourButton;
+    QCheckBox* m_overrideRowHeight;
+    QSpinBox* m_rowHeight;
+    QSpinBox* m_itemWidth;
+    QSpinBox* m_iconWidth;
+    QSpinBox* m_iconHeight;
+};
+
+FiltersGuiPageWidget::FiltersGuiPageWidget(SettingsManager* settings)
+    : m_settings{settings}
+    , m_filterHeaders{new QCheckBox(tr("Show headers"), this)}
+    , m_filterScrollBars{new QCheckBox(tr("Show scrollbars"), this)}
+    , m_altRowColours{new QCheckBox(tr("Alternating row colours"), this)}
+    , m_fontButton{new FontButton(Utils::iconFromTheme(Fooyin::Constants::Icons::Font), QStringLiteral(""), this)}
+    , m_colourButton{new ColourButton(this)}
+    , m_overrideRowHeight{new QCheckBox(tr("Override row height") + QStringLiteral(":"), this)}
+    , m_rowHeight{new QSpinBox(this)}
+    , m_itemWidth{new QSpinBox(this)}
+    , m_iconWidth{new QSpinBox(this)}
+    , m_iconHeight{new QSpinBox(this)}
+{
+    auto* appearance       = new QGroupBox(tr("Appearance"), this);
+    auto* appearanceLayout = new QGridLayout(appearance);
+
+    auto* fontLabel   = new QLabel(tr("Font") + QStringLiteral(":"), this);
+    auto* colourLabel = new QLabel(tr("Colour") + QStringLiteral(":"), this);
+
+    m_rowHeight->setMinimum(1);
+
+    auto* artworkMode   = new QGroupBox(tr("Artwork Mode"), this);
+    auto* artworkLayout = new QGridLayout(artworkMode);
+
+    auto* itemWidthLabel = new QLabel(tr("Item width") + QStringLiteral(":"), this);
+    auto* iconSizeLabel  = new QLabel(tr("Artwork") + QStringLiteral(":"), this);
+
+    auto* widthLabel  = new QLabel(tr("Width") + QStringLiteral(":"), this);
+    auto* heightLabel = new QLabel(tr("Height") + QStringLiteral(":"), this);
+
+    m_itemWidth->setSuffix(QStringLiteral("px"));
+    m_iconWidth->setSuffix(QStringLiteral("px"));
+    m_iconHeight->setSuffix(QStringLiteral("px"));
+
+    m_itemWidth->setMaximum(2048);
+    m_iconWidth->setMaximum(2048);
+    m_iconHeight->setMaximum(2048);
+
+    m_itemWidth->setSingleStep(25);
+    m_iconWidth->setSingleStep(25);
+    m_iconHeight->setSingleStep(25);
+
+    widthLabel->setIndent(25);
+    heightLabel->setIndent(25);
+
+    artworkLayout->addWidget(itemWidthLabel, 0, 0);
+    artworkLayout->addWidget(m_itemWidth, 0, 1);
+    artworkLayout->addWidget(iconSizeLabel, 1, 0);
+    artworkLayout->addWidget(widthLabel, 2, 0);
+    artworkLayout->addWidget(m_iconWidth, 2, 1);
+    artworkLayout->addWidget(heightLabel, 3, 0);
+    artworkLayout->addWidget(m_iconHeight, 3, 1);
+    artworkLayout->setColumnStretch(2, 1);
+
+    int row{0};
+    appearanceLayout->addWidget(m_filterHeaders, row++, 0, 1, 2);
+    appearanceLayout->addWidget(m_filterScrollBars, row++, 0, 1, 2);
+    appearanceLayout->addWidget(m_altRowColours, row++, 0, 1, 2);
+    appearanceLayout->addWidget(m_overrideRowHeight, row, 0, 1, 2);
+    appearanceLayout->addWidget(m_rowHeight, row++, 2);
+    appearanceLayout->addWidget(fontLabel, row, 0);
+    appearanceLayout->addWidget(m_fontButton, row++, 1, 1, 2);
+    appearanceLayout->addWidget(colourLabel, row, 0);
+    appearanceLayout->addWidget(m_colourButton, row++, 1, 1, 2);
+    appearanceLayout->setColumnStretch(3, 1);
+
+    auto* mainLayout = new QGridLayout(this);
+    mainLayout->addWidget(appearance, 0, 0);
+    mainLayout->addWidget(artworkMode, 1, 0);
+    mainLayout->setRowStretch(mainLayout->rowCount(), 1);
+
+    QObject::connect(m_overrideRowHeight, &QCheckBox::toggled, this,
+                     [this](bool checked) { m_rowHeight->setEnabled(checked); });
+}
+
+void FiltersGuiPageWidget::load()
+{
+    m_filterHeaders->setChecked(m_settings->value<Settings::Filters::FilterHeader>());
+    m_filterScrollBars->setChecked(m_settings->value<Settings::Filters::FilterScrollBar>());
+    m_altRowColours->setChecked(m_settings->value<Settings::Filters::FilterAltColours>());
+
+    m_fontButton->setButtonFont(m_settings->value<Settings::Filters::FilterFont>());
+    m_colourButton->setColour(m_settings->value<Settings::Filters::FilterColour>());
+    m_overrideRowHeight->setChecked(m_settings->value<Settings::Filters::FilterRowHeight>() > 0);
+    m_rowHeight->setValue(m_settings->value<Settings::Filters::FilterRowHeight>());
+    m_rowHeight->setEnabled(m_overrideRowHeight->isChecked());
+    m_itemWidth->setValue(m_settings->value<Settings::Filters::FilterIconItemWidth>());
+
+    const auto iconSize = m_settings->value<Settings::Filters::FilterIconSize>().toSize();
+    m_iconWidth->setValue(iconSize.width());
+    m_iconHeight->setValue(iconSize.height());
+}
+
+void FiltersGuiPageWidget::apply()
+{
+    m_settings->set<Settings::Filters::FilterHeader>(m_filterHeaders->isChecked());
+    m_settings->set<Settings::Filters::FilterScrollBar>(m_filterScrollBars->isChecked());
+    m_settings->set<Settings::Filters::FilterAltColours>(m_altRowColours->isChecked());
+
+    if(m_fontButton->fontChanged()) {
+        m_settings->set<Settings::Filters::FilterFont>(m_fontButton->buttonFont().toString());
+    }
+    if(m_colourButton->colourChanged()) {
+        m_settings->set<Settings::Filters::FilterColour>(m_colourButton->colour().name());
+    }
+
+    if(m_overrideRowHeight->isChecked()) {
+        m_settings->set<Settings::Filters::FilterRowHeight>(m_rowHeight->value());
+    }
+    else {
+        m_settings->reset<Settings::Filters::FilterRowHeight>();
+    }
+
+    m_settings->set<Settings::Filters::FilterIconItemWidth>(m_itemWidth->value());
+    const QSize iconSize{m_iconWidth->value(), m_iconHeight->value()};
+    m_settings->set<Settings::Filters::FilterIconSize>(iconSize);
+}
+
+void FiltersGuiPageWidget::reset()
+{
+    m_settings->reset<Settings::Filters::FilterHeader>();
+    m_settings->reset<Settings::Filters::FilterScrollBar>();
+    m_settings->reset<Settings::Filters::FilterAltColours>();
+
+    m_settings->reset<Settings::Filters::FilterFont>();
+    m_settings->reset<Settings::Filters::FilterColour>();
+    m_settings->reset<Settings::Filters::FilterRowHeight>();
+    m_settings->reset<Settings::Filters::FilterIconItemWidth>();
+    m_settings->reset<Settings::Filters::FilterIconSize>();
+}
+
+FiltersGuiPage::FiltersGuiPage(SettingsManager* settings)
+    : SettingsPage{settings->settingsDialog()}
+{
+    setId(Constants::Page::FiltersAppearance);
+    setName(tr("Appearance"));
+    setCategory({tr("Plugins"), tr("Filters")});
+    setWidgetCreator([settings] { return new FiltersGuiPageWidget(settings); });
+}
+} // namespace Fooyin::Filters
+
+#include "filtersguipage.moc"
+#include "moc_filtersguipage.cpp"

--- a/src/plugins/filters/settings/filtersguipage.cpp
+++ b/src/plugins/filters/settings/filtersguipage.cpp
@@ -57,7 +57,6 @@ private:
     ColourButton* m_colourButton;
     QCheckBox* m_overrideRowHeight;
     QSpinBox* m_rowHeight;
-    QSpinBox* m_itemWidth;
     QSpinBox* m_iconWidth;
     QSpinBox* m_iconHeight;
 };
@@ -71,7 +70,6 @@ FiltersGuiPageWidget::FiltersGuiPageWidget(SettingsManager* settings)
     , m_colourButton{new ColourButton(this)}
     , m_overrideRowHeight{new QCheckBox(tr("Override row height") + QStringLiteral(":"), this)}
     , m_rowHeight{new QSpinBox(this)}
-    , m_itemWidth{new QSpinBox(this)}
     , m_iconWidth{new QSpinBox(this)}
     , m_iconHeight{new QSpinBox(this)}
 {
@@ -86,37 +84,26 @@ FiltersGuiPageWidget::FiltersGuiPageWidget(SettingsManager* settings)
     auto* artworkMode   = new QGroupBox(tr("Artwork Mode"), this);
     auto* artworkLayout = new QGridLayout(artworkMode);
 
-    auto* itemWidthLabel = new QLabel(tr("Item width") + QStringLiteral(":"), this);
-    auto* iconSizeLabel  = new QLabel(tr("Artwork") + QStringLiteral(":"), this);
-
     auto* widthLabel  = new QLabel(tr("Width") + QStringLiteral(":"), this);
     auto* heightLabel = new QLabel(tr("Height") + QStringLiteral(":"), this);
 
-    m_itemWidth->setSuffix(QStringLiteral("px"));
     m_iconWidth->setSuffix(QStringLiteral("px"));
     m_iconHeight->setSuffix(QStringLiteral("px"));
 
-    m_itemWidth->setMaximum(2048);
     m_iconWidth->setMaximum(2048);
     m_iconHeight->setMaximum(2048);
 
-    m_itemWidth->setSingleStep(20);
     m_iconWidth->setSingleStep(20);
     m_iconHeight->setSingleStep(20);
 
-    widthLabel->setIndent(25);
-    heightLabel->setIndent(25);
-
-    artworkLayout->addWidget(itemWidthLabel, 0, 0);
-    artworkLayout->addWidget(m_itemWidth, 0, 1);
-    artworkLayout->addWidget(iconSizeLabel, 1, 0);
-    artworkLayout->addWidget(widthLabel, 2, 0);
-    artworkLayout->addWidget(m_iconWidth, 2, 1);
-    artworkLayout->addWidget(heightLabel, 3, 0);
-    artworkLayout->addWidget(m_iconHeight, 3, 1);
+    int row{0};
+    artworkLayout->addWidget(widthLabel, row, 0);
+    artworkLayout->addWidget(m_iconWidth, row++, 1);
+    artworkLayout->addWidget(heightLabel, row, 0);
+    artworkLayout->addWidget(m_iconHeight, row++, 1);
     artworkLayout->setColumnStretch(2, 1);
 
-    int row{0};
+    row = 0;
     appearanceLayout->addWidget(m_filterHeaders, row++, 0, 1, 2);
     appearanceLayout->addWidget(m_filterScrollBars, row++, 0, 1, 2);
     appearanceLayout->addWidget(m_altRowColours, row++, 0, 1, 2);
@@ -148,7 +135,6 @@ void FiltersGuiPageWidget::load()
     m_overrideRowHeight->setChecked(m_settings->value<Settings::Filters::FilterRowHeight>() > 0);
     m_rowHeight->setValue(m_settings->value<Settings::Filters::FilterRowHeight>());
     m_rowHeight->setEnabled(m_overrideRowHeight->isChecked());
-    m_itemWidth->setValue(m_settings->value<Settings::Filters::FilterIconItemWidth>());
 
     const auto iconSize = m_settings->value<Settings::Filters::FilterIconSize>().toSize();
     m_iconWidth->setValue(iconSize.width());
@@ -175,7 +161,6 @@ void FiltersGuiPageWidget::apply()
         m_settings->reset<Settings::Filters::FilterRowHeight>();
     }
 
-    m_settings->set<Settings::Filters::FilterIconItemWidth>(m_itemWidth->value());
     const QSize iconSize{m_iconWidth->value(), m_iconHeight->value()};
     m_settings->set<Settings::Filters::FilterIconSize>(iconSize);
 }
@@ -189,7 +174,6 @@ void FiltersGuiPageWidget::reset()
     m_settings->reset<Settings::Filters::FilterFont>();
     m_settings->reset<Settings::Filters::FilterColour>();
     m_settings->reset<Settings::Filters::FilterRowHeight>();
-    m_settings->reset<Settings::Filters::FilterIconItemWidth>();
     m_settings->reset<Settings::Filters::FilterIconSize>();
 }
 

--- a/src/plugins/filters/settings/filtersguipage.h
+++ b/src/plugins/filters/settings/filtersguipage.h
@@ -19,22 +19,18 @@
 
 #pragma once
 
-#include <utils/widgets/expandedtreeview.h>
+#include <utils/settings/settingspage.h>
 
-namespace Fooyin::Filters {
-class FilterView : public ExpandedTreeView
+namespace Fooyin {
+class SettingsManager;
+
+namespace Filters {
+class FiltersGuiPage : public SettingsPage
 {
     Q_OBJECT
 
 public:
-    explicit FilterView(QWidget* parent = nullptr);
-
-signals:
-    void middleClicked();
-
-protected:
-    void mousePressEvent(QMouseEvent* event) override;
-    void mouseDoubleClickEvent(QMouseEvent* event) override;
-    void keyPressEvent(QKeyEvent* event) override;
+    explicit FiltersGuiPage(SettingsManager* settings);
 };
-} // namespace Fooyin::Filters
+} // namespace Filters
+} // namespace Fooyin

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -325,6 +325,20 @@ int visibleSectionCount(const QHeaderView* headerView)
     return visibleCount;
 }
 
+int firstVisualIndex(const QHeaderView* headerView)
+{
+    int visibleCount{0};
+    const int count = headerView->count();
+    for(int section{0}; section < count; ++section) {
+        const int logical = headerView->logicalIndex(section);
+        if(!headerView->isSectionHidden(logical)) {
+            return visibleCount;
+        }
+        ++visibleCount;
+    }
+    return visibleCount;
+}
+
 int realVisualIndex(const QHeaderView* headerView, int logicalIndex)
 {
     if(headerView->isSectionHidden(logicalIndex)) {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -20,6 +20,7 @@
 #include <utils/utils.h>
 
 #include <QApplication>
+#include <QHeaderView>
 #include <QIcon>
 #include <QLabel>
 #include <QMainWindow>
@@ -310,6 +311,40 @@ void appendMenuActions(QMenu* originalMenu, QMenu* menu)
     for(QAction* action : actions) {
         menu->addAction(action);
     }
+}
+
+int visibleSectionCount(const QHeaderView* headerView)
+{
+    int visibleCount{0};
+    const int count = headerView->count();
+    for(int section{0}; section < count; ++section) {
+        if(!headerView->isSectionHidden(section)) {
+            ++visibleCount;
+        }
+    }
+    return visibleCount;
+}
+
+int realVisualIndex(const QHeaderView* headerView, int logicalIndex)
+{
+    if(headerView->isSectionHidden(logicalIndex)) {
+        return -1;
+    }
+
+    int realIndex{0};
+
+    const int count = headerView->count();
+    for(int i{0}; i < count; ++i) {
+        const int section = headerView->logicalIndex(i);
+        if(!headerView->isSectionHidden(section)) {
+            if(section == logicalIndex) {
+                return realIndex;
+            }
+            ++realIndex;
+        }
+    }
+
+    return -1;
 }
 
 bool isDarkMode()

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -1587,7 +1587,7 @@ private:
 
     QRect m_layoutBounds;
     int m_segmentSize{0};
-    int m_itemSpacing{0};
+    int m_itemSpacing{10};
     int m_rowSpacing{10};
     mutable int m_uniformBaseHeight{0};
     mutable int m_uniformRowHeight{0};
@@ -1674,7 +1674,7 @@ void IconView::invalidate()
     m_uniformBaseHeight    = 0;
     m_uniformCaptionHeight = 0;
     m_segmentSize          = 0;
-    m_itemSpacing          = 0;
+    m_itemSpacing          = 10;
 }
 
 void IconView::doItemLayout()
@@ -1686,7 +1686,7 @@ void IconView::doItemLayout()
     const QPoint topLeft{m_layoutBounds.x(), m_layoutBounds.y() + m_rowSpacing};
 
     const int segStartPosition{m_layoutBounds.left()};
-    const int segEndPosition{m_layoutBounds.right()};
+    const int segEndPosition{m_layoutBounds.right() - m_itemSpacing};
 
     int deltaSegPosition{0};
     int segPosition{topLeft.y()};
@@ -1695,7 +1695,7 @@ void IconView::doItemLayout()
     const int count = itemCount();
     for(int i{0}; i < count; ++i) {
         if(m_segmentSize == 0) {
-            if(topLeft.x() + (i + 1) * itemWidth() > segEndPosition) {
+            if(topLeft.x() + (i + 1) * (itemWidth() + m_itemSpacing) > segEndPosition) {
                 m_segmentSize = std::max(i, 1);
                 break;
             }
@@ -1707,7 +1707,7 @@ void IconView::doItemLayout()
     }
 
     const int totalWidthAvailable = segEndPosition - segStartPosition;
-    const int totalItemWidth      = m_segmentSize * itemWidth();
+    const int totalItemWidth      = m_segmentSize * (itemWidth() + m_itemSpacing);
     const int remainingSpace      = totalWidthAvailable - totalItemWidth;
     m_itemSpacing                 = std::max(m_itemSpacing, remainingSpace / (m_segmentSize + 1));
 
@@ -1919,8 +1919,6 @@ void IconView::drawItem(QPainter* painter, const QStyleOptionViewItem& option, c
 
     opt.state.setFlag(QStyle::State_MouseOver, hoverRow);
 
-    // const QPoint offset       = m_p->m_scrollDelayOffset;
-    // const int y               = opt.rect.y() + offset.y();
     const int left            = m_leftAndRight.first;
     const int right           = m_leftAndRight.second;
     const QModelIndex current = m_view->currentIndex();

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -3387,11 +3387,10 @@ void ExpandedTreeView::startDrag(Qt::DropActions supportedActions)
         return;
     }
 
-    QWindow* window    = windowHandle();
-    const double scale = window ? window->devicePixelRatio() : 1.0;
-
-    QPixmap pixmap{rect.size() * scale};
-    pixmap.setDevicePixelRatio(scale);
+    const qreal dpr = devicePixelRatioF();
+    const auto size = rect.size() * dpr;
+    QPixmap pixmap{size};
+    pixmap.setDevicePixelRatio(dpr);
 
     pixmap.fill(Qt::transparent);
     QPainter painter{&pixmap};

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -1192,6 +1192,10 @@ void TreeView::drawRow(QPainter* painter, const QStyleOptionViewItem& option, co
 
     opt.state.setFlag(QStyle::State_MouseOver, hoverRow);
 
+    if(m_view->alternatingRowColors()) {
+        opt.features.setFlag(QStyleOptionViewItem::Alternate, index.row() & 1);
+    }
+
     if(model()->hasChildren(index)) {
         // Span first column of headers/subheaders
         opt.rect.setX(0);

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -28,7 +28,7 @@
 #include <QStack>
 #include <QStylePainter>
 #include <QTimer>
-#include <QWindow>
+#include <QWheelEvent>
 
 #include <set>
 
@@ -3162,6 +3162,22 @@ void ExpandedTreeView::mousePressEvent(QMouseEvent* event)
 
     auto command = selectionCommand(index, event);
     selectModel->select(selection, command);
+}
+
+void ExpandedTreeView::wheelEvent(QWheelEvent* event)
+{
+    if(!(event->modifiers() & Qt::ControlModifier)) {
+        QAbstractItemView::wheelEvent(event);
+        return;
+    }
+
+    const int delta     = event->angleDelta().y();
+    const int increment = (delta > 0) ? 1 : -1;
+    int newSize         = iconSize().width() + increment * 2;
+    newSize             = std::clamp(newSize, 16, 1024);
+    changeIconSize({newSize, newSize});
+
+    event->accept();
 }
 
 void ExpandedTreeView::resizeEvent(QResizeEvent* event)

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -1592,7 +1592,6 @@ private:
     mutable int m_uniformBaseHeight{0};
     mutable int m_uniformRowHeight{0};
     mutable int m_uniformCaptionHeight{0};
-    mutable QSize m_iconSize;
 };
 
 void IconView::drawView(QPainter* painter, const QRegion& region) const
@@ -1676,7 +1675,6 @@ void IconView::invalidate()
     m_uniformCaptionHeight = 0;
     m_segmentSize          = 0;
     m_itemSpacing          = 0;
-    m_iconSize             = {};
 }
 
 void IconView::doItemLayout()
@@ -1878,29 +1876,7 @@ int IconView::spacing() const
 
 QSize IconView::iconSize() const
 {
-    if(m_iconSize.isValid()) {
-        return m_iconSize;
-    }
-
-    QSize size;
-
-    const int visibleCount = Utils::visibleSectionCount(header());
-    if(visibleCount > 1) {
-        int visualIndex{0};
-        while(header()->isSectionHidden(header()->logicalIndex(visualIndex))) {
-            ++visualIndex;
-        }
-
-        const int firstColumn = header()->logicalIndex(visualIndex);
-        const int width       = header()->sectionSize(firstColumn) / visibleCount;
-        size                  = {width, width};
-    }
-    else {
-        size = m_view->iconSize();
-    }
-
-    m_iconSize = size;
-    return m_iconSize;
+    return m_view->iconSize();
 }
 
 void IconView::prepareItemLayout()

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -2816,7 +2816,7 @@ void ExpandedTreeView::changeIconSize(const QSize& size)
 {
     if(iconSize() != size) {
         setIconSize(size);
-        p->doDelayedItemsLayout();
+        p->doDelayedItemsLayout(100);
     }
 }
 

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -1388,7 +1388,7 @@ int TreeView::indexSizeHint(const QModelIndex& index, bool span) const
     height         = std::max(height, hint);
 
     if(m_p->m_uniformRowHeights) {
-        return m_uniformRowHeight = height;
+        m_uniformRowHeight = height;
     }
 
     return height;
@@ -3101,6 +3101,7 @@ void ExpandedTreeView::dragMoveEvent(QDragMoveEvent* event)
 
     if(!index.isValid() && p->itemCount() > 0) {
         index = p->m_viewItems.back().index;
+        index = index.siblingAtColumn(Utils::firstVisualIndex(p->m_header));
     }
 
     if(index.isValid() && showDropIndicator()) {

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -1857,7 +1857,7 @@ IconView::SizeHint IconView::indexSizeHint(const QModelIndex& index) const
             size.captionHeight = hint.height();
         }
 
-        size.width = std::max(size.width, hint.width());
+        size.width = std::clamp(size.width, hint.width(), iconSize().width() + (2 * MinItemSpacing));
         size.height += hint.height();
     }
 


### PR DESCRIPTION
Adds an icon/artwork view to ExpandedTreeView. Rather than lay out items row by row from top to bottom, it lays them out in a responsive grid, with each column painted below the artwork.

![iconmode](https://github.com/fooyin/fooyin/assets/45490980/1f732a28-7d38-4693-ae9d-2b4aaa713480)

Switching between the standard columns view and artwork view is seamless, and the summary item at the top of each Library Filter can also now be toggled.