### PR TITLE
[cmake/gme] Define LIBGME_LIBRARY_DIRS

### DIFF
--- a/src/plugins/gme/CMakeLists.txt
+++ b/src/plugins/gme/CMakeLists.txt
@@ -23,6 +23,11 @@ target_include_directories(
     PRIVATE ${LIBGME_INCLUDE_DIRS}
 )
 
+target_link_directories(
+    gmeinput
+    PRIVATE ${LIBGME_LIBRARY_DIRS}
+)
+
 fooyin_append_mimes(
     audio/x-ay
     audio/x-gbs


### PR DESCRIPTION
 Define LIBGME_LIBRARY_DIRS to fix build on FreeBSD