### PR TITLE
Add ReplayGain playback support and settings page

### DIFF
--- a/include/core/coresettings.h
+++ b/include/core/coresettings.h
@@ -57,7 +57,9 @@ enum CoreSettings : uint32_t
     ExternalSortScript      = 18 | Type::String,
     Shutdown                = 19 | Type::Bool,
     StopAfterCurrent        = 20 | Type::Bool,
-
+    ReplayGainEnabled       = 21 | Type::Bool,
+    ReplayGainType          = 22 | Type::Int,
+    ReplayGainPreAmp        = 23 | Type::Int,
 };
 Q_ENUM_NS(CoreSettings)
 } // namespace Settings::Core

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -85,6 +85,7 @@ constexpr auto TrackQueue     = "Fooyin.Menu.Queue";
 constexpr auto TracksPlaylist = "Fooyin.Menu.Tracks.Playlist";
 constexpr auto Playlist       = "Fooyin.Menu.Playlist";
 constexpr auto PlaylistAddTo  = "Fooyin.Menu.Playlist.AddTo";
+constexpr auto ReplayGain     = "Fooyin.Menu.ReplayGain";
 constexpr auto Tagging        = "Fooyin.Menu.Tagging";
 constexpr auto Utilities      = "Fooyin.Menu.Utilities";
 } // namespace Context
@@ -179,6 +180,7 @@ constexpr auto GeneralCore        = "Fooyin.Page.General.Core";
 constexpr auto Playback           = "Fooyin.Page.Playback";
 constexpr auto Output             = "Fooyin.Page.Playback.Output";
 constexpr auto Decoding           = "Fooyin.Page.Playback.Decoding";
+constexpr auto ReplayGain         = "Fooyin.Page.Playback.ReplayGain";
 constexpr auto InterfaceGeneral   = "Fooyin.Page.Interface.General";
 constexpr auto InterfaceTheme     = "Fooyin.Page.Interface.Theme";
 constexpr auto Artwork            = "Fooyin.Page.Interface.Artwork";

--- a/src/core/engine/audioplaybackengine.h
+++ b/src/core/engine/audioplaybackengine.h
@@ -98,6 +98,7 @@ private:
 
     uint64_t m_duration;
     double m_volume;
+    float m_trackPeak;
     bool m_ending;
     bool m_decoding;
     bool m_updatingTrack;

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -275,7 +275,7 @@ void AudioRenderer::resetFade(int length)
         m_fadeTimer.stop();
     }
 
-    m_flipFade   = !m_flipFade && m_currentFadeStep != 0 && length > 0;
+    m_flipFade   = !m_flipFade && m_currentFadeStep > 0 && length > 0;
     m_fadeLength = length;
 
     if(!m_flipFade) {

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -66,6 +66,10 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
                                                   QStringLiteral("Library/ExternalSortScript"));
     m_settings->createTempSetting<Shutdown>(false);
     m_settings->createTempSetting<StopAfterCurrent>(false);
+    m_settings->createSetting<ReplayGainEnabled>(false, QStringLiteral("Engine/ReplayGainEnabled"));
+    m_settings->createSetting<Settings::Core::ReplayGainType>(static_cast<int>(ReplayGainType::Track),
+                                                              QStringLiteral("Engine/ReplayGainType"));
+    m_settings->createSetting<ReplayGainPreAmp>(0, QStringLiteral("Engine/ReplayGainPreAmp"));
 
     m_settings->createSetting<Internal::MonitorLibraries>(true, QStringLiteral("Library/MonitorLibraries"));
     m_settings->createTempSetting<Internal::MuteVolume>(m_settings->value<OutputVolume>());

--- a/src/core/internalcoresettings.h
+++ b/src/core/internalcoresettings.h
@@ -26,6 +26,12 @@
 namespace Fooyin {
 class SettingsManager;
 
+enum class ReplayGainType : uint8_t
+{
+    Track = 0,
+    Album,
+};
+
 struct FadingIntervals
 {
     int inPauseStop{1000};

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -222,6 +222,8 @@ set(SOURCES
     settings/playback/outputpage.h
     settings/playback/playbackpage.cpp
     settings/playback/playbackpage.h
+    settings/playback/replaygainpage.cpp
+    settings/playback/replaygainpage.h
     settings/playlist/playlistcolumnmodel.cpp
     settings/playlist/playlistcolumnmodel.h
     settings/playlist/playlistcolumnpage.cpp

--- a/src/gui/settings/playback/replaygainpage.cpp
+++ b/src/gui/settings/playback/replaygainpage.cpp
@@ -1,0 +1,156 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "replaygainpage.h"
+
+#include <core/coresettings.h>
+#include <core/engine/enginecontroller.h>
+#include <core/internalcoresettings.h>
+#include <gui/guiconstants.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QButtonGroup>
+#include <QCheckBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QRadioButton>
+#include <QSlider>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+namespace Fooyin {
+class ReplayGainWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ReplayGainWidget(SettingsManager* settings);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    SettingsManager* m_settings;
+
+    QCheckBox* m_enabled;
+    QRadioButton* m_trackGain;
+    QRadioButton* m_albumGain;
+    QSlider* m_preAmpSlider;
+    QSpinBox* m_preAmpSpinBox;
+};
+
+ReplayGainWidget::ReplayGainWidget(SettingsManager* settings)
+    : m_settings{settings}
+    , m_enabled{new QCheckBox(tr("Enable ReplayGain"), this)}
+    , m_trackGain{new QRadioButton(tr("Use track-based gain"), this)}
+    , m_albumGain{new QRadioButton(tr("Use album-based gain"), this)}
+    , m_preAmpSlider{new QSlider(Qt::Horizontal, this)}
+    , m_preAmpSpinBox{new QSpinBox(this)}
+{
+    m_enabled->setToolTip(tr("Normalize loudness for tracks or albums"));
+    m_trackGain->setToolTip(tr("Base normalization on track loudness"));
+    m_albumGain->setToolTip(tr("Base normalization on album loudness"));
+
+    auto* layout = new QGridLayout(this);
+
+    auto* typeGroupBox    = new QGroupBox(tr("Type"), this);
+    auto* typeButtonGroup = new QButtonGroup(this);
+    auto* typeBoxLayout   = new QVBoxLayout(typeGroupBox);
+
+    typeButtonGroup->addButton(m_trackGain);
+    typeButtonGroup->addButton(m_albumGain);
+
+    typeBoxLayout->addWidget(m_trackGain);
+    typeBoxLayout->addWidget(m_albumGain);
+
+    auto* preAmpLabel = new QLabel(tr("Pre-amplification") + QStringLiteral(":"), this);
+
+    m_preAmpSlider->setRange(-20, 20);
+    m_preAmpSlider->setSingleStep(1);
+
+    m_preAmpSpinBox->setRange(-20, 20);
+    m_preAmpSpinBox->setSingleStep(1);
+    m_preAmpSpinBox->setSuffix(QStringLiteral(" dB"));
+
+    const auto preAmpToolTip = tr("Amount of gain to apply in combination with ReplayGain");
+    m_preAmpSpinBox->setToolTip(preAmpToolTip);
+    m_preAmpSlider->setToolTip(preAmpToolTip);
+    preAmpLabel->setToolTip(preAmpToolTip);
+
+    QObject::connect(m_preAmpSlider, &QSlider::valueChanged, this,
+                     [this](int value) { m_preAmpSpinBox->setValue(value); });
+    QObject::connect(m_preAmpSpinBox, &QSpinBox::valueChanged, this,
+                     [this](int value) { m_preAmpSlider->setValue(value); });
+
+    auto* preAmpLayout = new QGridLayout();
+    preAmpLayout->addWidget(preAmpLabel, 0, 0);
+    preAmpLayout->addWidget(m_preAmpSlider, 0, 1);
+    preAmpLayout->addWidget(m_preAmpSpinBox, 0, 2);
+    preAmpLayout->setColumnStretch(1, 1);
+
+    layout->addWidget(m_enabled, 0, 0);
+    layout->addWidget(typeGroupBox, 1, 0);
+    layout->addLayout(preAmpLayout, 2, 0);
+
+    layout->setRowStretch(layout->rowCount(), 1);
+}
+
+void ReplayGainWidget::load()
+{
+    m_enabled->setChecked(m_settings->value<Settings::Core::ReplayGainEnabled>());
+    const auto gainType = static_cast<ReplayGainType>(m_settings->value<Settings::Core::ReplayGainType>());
+    if(gainType == ReplayGainType::Track) {
+        m_trackGain->setChecked(true);
+    }
+    else {
+        m_albumGain->setChecked(true);
+    }
+    const auto preAmp = m_settings->value<Settings::Core::ReplayGainPreAmp>();
+    m_preAmpSlider->setValue(preAmp);
+    m_preAmpSpinBox->setValue(preAmp);
+}
+
+void ReplayGainWidget::apply()
+{
+    m_settings->set<Settings::Core::ReplayGainEnabled>(m_enabled->isChecked());
+    m_settings->set<Settings::Core::ReplayGainType>(
+        static_cast<int>(m_trackGain->isChecked() ? ReplayGainType::Track : ReplayGainType::Album));
+    m_settings->set<Settings::Core::ReplayGainPreAmp>(m_preAmpSpinBox->value());
+}
+
+void ReplayGainWidget::reset()
+{
+    m_settings->reset<Settings::Core::ReplayGainEnabled>();
+    m_settings->reset<Settings::Core::ReplayGainPreAmp>();
+}
+
+ReplayGainPage::ReplayGainPage(SettingsManager* settings, QObject* parent)
+    : SettingsPage{settings->settingsDialog(), parent}
+{
+    setId(Constants::Page::ReplayGain);
+    setName(tr("General"));
+    setCategory({tr("Playback"), tr("ReplayGain")});
+    setWidgetCreator([settings] { return new ReplayGainWidget(settings); });
+}
+} // namespace Fooyin
+
+#include "moc_replaygainpage.cpp"
+#include "replaygainpage.moc"

--- a/src/gui/settings/playback/replaygainpage.h
+++ b/src/gui/settings/playback/replaygainpage.h
@@ -1,0 +1,34 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/settings/settingspage.h>
+
+namespace Fooyin {
+class SettingsManager;
+
+class ReplayGainPage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    explicit ReplayGainPage(SettingsManager* settings, QObject* parent = nullptr);
+};
+} // namespace Fooyin

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -48,6 +48,7 @@
 #include "settings/playback/decoderpage.h"
 #include "settings/playback/outputpage.h"
 #include "settings/playback/playbackpage.h"
+#include "settings/playback/replaygainpage.h"
 #include "settings/playlist/playlistcolumnpage.h"
 #include "settings/playlist/playlistgeneralpage.h"
 #include "settings/playlist/playlistpresetspage.h"
@@ -253,6 +254,7 @@ void Widgets::registerPages()
     new ShortcutsPage(m_gui.actionManager, m_settings, this);
     new OutputPage(m_core->engine(), m_settings, this);
     new DecoderPage(m_core->audioLoader().get(), m_settings, this);
+    new ReplayGainPage(m_settings, this);
     new DirBrowserPage(m_settings, this);
     new LibraryTreePage(m_settings, this);
     new LibraryTreeGroupPage(m_gui.actionManager, m_libraryTreeController->groupRegistry(), m_settings, this);


### PR DESCRIPTION
This patch adds support into the playback engine for playing tracks with ReplayGain tags.
It also adds a settings page with an enablement option (disabled by default), a track/album gain radio selection and a pre-amp slider.

Some notes:
* There is a delay of a few seconds before anything happens when any RG setting is changed. Some kind of Linux audio driver issue? I've had this happen on Pipewire and ALSA.
* The implementation guide recommends dithering after scaling the audio, which I've not done here (yet)
* Currently we always use the track peak for clipping prevention, and it's done by simply lowering the gain if needed. I feel like compression just sounds too ugly to be used, but that could be made a configurable option.
* fb2k also supports RG "in playback order", I don't know what this means so I didn't add it.

I'm sure all these problems can be fixed in time.