### PR TITLE
[utils] Timer: Add missing include for sstream

### DIFF
--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -20,6 +20,7 @@
 #include <utils/timer.h>
 
 #include <iomanip>
+#include <sstream>
 
 namespace Fooyin {
 void Timer::reset()


### PR DESCRIPTION
Fixes build issue on FreeBSD 14.0

error: implicit instantiation of undefined template 'std::basic_ostringstream<char>