### PR TITLE
Fix $iflonger behaviour

### DIFF
--- a/src/core/scripting/functions/controlfuncs.cpp
+++ b/src/core/scripting/functions/controlfuncs.cpp
@@ -83,7 +83,14 @@ ScriptResult iflonger(const ScriptValueList& vec)
     if(size != 4) {
         return {};
     }
-    if(vec.at(0).value.size() > vec.at(1).value.size()) {
+
+    bool ok{false};
+    const auto length = vec.at(1).value.toLongLong(&ok);
+    if(!ok) {
+        return {};
+    }
+
+    if(vec.at(0).value.size() >= length) {
         return vec.at(2);
     }
     return vec.at(3);


### PR DESCRIPTION
Previously, `$iflonger` compared the length of two strings, but according to [this reference](https://wiki.hydrogenaud.io/index.php?title=Foobar2000:Title_Formatting_Reference), `$iflonger` instead takes a numerical length as the second argument. `$longer` already covers comparing the lengths of two strings.