### PR TITLE
Handle audio samples as float64/double

### DIFF
--- a/include/core/coresettings.h
+++ b/include/core/coresettings.h
@@ -64,7 +64,6 @@ enum CoreSettings : uint32_t
     NonRGPreAmp             = 24 | Type::Float,
     ProxyMode               = 25 | Type::Int,
     ProxyConfig             = 26 | Type::Variant,
-
 };
 Q_ENUM_NS(CoreSettings)
 } // namespace Settings::Core

--- a/include/core/engine/audioformat.h
+++ b/include/core/engine/audioformat.h
@@ -26,14 +26,15 @@
 #include <cstdint>
 
 namespace Fooyin {
-enum class SampleFormat
+enum class SampleFormat : uint8_t
 {
-    Unknown,
+    Unknown = 0,
     U8,
     S16,
     S24,
     S32,
     F32,
+    F64,
 };
 
 // TODO: Handle channel layout

--- a/include/utils/math.h
+++ b/include/utils/math.h
@@ -25,24 +25,24 @@
 namespace Fooyin::Math {
 #if(defined(__GNUC__) && defined(__x86_64__))
 #include <emmintrin.h>
-inline int fltToInt(float flt)
+inline int32_t fltToInt(float flt)
 {
     return _mm_cvtss_si32(_mm_load_ss(&flt));
 }
 
-inline int fltToInt(double flt)
+inline int32_t fltToInt(double flt)
 {
     return _mm_cvtsd_si32(_mm_load_sd(&flt));
 }
 #else
-inline int fltToInt(float flt)
+inline int32_t fltToInt(float flt)
 {
-    return static_cast<int>(std::floor(flt + 0.5));
+    return static_cast<int32_t>(std::floor(flt + 0.5));
 }
 
-inline int fltToInt(double flt)
+inline int32_t fltToInt(double flt)
 {
-    return static_cast<int>(std::floor(flt + 0.5));
+    return static_cast<int32_t>(std::floor(flt + 0.5));
 }
 #endif
 } // namespace Fooyin::Math

--- a/src/core/engine/audiobuffer.cpp
+++ b/src/core/engine/audiobuffer.cpp
@@ -267,6 +267,9 @@ void AudioBuffer::scale(double volume)
         case(SampleFormat::F32):
             p->scale<float>(volume);
             break;
+        case(SampleFormat::F64):
+            p->scale<double>(volume);
+            break;
         case(SampleFormat::Unknown):
         default:
             qCWarning(AUD_BUFF) << "Unable to scale samples of unsupported format";

--- a/src/core/engine/audioconverter.cpp
+++ b/src/core/engine/audioconverter.cpp
@@ -75,12 +75,12 @@ int32_t convertU8ToS32(const uint8_t inSample)
 
 float convertU8ToFloat(const uint8_t inSample)
 {
-    return static_cast<float>(inSample) / 0x80 - 1.0F;
+    return static_cast<float>(inSample) * (1.0F / static_cast<float>(0x80)) - 1.0F;
 }
 
 double convertU8ToDouble(const uint8_t inSample)
 {
-    return static_cast<double>(inSample) / 0x80 - 1.0;
+    return static_cast<double>(inSample) * (1.0 / static_cast<double>(0x80)) - 1.0;
 }
 
 uint8_t convertS16ToU8(const int16_t inSample)
@@ -100,12 +100,12 @@ int32_t convertS16ToS32(const int16_t inSample)
 
 float convertS16ToFloat(const int16_t inSample)
 {
-    return static_cast<float>(inSample) / static_cast<float>(std::numeric_limits<int16_t>::max());
+    return static_cast<float>(inSample) * (1.0F / static_cast<float>(0x8000));
 }
 
 double convertS16ToDouble(const int16_t inSample)
 {
-    return static_cast<double>(inSample) / static_cast<double>(std::numeric_limits<int16_t>::max());
+    return static_cast<double>(inSample) * (1.0 / static_cast<double>(0x8000));
 }
 
 uint8_t convertS32ToU8(const int32_t inSample)
@@ -125,12 +125,12 @@ int32_t convertS32ToS32(const int32_t inSample)
 
 float convertS32ToFloat(const int32_t inSample)
 {
-    return static_cast<float>(inSample) / static_cast<float>(std::numeric_limits<int32_t>::max());
+    return static_cast<float>(inSample) * (1.0F / static_cast<float>(0x80000000));
 }
 
 double convertS32ToDouble(const int32_t inSample)
 {
-    return static_cast<double>(inSample) / static_cast<double>(std::numeric_limits<int32_t>::max());
+    return static_cast<double>(inSample) * (1.0 / static_cast<double>(0x80000000));
 }
 
 template <typename T, typename R>

--- a/src/core/engine/audioformat.cpp
+++ b/src/core/engine/audioformat.cpp
@@ -143,6 +143,8 @@ int AudioFormat::bytesPerSample() const
         case(SampleFormat::S32):
         case(SampleFormat::F32):
             return 4;
+        case(SampleFormat::F64):
+            return 8;
         case(SampleFormat::Unknown):
         default:
             return 0;
@@ -167,6 +169,8 @@ QString AudioFormat::prettyFormat() const
             return QStringLiteral("32 bit (signed)");
         case(SampleFormat::F32):
             return QStringLiteral("32 bit (float)");
+        case(SampleFormat::F64):
+            return QStringLiteral("64 bit (float)");
         case(SampleFormat::Unknown):
         default:
             return QStringLiteral("Unknown format");

--- a/src/core/engine/ffmpeg/ffmpegutils.cpp
+++ b/src/core/engine/ffmpeg/ffmpegutils.cpp
@@ -75,6 +75,9 @@ SampleFormat sampleFormat(AVSampleFormat format, int bps)
         case(AV_SAMPLE_FMT_FLT):
         case(AV_SAMPLE_FMT_FLTP):
             return SampleFormat::F32;
+        case(AV_SAMPLE_FMT_DBL):
+        case(AV_SAMPLE_FMT_DBLP):
+            return SampleFormat::F64;
         default:
             return SampleFormat::Unknown;
     }
@@ -92,6 +95,8 @@ AVSampleFormat sampleFormat(SampleFormat format)
             return AV_SAMPLE_FMT_S32;
         case(SampleFormat::F32):
             return AV_SAMPLE_FMT_FLT;
+        case(SampleFormat::F64):
+            return AV_SAMPLE_FMT_DBL;
         case(SampleFormat::Unknown):
         default:
             return AV_SAMPLE_FMT_NONE;

--- a/src/plugins/alsa/alsaoutput.cpp
+++ b/src/plugins/alsa/alsaoutput.cpp
@@ -41,6 +41,8 @@ snd_pcm_format_t findAlsaFormat(Fooyin::SampleFormat format)
             return SND_PCM_FORMAT_S32;
         case(Fooyin::SampleFormat::F32):
             return SND_PCM_FORMAT_FLOAT;
+        case(Fooyin::SampleFormat::F64):
+            return SND_PCM_FORMAT_FLOAT64;
         case(Fooyin::SampleFormat::Unknown):
         default:
             return SND_PCM_FORMAT_UNKNOWN;
@@ -58,6 +60,8 @@ Fooyin::SampleFormat findSampleFormat(snd_pcm_format_t format)
             return Fooyin::SampleFormat::S32;
         case(SND_PCM_FORMAT_FLOAT):
             return Fooyin::SampleFormat::F32;
+        case(SND_PCM_FORMAT_FLOAT64):
+            return Fooyin::SampleFormat::F64;
         case(SND_PCM_FORMAT_UNKNOWN):
         default:
             return Fooyin::SampleFormat::Unknown;
@@ -466,8 +470,11 @@ bool AlsaOutput::setAlsaFormat(snd_pcm_hw_params_t* hwParams)
         qCInfo(ALSA) << "Format not supported:" << m_format.prettyFormat();
         qCDebug(ALSA) << "Trying all supported formats";
 
-        static constexpr std::array<std::pair<snd_pcm_format_t, int>, 4> formats{
-            {{SND_PCM_FORMAT_S16, 16}, {SND_PCM_FORMAT_S32, 32}, {SND_PCM_FORMAT_FLOAT, 32}, {SND_PCM_FORMAT_U8, 8}}};
+        static constexpr std::array<std::pair<snd_pcm_format_t, int>, 5> formats{{{SND_PCM_FORMAT_S16, 16},
+                                                                                  {SND_PCM_FORMAT_S32, 32},
+                                                                                  {SND_PCM_FORMAT_FLOAT, 32},
+                                                                                  {SND_PCM_FORMAT_FLOAT64, 64},
+                                                                                  {SND_PCM_FORMAT_U8, 8}}};
 
         snd_pcm_format_t compatFormat{SND_PCM_FORMAT_UNKNOWN};
 

--- a/src/plugins/pipewire/pipewireoutput.cpp
+++ b/src/plugins/pipewire/pipewireoutput.cpp
@@ -58,6 +58,8 @@ spa_audio_format findSpaFormat(const Fooyin::SampleFormat& format)
             return SPA_AUDIO_FORMAT_S32;
         case(Fooyin::SampleFormat::F32):
             return SPA_AUDIO_FORMAT_F32;
+        case(Fooyin::SampleFormat::F64):
+            return SPA_AUDIO_FORMAT_F64;
         case(Fooyin::SampleFormat::Unknown):
         default:
             return SPA_AUDIO_FORMAT_UNKNOWN;

--- a/src/plugins/sdl/sdloutput.cpp
+++ b/src/plugins/sdl/sdloutput.cpp
@@ -36,24 +36,6 @@ constexpr auto EventInterval = 200;
 #endif
 
 namespace {
-SDL_AudioFormat findFormat(Fooyin::SampleFormat format)
-{
-    switch(format) {
-        case(Fooyin::SampleFormat::U8):
-            return AUDIO_U8;
-        case(Fooyin::SampleFormat::S16):
-            return AUDIO_S16SYS;
-        case(Fooyin::SampleFormat::S24):
-        case(Fooyin::SampleFormat::S32):
-            return AUDIO_S32SYS;
-        case(Fooyin::SampleFormat::F32):
-            return AUDIO_F32SYS;
-        case(Fooyin::SampleFormat::Unknown):
-        default:
-            return AUDIO_S16;
-    }
-}
-
 Fooyin::SampleFormat findSampleFormat(SDL_AudioFormat format)
 {
     switch(format) {
@@ -86,7 +68,7 @@ bool SdlOutput::init(const AudioFormat& format)
     SDL_Init(SDL_INIT_AUDIO);
 
     m_desiredSpec.freq     = format.sampleRate();
-    m_desiredSpec.format   = findFormat(format.sampleFormat());
+    m_desiredSpec.format   = AUDIO_F32SYS;
     m_desiredSpec.channels = format.channelCount();
     m_desiredSpec.samples  = m_bufferSize;
     m_desiredSpec.callback = nullptr;
@@ -104,11 +86,8 @@ bool SdlOutput::init(const AudioFormat& format)
         return false;
     }
 
-    if(m_obtainedSpec.format != m_desiredSpec.format) {
-        qCInfo(SDL) << "Format not supported:" << m_format.prettyFormat();
-        m_format.setSampleFormat(findSampleFormat(m_obtainedSpec.format));
-        qCInfo(SDL) << "Using compatible format:" << m_format.prettyFormat();
-    }
+    m_format.setSampleFormat(findSampleFormat(m_obtainedSpec.format));
+
     if(m_obtainedSpec.freq != m_desiredSpec.freq) {
         qCInfo(SDL) << "Sample rate not supported:" << m_desiredSpec.freq << "Hz";
         qCInfo(SDL) << "Using sample rate:" << m_obtainedSpec.freq << "Hz";


### PR DESCRIPTION
All audio samples sent to the queue to be rendered are now converted to float64/double by default. This improves the application of soft volume, and larger preamp gains can now be handled without the risk of integer overflow.

Decoders are still free to output audio in any of the supported formats.

Once DSP chains are implemented, DSP plugins will only need to input and output float64 audio.