### PR TITLE
Reverse fade when interrupted

### DIFF
--- a/src/core/engine/audioplaybackengine.cpp
+++ b/src/core/engine/audioplaybackengine.cpp
@@ -294,8 +294,8 @@ void AudioPlaybackEngine::stop()
     };
 
     const bool canFade = playbackState() != PlaybackState::Paused
-                      && m_settings->value<Settings::Core::Internal::EngineFading>()
-                      && m_fadeIntervals.outPauseStop > 0;
+                      && m_settings->value<Settings::Core::Internal::EngineFading>() && m_fadeIntervals.outPauseStop > 0
+                      && m_volume > 0;
     if(canFade) {
         const int fadeLength = calculateFadeLength(m_fadeIntervals.outPauseStop);
         if(fadeLength > 0 && fadeLength < m_fadeIntervals.outPauseStop) {

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -241,12 +241,7 @@ void AudioRenderer::timerEvent(QTimerEvent* event)
     };
 
     const auto currentStep = m_currentFadeStep;
-    const bool inFade      = [this]() {
-        if(m_flipFade) {
-            return m_currentFadeStep-- >= 0;
-        }
-        return m_currentFadeStep++ <= m_fadeSteps;
-    }();
+    const bool inFade      = m_flipFade ? m_currentFadeStep-- >= 0 : m_currentFadeStep++ <= m_fadeSteps;
 
     if(inFade) {
         if(m_fadeLength >= 1000) {

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -45,8 +45,9 @@ AudioRenderer::AudioRenderer(QObject* parent)
     , m_currentBufferResampled{false}
     , m_isRunning{false}
     , m_writeInterval{100}
-    , m_fadingOut{false}
     , m_fadeLength{0}
+    , m_fadingOut{false}
+    , m_flipFade{false}
     , m_fadeSteps{0}
     , m_currentFadeStep{0}
     , m_volumeChange{0.0}
@@ -123,10 +124,12 @@ void AudioRenderer::pause(bool paused, int fadeLength)
     m_fadingOut = paused;
 
     if(paused) {
-        if(m_fadeVolume <= 0) {
-            m_fadeVolume = m_volume;
+        if(!m_flipFade) {
+            if(m_fadeVolume <= 0) {
+                m_fadeVolume = m_volume;
+            }
+            m_volumeChange = -(m_fadeVolume / m_fadeSteps);
         }
-        m_volumeChange = -(m_fadeVolume / m_fadeSteps);
     }
     else {
         if(validOutputState()) {
@@ -134,10 +137,14 @@ void AudioRenderer::pause(bool paused, int fadeLength)
         }
         start();
 
-        if(fadeLength > 0) {
+        if(!m_flipFade && fadeLength > 0) {
             m_fadeVolume   = std::max(m_fadeVolume, 0.0);
             m_volumeChange = std::abs(m_fadeVolume - m_volume) / m_fadeSteps;
         }
+    }
+
+    if(m_flipFade) {
+        m_volumeChange = -m_volumeChange;
     }
 
     m_fadeTimer.start(FadeInterval, this);
@@ -233,11 +240,19 @@ void AudioRenderer::timerEvent(QTimerEvent* event)
         }
     };
 
-    if(m_currentFadeStep <= m_fadeSteps) {
-        if(m_fadeSteps >= 100) {
-            const auto step = static_cast<double>(m_currentFadeStep) / m_fadeSteps;
+    const auto currentStep = m_currentFadeStep;
+    const bool inFade      = [this]() {
+        if(m_flipFade) {
+            return m_currentFadeStep-- >= 0;
+        }
+        return m_currentFadeStep++ <= m_fadeSteps;
+    }();
+
+    if(inFade) {
+        if(m_fadeLength >= 1000) {
+            const auto step = static_cast<double>(currentStep) / m_fadeSteps;
             m_fadeVolume    = m_volume * ((1.0 + std::erfl(3.0 * step - 1.5)) / 2.0);
-            if(m_fadingOut) {
+            if(m_flipFade ^ m_fadingOut) {
                 m_fadeVolume = m_volume - m_fadeVolume;
             }
         }
@@ -246,13 +261,9 @@ void AudioRenderer::timerEvent(QTimerEvent* event)
         }
 
         m_fadeVolume = std::clamp(m_fadeVolume, 0.0, 1.0);
-
         updateOutputVolume();
-        m_currentFadeStep++;
         return;
     }
-
-    m_currentFadeStep = 0;
 
     if(m_volumeChange < 0.0) {
         // Faded out
@@ -261,6 +272,9 @@ void AudioRenderer::timerEvent(QTimerEvent* event)
     else {
         m_fadeVolume = -1;
     }
+
+    m_currentFadeStep = 0;
+    m_flipFade        = false;
 
     updateOutputVolume();
     m_fadeTimer.stop();
@@ -282,11 +296,14 @@ void AudioRenderer::resetFade(int length)
         m_fadeTimer.stop();
     }
 
-    m_fadeSteps = std::abs(m_currentFadeStep - static_cast<int>(static_cast<double>(length) / FadeInterval));
+    m_flipFade   = !m_flipFade && m_currentFadeStep != 0 && length > 0;
+    m_fadeLength = length;
 
-    m_volumeChange    = 0;
-    m_fadeLength      = length;
-    m_currentFadeStep = 0;
+    if(!m_flipFade) {
+        m_fadeSteps       = static_cast<int>(static_cast<double>(length) / FadeInterval);
+        m_currentFadeStep = 0;
+        m_volumeChange    = 0;
+    }
 }
 
 bool AudioRenderer::canWrite() const

--- a/src/core/engine/audiorenderer.h
+++ b/src/core/engine/audiorenderer.h
@@ -106,8 +106,9 @@ private:
     int m_writeInterval;
 
     QBasicTimer m_fadeTimer;
-    bool m_fadingOut;
     int m_fadeLength;
+    bool m_fadingOut;
+    bool m_flipFade;
     int m_fadeSteps;
     int m_currentFadeStep;
     double m_volumeChange;


### PR DESCRIPTION
Here is a better version of the fade steps change from yesterday's PR.

The idea is that if a fade gets interrupted by another fade, instead of completely resetting the fade state, we just
reverse it by decrementing the steps and going backwards on the curve. This makes it possible to quickly pause and unpause without the volume getting choppy at any point.