### PR TITLE
Use S-curve for longer fade durations

### DIFF
--- a/src/core/engine/audiorenderer.h
+++ b/src/core/engine/audiorenderer.h
@@ -106,6 +106,7 @@ private:
     int m_writeInterval;
 
     QBasicTimer m_fadeTimer;
+    bool m_fadingOut;
     int m_fadeLength;
     int m_fadeSteps;
     int m_currentFadeStep;


### PR DESCRIPTION
This implements a simple S-curve fading algorithm for fade durations over 1000ms. The linear algo makes the end of a fade-out/start of a fade-in sound very abrupt, which this patch fixes.

The formula is not perfect, there is probably a more efficient/better version but this sounds pretty good to me as a start.
I've also changed the code so that pausing/unpausing repeatedly does not reset the fade steps every time.