### PR TITLE
Improve volume tooltip positioning

### DIFF
--- a/src/gui/controls/volumecontrol.cpp
+++ b/src/gui/controls/volumecontrol.cpp
@@ -262,7 +262,7 @@ void VolumeControlPrivate::updateToolTip(int value)
 
         if(displayLeft) {
             alignment = Qt::AlignRight;
-            toolTipPos.setX(pos.x() - m_volumeSlider->width());
+            toolTipPos.setX(pos.x() - m_volumeSlider->width() * 3);
         }
         else {
             toolTipPos.setX(pos.x() + m_volumeSlider->width());


### PR DESCRIPTION
This patch fixes the volume control tooltip being partly hidden by the slider popup rect
when the tooltip is displayed on the left. The distance between the popup rect and the tooltip should now be equal no matter if the tooltip is on the left or right.