### PR TITLE
Allow changing album cover alignment

### DIFF
--- a/src/gui/widgets/coverwidget.h
+++ b/src/gui/widgets/coverwidget.h
@@ -28,6 +28,7 @@
 
 class QLabel;
 class QTimer;
+class QVBoxLayout;
 
 namespace Fooyin {
 class CoverProvider;
@@ -66,9 +67,11 @@ private:
 
     SelectionDisplay m_displayOption;
     Track::Cover m_coverType;
+    Qt::Alignment m_coverAlignment;
     bool m_keepAspectRatio;
     QTimer* m_resizeTimer;
 
+    QVBoxLayout* m_coverLayout;
     QLabel* m_coverLabel;
     QPixmap m_cover;
 };


### PR DESCRIPTION
This adds an action group to the album cover context menu allowing the user to change the album cover alignment. The alignment is also saved & loaded from the layout configuration.