### PR TITLE
Switch playlist when scrolling over playlist tabs

### DIFF
--- a/include/utils/widgets/editabletabbar.h
+++ b/include/utils/widgets/editabletabbar.h
@@ -51,6 +51,7 @@ signals:
     void tabTextChanged(int index, const QString& text);
 
 protected:
+    bool event(QEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
@@ -59,5 +60,6 @@ private:
     QString m_title;
     EditMode m_mode;
     PopupLineEdit* m_lineEdit;
+    QPoint m_accumDelta;
 };
 } // namespace Fooyin

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -79,7 +79,6 @@ PlaylistTabs::PlaylistTabs(ActionManager* actionManager, WidgetProvider* widgetP
     m_tabs->setMovable(true);
     m_tabs->setTabsClosable(m_settings->value<Settings::Gui::Internal::PlaylistTabsCloseButton>());
     m_tabs->tabBar()->setExpanding(m_settings->value<Settings::Gui::Internal::PlaylistTabsExpand>());
-    m_tabs->tabBar()->installEventFilter(this);
 
     setAcceptDrops(true);
 
@@ -347,34 +346,6 @@ void PlaylistTabs::contextMenuEvent(QContextMenuEvent* event)
     }
 
     menu->popup(mapToGlobal(point));
-}
-
-bool PlaylistTabs::eventFilter(QObject* watched, QEvent* event)
-{
-    if(event->type() != QEvent::Wheel) {
-        return QObject::eventFilter(watched, event);
-    }
-
-    const auto* wheelEvent = static_cast<const QWheelEvent*>(event);
-    auto newIndex          = m_tabs->currentIndex();
-    if(wheelEvent->angleDelta().y() < 0) {
-        newIndex++;
-    }
-    else {
-        newIndex--;
-    }
-
-    const auto highestIndex = m_tabs->tabBar()->count();
-    if(newIndex < 0) {
-        newIndex = highestIndex - 1;
-    }
-    else if(newIndex >= highestIndex) {
-        newIndex = 0;
-    }
-
-    m_tabs->setCurrentIndex(newIndex);
-    tabChanged(newIndex);
-    return true;
 }
 
 void PlaylistTabs::dragEnterEvent(QDragEnterEvent* event)

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -79,6 +79,8 @@ PlaylistTabs::PlaylistTabs(ActionManager* actionManager, WidgetProvider* widgetP
     m_tabs->setMovable(true);
     m_tabs->setTabsClosable(m_settings->value<Settings::Gui::Internal::PlaylistTabsCloseButton>());
     m_tabs->tabBar()->setExpanding(m_settings->value<Settings::Gui::Internal::PlaylistTabsExpand>());
+    m_tabs->tabBar()->installEventFilter(this);
+
     setAcceptDrops(true);
 
     setupConnections();
@@ -345,6 +347,34 @@ void PlaylistTabs::contextMenuEvent(QContextMenuEvent* event)
     }
 
     menu->popup(mapToGlobal(point));
+}
+
+bool PlaylistTabs::eventFilter(QObject* watched, QEvent* event)
+{
+    if(event->type() != QEvent::Wheel) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    const auto* wheelEvent = static_cast<const QWheelEvent*>(event);
+    auto newIndex          = m_tabs->currentIndex();
+    if(wheelEvent->angleDelta().y() < 0) {
+        newIndex++;
+    }
+    else {
+        newIndex--;
+    }
+
+    const auto highestIndex = m_tabs->tabBar()->count();
+    if(newIndex < 0) {
+        newIndex = highestIndex - 1;
+    }
+    else if(newIndex >= highestIndex) {
+        newIndex = 0;
+    }
+
+    m_tabs->setCurrentIndex(newIndex);
+    tabChanged(newIndex);
+    return true;
 }
 
 void PlaylistTabs::dragEnterEvent(QDragEnterEvent* event)

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -84,7 +84,6 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void dropEvent(QDropEvent* event) override;
-    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
     void setupConnections();

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -84,6 +84,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void dropEvent(QDropEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
     void setupConnections();


### PR DESCRIPTION
Previously, scrolling over playlist tabs already visually changed the active tab, but did not update the playlist view. This fixes it, and adds wrap-around when scrolling at the first or last playlist.