### PR TITLE
Scroll ExpandedTreeView if selected item is not fully visible

### DIFF
--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -75,10 +75,6 @@ bool cmpItemsPlaylistItems(Fooyin::PlaylistItem* pItem1, Fooyin::PlaylistItem* p
         }
     }
 
-    if(item1->row() == item2->row()) {
-        return false;
-    }
-
     return reverse ? item1->row() > item2->row() : item1->row() < item2->row();
 };
 

--- a/src/utils/widgets/expandedtreeview.cpp
+++ b/src/utils/widgets/expandedtreeview.cpp
@@ -3205,7 +3205,7 @@ void ExpandedTreeView::scrollTo(const QModelIndex& index, ScrollHint hint)
         }
     }
     else if(!rect.isEmpty()) {
-        if(hint == EnsureVisible && area.intersects(rect)) {
+        if(hint == EnsureVisible && area.contains(rect)) {
             viewport()->update(rect);
         }
         else {


### PR DESCRIPTION
Previously, selecting an item which was only barely visible did not scroll the playlist or the queue viewer, which felt a bit irritating to me. I also simplified the logic in cmpItemsPlaylistItems; I can do a separate PR for this if needed but it's a very small change.