### PR TITLE
Support reading and storing ReplayGain metadata

### DIFF
--- a/data/dbschema.xml
+++ b/data/dbschema.xml
@@ -299,4 +299,15 @@
             WHERE DiscTotal = '-1';
         </sql>
     </revision>
+    <revision version="11">
+        <description>
+            Add ReplayGain metadata fields.
+        </description>
+        <sql>
+            ALTER TABLE Tracks ADD COLUMN RGTrackGain FLOAT(3,7) DEFAULT 0.0;
+            ALTER TABLE Tracks ADD COLUMN RGAlbumGain FLOAT(3,7) DEFAULT 0.0;
+            ALTER TABLE Tracks ADD COLUMN RGTrackPeak FLOAT(3,7) DEFAULT 0.0;
+            ALTER TABLE Tracks ADD COLUMN RGAlbumPeak FLOAT(3,7) DEFAULT 0.0;
+        </sql>
+    </revision>
 </schema>

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -120,6 +120,11 @@ public:
     [[nodiscard]] float rating() const;
     [[nodiscard]] int ratingStars() const;
 
+    [[nodiscard]] float replayGainTrackGain() const;
+    [[nodiscard]] float replayGainAlbumGain() const;
+    [[nodiscard]] float replayGainTrackPeak() const;
+    [[nodiscard]] float replayGainAlbumPeak() const;
+
     [[nodiscard]] bool hasCue() const;
     [[nodiscard]] QString cuePath() const;
 
@@ -175,6 +180,10 @@ public:
     void setYear(int year);
     void setRating(float rating);
     void setRatingStars(int rating);
+    void setReplayGainTrackGain(float gain);
+    void setReplayGainAlbumGain(float gain);
+    void setReplayGainTrackPeak(float peak);
+    void setReplayGainAlbumPeak(float peak);
 
     [[nodiscard]] QString metaValue(const QString& name) const;
     [[nodiscard]] QString techInfo(const QString& name) const;

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -28,7 +28,7 @@
 
 #include <QFileInfo>
 
-constexpr auto CurrentSchemaVersion = 10;
+constexpr auto CurrentSchemaVersion = 11;
 
 namespace {
 Fooyin::DbConnection::DbParams dbConnectionParams()

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -62,9 +62,13 @@ QString fetchTrackColumns()
                                                   "Codec,"
                                                   "ExtraTags,"
                                                   "ExtraProperties,"
-                                                  "ModifiedDate, "
+                                                  "ModifiedDate,"
                                                   "LibraryID,"
                                                   "TrackHash,"
+                                                  "RGTrackGain,"
+                                                  "RGAlbumGain,"
+                                                  "RGTrackPeak,"
+                                                  "RGAlbumPeak,"
                                                   "AddedDate,"
                                                   "FirstPlayed,"
                                                   "LastPlayed,"
@@ -104,7 +108,11 @@ BindingsMap trackBindings(const Fooyin::Track& track)
             {QStringLiteral(":extraProperties"), track.serialiseExtraProperties()},
             {QStringLiteral(":modifiedDate"), static_cast<quint64>(track.modifiedTime())},
             {QStringLiteral(":trackHash"), track.hash()},
-            {QStringLiteral(":libraryID"), track.libraryId()}};
+            {QStringLiteral(":libraryID"), track.libraryId()},
+            {QStringLiteral(":rgTrackGain"), track.replayGainTrackGain()},
+            {QStringLiteral(":rgAlbumGain"), track.replayGainAlbumGain()},
+            {QStringLiteral(":rgTrackPeak"), track.replayGainTrackPeak()},
+            {QStringLiteral(":rgAlbumPeak"), track.replayGainAlbumPeak()}};
 }
 
 Fooyin::Track readToTrack(const Fooyin::DbQuery& q)
@@ -141,11 +149,15 @@ Fooyin::Track readToTrack(const Fooyin::DbQuery& q)
     track.setModifiedTime(q.value(27).toULongLong());
     track.setLibraryId(q.value(28).toInt());
     track.setHash(q.value(29).toString());
-    track.setAddedTime(q.value(30).toULongLong());
-    track.setFirstPlayed(q.value(31).toULongLong());
-    track.setLastPlayed(q.value(32).toULongLong());
-    track.setPlayCount(q.value(33).toInt());
-    track.setRating(q.value(34).toFloat());
+    track.setReplayGainTrackGain(q.value(30).toFloat());
+    track.setReplayGainAlbumGain(q.value(31).toFloat());
+    track.setReplayGainTrackPeak(q.value(32).toFloat());
+    track.setReplayGainTrackPeak(q.value(33).toFloat());
+    track.setAddedTime(q.value(34).toULongLong());
+    track.setFirstPlayed(q.value(35).toULongLong());
+    track.setLastPlayed(q.value(36).toULongLong());
+    track.setPlayCount(q.value(37).toInt());
+    track.setRating(q.value(38).toFloat());
 
     track.generateHash();
 
@@ -343,7 +355,11 @@ bool TrackDatabase::updateTrack(const Track& track)
                                           "ExtraProperties = :extraProperties,"
                                           "ModifiedDate = :modifiedDate,"
                                           "TrackHash = :trackHash,"
-                                          "LibraryID = :libraryID"
+                                          "LibraryID = :libraryID,"
+                                          "RGTrackGain = :rgTrackGain,"
+                                          "RGAlbumGain = :rgAlbumGain,"
+                                          "RGTrackPeak = :rgTrackPeak,"
+                                          "RGAlbumPeak = :rgAlbumPeak"
                                           " WHERE TrackID = :trackId;");
 
     DbQuery query{db(), statement};
@@ -507,6 +523,10 @@ void TrackDatabase::insertViews(const QSqlDatabase& db)
                                           "Tracks.ModifiedDate,"
                                           "Tracks.LibraryID,"
                                           "Tracks.TrackHash,"
+                                          "Tracks.RGTrackGain,"
+                                          "Tracks.RGAlbumGain,"
+                                          "Tracks.RGTrackPeak,"
+                                          "Tracks.RGAlbumPeak,"
                                           "TrackStats.AddedDate,"
                                           "TrackStats.FirstPlayed,"
                                           "TrackStats.LastPlayed,"
@@ -568,7 +588,11 @@ bool TrackDatabase::insertTrack(Track& track) const
                                           "ExtraProperties,"
                                           "ModifiedDate,"
                                           "TrackHash,"
-                                          "LibraryID"
+                                          "LibraryID,"
+                                          "RGTrackGain,"
+                                          "RGAlbumGain,"
+                                          "RGTrackPeak,"
+                                          "RGAlbumPeak"
                                           ") "
                                           "VALUES ("
                                           ":filePath,"
@@ -599,7 +623,11 @@ bool TrackDatabase::insertTrack(Track& track) const
                                           ":extraProperties,"
                                           ":modifiedDate,"
                                           ":trackHash,"
-                                          ":libraryID"
+                                          ":libraryID,"
+                                          ":rgTrackGain,"
+                                          ":rgAlbumGain,"
+                                          ":rgTrackPeak,"
+                                          ":rgAlbumPeak"
                                           ");");
 
     DbQuery query{db(), statement};

--- a/src/core/engine/tagdefs.h
+++ b/src/core/engine/tagdefs.h
@@ -43,6 +43,18 @@ constexpr auto Disc          = "DISCNUMBER";
 constexpr auto DiscAlt       = "DISC";
 constexpr auto DiscTotal     = "DISCTOTAL";
 constexpr auto DiscTotalAlt  = "TOTALDISCS";
+
+namespace ReplayGain {
+constexpr auto ReplayGainStart = "REPLAYGAIN_";
+constexpr auto AlbumPeak       = "REPLAYGAIN_ALBUM_PEAK";
+constexpr auto AlbumPeakAlt    = "REPLAYGAIN_ALBUMPEAK";
+constexpr auto AlbumGain       = "REPLAYGAIN_ALBUM_GAIN";
+constexpr auto AlbumGainAlt    = "REPLAYGAIN_ALBUMGAIN";
+constexpr auto TrackPeak       = "REPLAYGAIN_TRACK_PEAK";
+constexpr auto TrackPeakAlt    = "REPLAYGAIN_TRACKPEAK";
+constexpr auto TrackGain       = "REPLAYGAIN_TRACK_GAIN";
+constexpr auto TrackGainAlt    = "REPLAYGAIN_TRACKGAIN";
+} // namespace ReplayGain
 } // namespace Tag
 
 namespace Mp4 {

--- a/src/core/engine/taglibparser.cpp
+++ b/src/core/engine/taglibparser.cpp
@@ -583,7 +583,7 @@ void readGeneralProperties(const TagLib::PropertyMap& props, Fooyin::Track& trac
         }
 
         if(string.endsWith(QStringLiteral("dB"), Qt::CaseInsensitive)) {
-            return string.chopped(2).toDouble();
+            return string.chopped(2).toFloat();
         }
 
         // Lack of dB suffix is unusual, but try to convert anyway
@@ -667,7 +667,7 @@ void readGeneralProperties(const TagLib::PropertyMap& props, Fooyin::Track& trac
             else if(field == Fooyin::Tag::ReplayGain::AlbumGain || field == Fooyin::Tag::ReplayGain::AlbumGainAlt) {
                 track.setReplayGainAlbumGain(gainStringToFloat(value.toString()));
             }
-            if(field == Fooyin::Tag::ReplayGain::TrackPeak || field == Fooyin::Tag::ReplayGain::TrackPeakAlt) {
+            else if(field == Fooyin::Tag::ReplayGain::TrackPeak || field == Fooyin::Tag::ReplayGain::TrackPeakAlt) {
                 track.setReplayGainTrackPeak(convertString(value.toString()).toFloat());
             }
             else if(field == Fooyin::Tag::ReplayGain::AlbumPeak || field == Fooyin::Tag::ReplayGain::AlbumPeakAlt) {

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -94,6 +94,11 @@ public:
     uint64_t firstPlayed{0};
     uint64_t lastPlayed{0};
 
+    float replayGainTrackGain{0.0};
+    float replayGainAlbumGain{0.0};
+    float replayGainTrackPeak{0.0};
+    float replayGainAlbumPeak{0.0};
+
     QString sort;
 
     bool metadataWasModified{false};
@@ -473,6 +478,26 @@ int Track::ratingStars() const
     return static_cast<int>(std::floor(p->rating * MaxStarCount));
 }
 
+float Track::replayGainTrackGain() const
+{
+    return p->replayGainTrackGain;
+}
+
+float Track::replayGainAlbumGain() const
+{
+    return p->replayGainAlbumGain;
+}
+
+float Track::replayGainTrackPeak() const
+{
+    return p->replayGainTrackPeak;
+}
+
+float Track::replayGainAlbumPeak() const
+{
+    return p->replayGainAlbumPeak;
+}
+
 bool Track::hasCue() const
 {
     return !p->cuePath.isEmpty();
@@ -822,6 +847,26 @@ void Track::setRatingStars(int rating)
     else {
         p->rating = static_cast<float>(rating) / MaxStarCount;
     }
+}
+
+void Track::setReplayGainTrackGain(float gain)
+{
+    p->replayGainTrackGain = gain;
+}
+
+void Track::setReplayGainAlbumGain(float gain)
+{
+    p->replayGainAlbumGain = gain;
+}
+
+void Track::setReplayGainTrackPeak(float peak)
+{
+    p->replayGainTrackPeak = peak;
+}
+
+void Track::setReplayGainAlbumPeak(float peak)
+{
+    p->replayGainAlbumPeak = peak;
 }
 
 QString Track::metaValue(const QString& name) const

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -687,12 +687,17 @@ void GuiApplicationPrivate::registerLayouts()
 
 void GuiApplicationPrivate::checkTracksNeedUpdate() const
 {
-    const int prev = m_core->database()->previousRevision();
-    const int curr = m_core->database()->currentRevision();
+    const auto libraryOutOfDate = [this](int threshold) -> bool {
+        const int prev = m_core->database()->previousRevision();
+        const int curr = m_core->database()->currentRevision();
+        return prev > 0 && prev < threshold && curr >= threshold;
+    };
 
-    if(prev > 0 && curr >= 7 && prev < 7 && m_library->hasLibrary()) {
-        // Revision 7 changed codec storage type
-        showNeedReloadMessage();
+    if(m_library->hasLibrary()) {
+        if(libraryOutOfDate(7) /* changed codec storage type */
+           || libraryOutOfDate(11) /* removed ReplayGain data in extra tags */) {
+            showNeedReloadMessage();
+        }
     }
 }
 


### PR DESCRIPTION
We don't do anything with these fields yet and they don't show up in the property viewer, but at least they're in the database now. This is step 1 towards resolving #129. Applying these fields in the playback engine should be pretty simple. I'll see what I can do tomorrow.