### PR TITLE
Fix formatting durations equal to or longer than 1 day

### DIFF
--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -42,7 +42,6 @@ class QWidget;
 namespace Fooyin::Utils {
 FYUTILS_EXPORT int randomNumber(int min, int max);
 FYUTILS_EXPORT QString msToString(uint64_t ms);
-FYUTILS_EXPORT QString msToStringExtended(uint64_t ms);
 FYUTILS_EXPORT QString formatFileSize(uint64_t bytes, bool includeBytes = false);
 FYUTILS_EXPORT QString addLeadingZero(int number, int leadingCount);
 FYUTILS_EXPORT QString appendShortcut(const QString& str, const QKeySequence& shortcut);

--- a/src/gui/selectioninfo/infopopulator.cpp
+++ b/src/gui/selectioninfo/infopopulator.cpp
@@ -201,7 +201,7 @@ void InfoPopulatorPrivate::addTrackGeneral(int total, const Track& track)
     }
 
     checkAddEntryNode(QStringLiteral("Duration"), InfoPopulator::tr("Duration"), ItemParent::General, track.duration(),
-                      InfoItem::Total, InfoItem::FormatUIntFunc{Utils::msToStringExtended});
+                      InfoItem::Total, InfoItem::FormatUIntFunc{Utils::msToString});
     checkAddEntryNode(QStringLiteral("Channels"), InfoPopulator::tr("Channels"), ItemParent::General, track.channels(),
                       InfoItem::Percentage);
     checkAddEntryNode(QStringLiteral("BitDepth"), InfoPopulator::tr("Bit Depth"), ItemParent::General, track.bitDepth(),

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -79,28 +79,6 @@ QString msToString(uint64_t ms)
     return formattedTime;
 }
 
-QString msToStringExtended(uint64_t ms)
-{
-    constexpr auto msPerSecond = 1000;
-    constexpr auto msPerMinute = msPerSecond * 60;
-    constexpr auto msPerHour   = msPerMinute * 60;
-    constexpr auto msPerDay    = msPerHour * 24;
-
-    const uint64_t hours   = (ms % msPerDay) / msPerHour;
-    const uint64_t minutes = (ms % msPerHour) / msPerMinute;
-    const uint64_t seconds = (ms % msPerMinute) / msPerSecond;
-
-    QString formattedTime;
-
-    if(hours > 0) {
-        formattedTime = formattedTime + addLeadingZero(static_cast<int>(hours), 2) + QStringLiteral(":");
-    }
-
-    formattedTime = formattedTime + addLeadingZero(static_cast<int>(minutes), 2) + QStringLiteral(":")
-                  + addLeadingZero(static_cast<int>(seconds), 2);
-    return formattedTime;
-}
-
 uint64_t currentDateToInt()
 {
     const auto str = QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMddHHmmss"));


### PR DESCRIPTION
This fixes the duration display in Selection Info when selecting a lot of songs in a long playlist (previously it would get reset to 0 after 23:59:59.)

The "d" suffix is not very common but it's what foobar does and avoids translation.