### PR TITLE
Apply ReplayGain in AudioRenderer

### DIFF
--- a/src/core/engine/audioplaybackengine.cpp
+++ b/src/core/engine/audioplaybackengine.cpp
@@ -67,6 +67,7 @@ AudioPlaybackEngine::AudioPlaybackEngine(std::shared_ptr<AudioLoader> audioLoade
     , m_updatingTrack{false}
     , m_pauseNextTrack{false}
     , m_outputThread{new QThread(this)}
+    , m_renderer{settings}
     , m_fadeIntervals{m_settings->value<Settings::Core::Internal::FadingIntervals>().value<FadingIntervals>()}
 {
     m_renderer.moveToThread(m_outputThread);
@@ -228,7 +229,7 @@ void AudioPlaybackEngine::play()
                 }
             },
             Qt::SingleShotConnection);
-        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_format); });
+        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_currentTrack, m_format); });
     }
     else {
         runOutput();
@@ -382,7 +383,7 @@ void AudioPlaybackEngine::setAudioOutput(const OutputCreator& output, const QStr
                 }
             },
             Qt::SingleShotConnection);
-        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_format); });
+        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_currentTrack, m_format); });
     }
 }
 
@@ -412,7 +413,7 @@ void AudioPlaybackEngine::setOutputDevice(const QString& device)
                 QMetaObject::invokeMethod(&m_renderer, qOverload<>(&AudioRenderer::play));
             }
         });
-        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_format); });
+        QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_currentTrack, m_format); });
     }
 }
 
@@ -524,7 +525,7 @@ void AudioPlaybackEngine::updateFormat(const AudioFormat& nextFormat, const std:
             callback(success);
         },
         Qt::SingleShotConnection);
-    QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_format); });
+    QMetaObject::invokeMethod(&m_renderer, [this]() { m_renderer.init(m_currentTrack, m_format); });
 }
 
 bool AudioPlaybackEngine::checkReadyToDecode()
@@ -597,22 +598,8 @@ void AudioPlaybackEngine::readNextBuffer()
         = std::min(bytesToEnd, static_cast<size_t>(m_format.bytesForDuration(m_bufferLength - m_totalBufferTime)));
     const auto maxBytes = std::min(bytesLeft, static_cast<size_t>(m_format.bytesForDuration(MaxDecodeLength)));
 
-    auto buffer = m_decoder->readBuffer(maxBytes);
+    const auto buffer = m_decoder->readBuffer(maxBytes);
     if(buffer.isValid()) {
-        if(m_settings->value<Settings::Core::ReplayGainEnabled>()) {
-            auto gain = static_cast<ReplayGainType>(m_settings->value<Settings::Core::ReplayGainType>())
-                             == ReplayGainType::Track
-                          ? m_currentTrack.replayGainTrackGain()
-                          : m_currentTrack.replayGainAlbumGain();
-            gain += static_cast<float>(m_settings->value<Settings::Core::ReplayGainPreAmp>());
-            auto gainScale = std::pow(10.0, gain / 20.0);
-            // Clipping prevention
-            gainScale = std::min(gainScale, 1.0 / m_currentTrack.replayGainTrackPeak());
-            m_renderer.setReplayGainScale(gainScale);
-        }
-        else {
-            m_renderer.setReplayGainScale(1.0);
-        }
         m_totalBufferTime += buffer.duration();
         QMetaObject::invokeMethod(&m_renderer, [this, buffer]() { m_renderer.queueBuffer(buffer); });
     }

--- a/src/core/engine/audioplaybackengine.cpp
+++ b/src/core/engine/audioplaybackengine.cpp
@@ -608,7 +608,10 @@ void AudioPlaybackEngine::readNextBuffer()
             auto gainScale = std::pow(10.0, gain / 20.0);
             // Clipping prevention
             gainScale = std::min(gainScale, 1.0 / m_currentTrack.replayGainTrackPeak());
-            buffer.scale(gainScale);
+            m_renderer.setReplayGainScale(gainScale);
+        }
+        else {
+            m_renderer.setReplayGainScale(1.0);
         }
         m_totalBufferTime += buffer.duration();
         QMetaObject::invokeMethod(&m_renderer, [this, buffer]() { m_renderer.queueBuffer(buffer); });

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -38,6 +38,7 @@ namespace Fooyin {
 AudioRenderer::AudioRenderer(QObject* parent)
     : QObject{parent}
     , m_volume{0.0}
+    , m_gainScale{1.0}
     , m_bufferSize{0}
     , m_bufferPrefilled{false}
     , m_samplePos{0}
@@ -240,6 +241,11 @@ void AudioRenderer::updateVolume(double volume)
     if(validOutputState()) {
         m_audioOutput->setVolume(m_volume);
     }
+}
+
+void AudioRenderer::setReplayGainScale(double scale)
+{
+    m_gainScale = scale;
 }
 
 QString AudioRenderer::deviceError() const
@@ -445,6 +451,8 @@ int AudioRenderer::writeAudioSamples(int samples)
             m_bufferQueue.pop();
             continue;
         }
+
+        buffer.scale(m_gainScale);
 
         const int sstride     = m_outputFormat.bytesPerFrame();
         const int sampleCount = std::min(bytesLeft / sstride, samples - samplesBuffered);

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -395,20 +395,19 @@ void AudioRenderer::calculateGain()
     }
 
     float peak{0.0};
+    const auto preamp   = static_cast<float>(m_settings->value<Settings::Core::ReplayGainPreAmp>());
     const auto gainType = static_cast<ReplayGainType>(m_settings->value<Settings::Core::ReplayGainType>());
+
     switch(gainType) {
         case(ReplayGainType::Track):
-            m_gainScale = std::pow(10.0, m_currentTrack.replayGainTrackGain() / 20.0);
+            m_gainScale = std::pow(10.0, (m_currentTrack.replayGainTrackGain() + preamp) / 20.0);
             peak        = m_currentTrack.replayGainTrackPeak();
             break;
         case(ReplayGainType::Album):
-            m_gainScale = std::pow(10.0, m_currentTrack.replayGainAlbumGain() / 20.0);
+            m_gainScale = std::pow(10.0, (m_currentTrack.replayGainAlbumGain() + preamp) / 20.0);
             peak        = m_currentTrack.replayGainAlbumPeak();
             break;
     }
-
-    const auto preamp = static_cast<float>(m_settings->value<Settings::Core::ReplayGainPreAmp>());
-    m_gainScale *= std::pow(10.0, preamp / 20.0);
 
     if(peak > 0.0) {
         // Prevent clipping

--- a/src/core/engine/audiorenderer.h
+++ b/src/core/engine/audiorenderer.h
@@ -58,6 +58,8 @@ public:
     void updateDevice(const QString& device);
     void updateVolume(double volume);
 
+    void setReplayGainScale(double scale);
+
     [[nodiscard]] QString deviceError() const;
 
 signals:
@@ -94,6 +96,7 @@ private:
     AudioFormat m_format;
     AudioFormat m_outputFormat;
     double m_volume;
+    double m_gainScale;
     int m_bufferSize;
     bool m_bufferPrefilled;
     std::unique_ptr<FFmpegResampler> m_resampler;

--- a/src/core/engine/audiorenderer.h
+++ b/src/core/engine/audiorenderer.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <core/engine/audiooutput.h>
+#include <core/track.h>
 
 #include "ffmpeg/ffmpegresampler.h"
 
@@ -31,15 +32,16 @@
 namespace Fooyin {
 class AudioBuffer;
 class AudioFormat;
+class SettingsManager;
 
 class AudioRenderer : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit AudioRenderer(QObject* parent = nullptr);
+    explicit AudioRenderer(SettingsManager* settings, QObject* parent = nullptr);
 
-    void init(const AudioFormat& format);
+    void init(const Track& track, const AudioFormat& format);
     void start();
     void stop();
     void closeOutput();
@@ -57,8 +59,6 @@ public:
     void updateOutput(const OutputCreator& output, const QString& device);
     void updateDevice(const QString& device);
     void updateVolume(double volume);
-
-    void setReplayGainScale(double scale);
 
     [[nodiscard]] QString deviceError() const;
 
@@ -86,13 +86,16 @@ private:
     [[nodiscard]] bool validOutputState() const;
     void handleStateChanged(AudioOutput::State state);
     void updateInterval();
+    void calculateGain();
 
     void pauseOutput();
     void writeNext();
     int writeAudioSamples(int samples);
     int renderAudio(int samples);
 
+    SettingsManager* m_settings;
     std::unique_ptr<AudioOutput> m_audioOutput;
+    Track m_currentTrack;
     AudioFormat m_format;
     AudioFormat m_outputFormat;
     double m_volume;


### PR DESCRIPTION
Propagate gainScale to the audio renderer. This makes the delay when changing RG settings a lot shorter.