### PR TITLE
Add $rand2() scripting function

### DIFF
--- a/src/core/scripting/functions/mathfuncs.cpp
+++ b/src/core/scripting/functions/mathfuncs.cpp
@@ -21,6 +21,15 @@
 
 #include <random>
 
+namespace {
+    uint32_t getRandomNumber(uint32_t min, uint32_t max)
+    {
+        std::mt19937 gen{std::random_device{}()};
+        std::uniform_int_distribution<uint32_t> dist{min, max};
+        return dist(gen);
+    }
+} // namespace
+
 namespace Fooyin::Scripting {
 QString baseOperation(const QStringList& vec, const QChar op)
 {
@@ -105,8 +114,15 @@ QString mod(const QStringList& vec)
 
 QString rand()
 {
-    std::mt19937 gen{std::random_device{}()};
-    std::uniform_int_distribution<uint32_t> dist{0, std::numeric_limits<uint32_t>::max()};
-    return QString::number(dist(gen));
+    return QString::number(getRandomNumber(0, std::numeric_limits<uint32_t>::max()));
+}
+
+QString rand2(const QStringList& vec)
+{
+    if(vec.size() < 2) {
+        return {};
+    }
+
+    return QString::number(getRandomNumber(vec.at(0).toInt(), vec.at(1).toInt()));
 }
 } // namespace Fooyin::Scripting

--- a/src/core/scripting/functions/mathfuncs.h
+++ b/src/core/scripting/functions/mathfuncs.h
@@ -30,4 +30,5 @@ QString mod(const QStringList& vec);
 QString min(const QStringList& vec);
 QString max(const QStringList& vec);
 QString rand();
+QString rand2(const QStringList& vec);
 } // namespace Fooyin::Scripting

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -211,14 +211,15 @@ void ScriptRegistryPrivate::addLibraryVars()
 
 void ScriptRegistryPrivate::addDefaultFunctions()
 {
-    m_funcs[QStringLiteral("add")]  = Fooyin::Scripting::add;
-    m_funcs[QStringLiteral("sub")]  = Fooyin::Scripting::sub;
-    m_funcs[QStringLiteral("mul")]  = Fooyin::Scripting::mul;
-    m_funcs[QStringLiteral("div")]  = Fooyin::Scripting::div;
-    m_funcs[QStringLiteral("min")]  = Fooyin::Scripting::min;
-    m_funcs[QStringLiteral("max")]  = Fooyin::Scripting::max;
-    m_funcs[QStringLiteral("mod")]  = Fooyin::Scripting::mod;
-    m_funcs[QStringLiteral("rand")] = Fooyin::Scripting::rand;
+    m_funcs[QStringLiteral("add")]   = Fooyin::Scripting::add;
+    m_funcs[QStringLiteral("sub")]   = Fooyin::Scripting::sub;
+    m_funcs[QStringLiteral("mul")]   = Fooyin::Scripting::mul;
+    m_funcs[QStringLiteral("div")]   = Fooyin::Scripting::div;
+    m_funcs[QStringLiteral("min")]   = Fooyin::Scripting::min;
+    m_funcs[QStringLiteral("max")]   = Fooyin::Scripting::max;
+    m_funcs[QStringLiteral("mod")]   = Fooyin::Scripting::mod;
+    m_funcs[QStringLiteral("rand")]  = Fooyin::Scripting::rand;
+    m_funcs[QStringLiteral("rand2")] = Fooyin::Scripting::rand2;
 
     m_funcs[QStringLiteral("num")]            = Fooyin::Scripting::num;
     m_funcs[QStringLiteral("replace")]        = Fooyin::Scripting::replace;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -42,9 +42,14 @@ constexpr auto DefaultIconSize = 20;
 namespace Fooyin::Utils {
 int randomNumber(int min, int max)
 {
-    if(min == max) {
+    if(min >= max) {
         return max;
     }
+
+    if(max == std::numeric_limits<int>::max()) {
+        --max;
+    }
+
     return QRandomGenerator::global()->bounded(min, max + 1);
 }
 


### PR DESCRIPTION
This patch adds a `$rand2(min,max)` function, which is an extension to `$rand()` to allow custom bounds.

Foobar does not have this function, probably because it can technically be replicated with `$add(%min%,$mod($rand(),%max%))`. However, having another function for this is better because 1) it's more readable and 2) [mod causes skewed results.](https://stackoverflow.com/questions/10984974/why-do-people-say-there-is-modulo-bias-when-using-a-random-number-generator)

I also fixed a potential overflow in `Utils::randomNumber()`. (sidenote, this function could be called instead of using \<random\>, after changing it to return uint32_t... I don't know if Qt's implementation is any better though?)