### PR TITLE
Add DSF/DSDIFF support

### DIFF
--- a/src/core/engine/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/ffmpeg/ffmpeginput.cpp
@@ -47,11 +47,12 @@ using namespace std::chrono_literals;
 namespace {
 QStringList fileExtensions(bool allSupported)
 {
-    QStringList extensions{
-        QStringLiteral("mp3"), QStringLiteral("ogg"),  QStringLiteral("opus"), QStringLiteral("oga"),
-        QStringLiteral("m4a"), QStringLiteral("wav"),  QStringLiteral("wv"),   QStringLiteral("flac"),
-        QStringLiteral("wma"), QStringLiteral("asf"),  QStringLiteral("mpc"),  QStringLiteral("aiff"),
-        QStringLiteral("ape"), QStringLiteral("webm"), QStringLiteral("mp4"),  QStringLiteral("mka")};
+    QStringList extensions{QStringLiteral("mp3"), QStringLiteral("ogg"),  QStringLiteral("opus"),
+                           QStringLiteral("oga"), QStringLiteral("m4a"),  QStringLiteral("wav"),
+                           QStringLiteral("wv"),  QStringLiteral("flac"), QStringLiteral("wma"),
+                           QStringLiteral("asf"), QStringLiteral("mpc"),  QStringLiteral("aiff"),
+                           QStringLiteral("ape"), QStringLiteral("webm"), QStringLiteral("mp4"),
+                           QStringLiteral("mka"), QStringLiteral("dsf"),  QStringLiteral("dff")};
 
     if(!allSupported) {
         return extensions;


### PR DESCRIPTION
Adds initial support for reading and playing DSD. 

Note this relies on FFmpeg for decoding, so playback of the native stream isn't yet supported.