### PR TITLE
Always reinit decoder when track was stopped

### DIFF
--- a/src/core/engine/audioplaybackengine.cpp
+++ b/src/core/engine/audioplaybackengine.cpp
@@ -199,22 +199,24 @@ void AudioPlaybackEngine::play()
         return;
     }
 
-    if(m_status == TrackStatus::End && m_state == PlaybackState::Stopped) {
-        seek(0);
-        emit positionChanged(0);
-    }
+    if(m_state == PlaybackState::Stopped) {
+        if(m_status == TrackStatus::Buffered || m_status == TrackStatus::End) {
+            if(m_status == TrackStatus::End) {
+                seek(0);
+                emit positionChanged(0);
+            }
 
-    if(m_state == PlaybackState::Stopped && m_status == TrackStatus::Buffered) {
-        // Current track was previously stopped, so init again
-        if(!m_currentTrack.isInArchive()) {
-            m_file = std::make_unique<QFile>(m_currentTrack.filepath());
-            m_file->open(QIODevice::ReadOnly);
-            m_source.device = m_file.get();
-        }
+            // Current track was previously stopped, so init again
+            if(!m_currentTrack.isInArchive()) {
+                m_file = std::make_unique<QFile>(m_currentTrack.filepath());
+                m_file->open(QIODevice::ReadOnly);
+                m_source.device = m_file.get();
+            }
 
-        if(!m_decoder->init(m_source, m_currentTrack, AudioDecoder::UpdateTracks)) {
-            changeTrackStatus(TrackStatus::Invalid);
-            return;
+            if(!m_decoder->init(m_source, m_currentTrack, AudioDecoder::UpdateTracks)) {
+                changeTrackStatus(TrackStatus::Invalid);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Without this patch, after reaching the end of a playlist, hitting Play again results in occasional segfaults/crashes. I wasn't 100% able to figure out why it sometimes doesn't happen, but this seems to fix it.