### PR TITLE
Add $elide_{mid,end} and allow $insert(str,ins)

### DIFF
--- a/src/core/scripting/functions/stringfuncs.cpp
+++ b/src/core/scripting/functions/stringfuncs.cpp
@@ -215,20 +215,24 @@ QString right(const QStringList& vec)
 
 QString insert(const QStringList& vec)
 {
-    if(vec.size() != 3) {
+    const qsizetype count = vec.size();
+
+    if(count < 2 || count > 3) {
         return {};
     }
 
-    bool numSuccess{false};
-    const int index = vec.at(2).toInt(&numSuccess);
-
-    if(numSuccess) {
-        QString ret{vec.front()};
-        ret.insert(index, vec.at(1));
-        return ret;
+    qsizetype index = vec.at(0).size();
+    if(count == 3) {
+        bool numSuccess{false};
+        index = vec.at(2).toInt(&numSuccess);
+        if(!numSuccess) {
+            return {};
+        }
     }
 
-    return {};
+    QString ret{vec.front()};
+    ret.insert(index, vec.at(1));
+    return ret;
 }
 
 QString substr(const QStringList& vec)
@@ -520,6 +524,51 @@ QString abbr(const QStringList& vec)
     }
 
     return abbreviated;
+}
+
+QString elide_end(const QStringList& vec)
+{
+    if(vec.size() != 3) {
+        return {};
+    }
+
+    bool ok{false};
+    const auto limit = vec.at(1).toLongLong(&ok);
+    if(!ok || limit < 1) {
+        return {};
+    }
+
+    const auto length = vec.at(0).size();
+    if(length > limit) {
+        return vec.at(0).first(limit) + vec.at(2);
+    }
+
+    return vec.at(0);
+}
+
+QString elide_mid(const QStringList& vec)
+{
+    if(vec.size() != 3) {
+        return {};
+    }
+
+    bool ok{false};
+    const auto limit = vec.at(1).toLongLong(&ok);
+    if(!ok || limit < 2) {
+        return {};
+    }
+
+    const auto length = vec.at(0).size();
+    if(length > limit) {
+        auto left        = limit / 2;
+        const auto right = left;
+        if(limit & 1) {
+            ++left;
+        }
+        return vec.at(0).first(left) + vec.at(2) + vec.at(0).last(right);
+    }
+
+    return vec.at(0);
 }
 
 QString caps(const QStringList& vec)

--- a/src/core/scripting/functions/stringfuncs.h
+++ b/src/core/scripting/functions/stringfuncs.h
@@ -54,6 +54,8 @@ QString abbr(const QStringList& vec);
 QString caps(const QStringList& vec);
 QString directory(const QStringList& vec);
 QString directoryPath(const QStringList& vec);
+QString elide_end(const QStringList& vec);
+QString elide_mid(const QStringList& vec);
 QString ext(const QStringList& vec);
 QString filename(const QStringList& vec);
 QString progress(const QStringList& vec);

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -248,6 +248,8 @@ void ScriptRegistryPrivate::addDefaultFunctions()
     m_funcs[QStringLiteral("caps")]           = Scripting::caps;
     m_funcs[QStringLiteral("directory")]      = Scripting::directory;
     m_funcs[QStringLiteral("directory_path")] = Scripting::directoryPath;
+    m_funcs[QStringLiteral("elide_end")]      = Scripting::elide_end;
+    m_funcs[QStringLiteral("elide_mid")]      = Scripting::elide_mid;
     m_funcs[QStringLiteral("ext")]            = Scripting::ext;
     m_funcs[QStringLiteral("filename")]       = Scripting::filename;
     m_funcs[QStringLiteral("progress")]       = Scripting::progress;


### PR DESCRIPTION
Two changes here:

First, I let `$insert` accept two arguments. In this case it appends to the end of the input string; useful for when the input string has been modified (e.g. with `$slice`) and `$len` isn't accurate anymore.

Second, two new functions are introduced, `$elide_mid(str,limit,ins)` and `$elide_end(str,limit,ins)`. These take a string and elide the end or middle when `str` is longer than `limit`, and insert `insert` at the removed part.

Examples:
`$elide_end("A medium length string",16,...)` -> `"A medium length ..."`
`$elide_mid("A medium length string",16,...)` -> `"A medium...h string"`

For an actual use case, this is useful to ensure that the window title doesn't get too long. I currently use the following script to achieve this for `%albumartist%`:
`$iflonger(%albumartist%,40,$insert($chop(%albumartist%,$sub($len(%albumartist%),36)),...,36) - ,%albumartist% - )`
which could be shortened this way to
`$elide_end(%albumartist%,36,...)`.