### PR TITLE
Clamp fade durations and pause next track if needed

### DIFF
--- a/include/core/engine/enginecontroller.h
+++ b/include/core/engine/enginecontroller.h
@@ -40,6 +40,8 @@ public:
         : QObject{parent}
     { }
 
+    [[nodiscard]] virtual PlaybackState engineState() const = 0;
+
     /** Returns a list of all output names. */
     [[nodiscard]] virtual OutputNames getAllOutputs() const = 0;
 

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -184,7 +184,8 @@ void ApplicationPrivate::setupConnections()
     m_settings->subscribe<Settings::Core::Shutdown>(m_self, [this]() {
         savePlaybackState();
 
-        if(m_playerController->playState() == Player::PlayState::Playing) {
+        const auto state = m_engine.engineState();
+        if(state == PlaybackState::Playing || state == PlaybackState::Fading) {
             QObject::connect(&m_engine, &EngineController::finished, m_self, Application::quit);
             m_playerController->stop();
         }

--- a/src/core/engine/audioplaybackengine.h
+++ b/src/core/engine/audioplaybackengine.h
@@ -79,6 +79,8 @@ private:
     void onBufferProcessed(const AudioBuffer& buffer);
     void onRendererFinished();
 
+    int calculateFadeLength(int initialValue);
+
     std::shared_ptr<AudioLoader> m_decoderProvider;
     ArchiveReader* m_reader;
     AudioDecoder* m_decoder;
@@ -102,6 +104,7 @@ private:
     bool m_ending;
     bool m_decoding;
     bool m_updatingTrack;
+    bool m_pauseNextTrack;
 
     Track m_currentTrack;
     AudioSource m_source;

--- a/src/core/engine/audioplaybackengine.h
+++ b/src/core/engine/audioplaybackengine.h
@@ -79,7 +79,8 @@ private:
     void onBufferProcessed(const AudioBuffer& buffer);
     void onRendererFinished();
 
-    int calculateFadeLength(int initialValue);
+    [[nodiscard]] bool trackIsValid() const;
+    [[nodiscard]] int calculateFadeLength(int initialValue) const;
 
     std::shared_ptr<AudioLoader> m_decoderProvider;
     ArchiveReader* m_reader;

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -93,6 +93,7 @@ void AudioRenderer::stop()
 
     resetFade(0);
     resetBuffer();
+    m_fadeVolume = -1;
 }
 
 void AudioRenderer::closeOutput()
@@ -110,6 +111,7 @@ void AudioRenderer::reset()
 
     resetFade(0);
     resetBuffer();
+    m_fadeVolume = -1;
 }
 
 bool AudioRenderer::isPaused() const

--- a/src/core/engine/enginehandler.cpp
+++ b/src/core/engine/enginehandler.cpp
@@ -246,6 +246,11 @@ void EngineHandler::setup()
     p->changeOutput(p->m_settings->value<Settings::Core::AudioOutput>());
 }
 
+PlaybackState EngineHandler::engineState() const
+{
+    return p->m_engineState;
+}
+
 OutputNames EngineHandler::getAllOutputs() const
 {
     OutputNames outputs;

--- a/src/core/engine/enginehandler.h
+++ b/src/core/engine/enginehandler.h
@@ -42,6 +42,8 @@ public:
 
     void setup();
 
+    [[nodiscard]] PlaybackState engineState() const override;
+
     [[nodiscard]] OutputNames getAllOutputs() const override;
     [[nodiscard]] OutputDevices getOutputDevices(const QString& output) const override;
     void addOutput(const QString& name, OutputCreator output) override;

--- a/src/core/engine/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/ffmpeg/ffmpeginput.cpp
@@ -716,7 +716,7 @@ void FFmpegDecoder::seek(uint64_t pos)
 
 AudioBuffer FFmpegDecoder::readBuffer(size_t bytes)
 {
-    if(!p->m_isDecoding || p->m_error) {
+    if(!p->m_isDecoding || p->m_error || !p->m_context) {
         return {};
     }
 


### PR DESCRIPTION
When playing/pausing/stopping near the end of a track with fading enabled, the fade duration can exceed the
remaining track duration. The current behavior is to cut off the fade before it has fully finished and then start the next track, even if the user pressed pause and expects playback to stop.

This patch clamps fade durations to the remaining track duration and, if pause or stop was pressed, pauses
when reaching the next song.