### PR TITLE
[core,gui] Add initial autoplaylist support

### DIFF
--- a/data/dbschema.xml
+++ b/data/dbschema.xml
@@ -336,4 +336,13 @@
             ALTER TABLE Tracks ADD COLUMN Encoding TEXT;
         </sql>
     </revision>
+    <revision version="14">
+        <description>
+            Add fields to support autoplaylists.
+        </description>
+        <sql>
+            ALTER TABLE Playlists ADD COLUMN IsAutoPlaylist INTEGER DEFAULT 0;
+            ALTER TABLE Playlists ADD COLUMN Query TEXT;
+        </sql>
+    </revision>
 </schema>

--- a/include/core/playlist/playlist.h
+++ b/include/core/playlist/playlist.h
@@ -84,7 +84,6 @@ public:
     };
     Q_DECLARE_FLAGS(PlayModes, PlayMode)
 
-    Playlist(PrivateKey, QString name, SettingsManager* settings);
     Playlist(PrivateKey, int dbId, QString name, int index, SettingsManager* settings);
 
     Playlist(const Playlist&)            = delete;
@@ -112,6 +111,13 @@ public:
     [[nodiscard]] bool tracksModified() const;
     /** Returns @c true if this playlist does not persist (saved to db). */
     [[nodiscard]] bool isTemporary() const;
+    /** Returns @c true if this an autoplaylist (generated from a query). */
+    [[nodiscard]] bool isAutoPlaylist() const;
+    /** Returns the query used to generate this autoplaylist, else an empty string. */
+    [[nodiscard]] QString query() const;
+
+    /** Regenerates this autoplaylist using the tracks @p tracks. */
+    bool regenerateTracks(const TrackList& tracks);
 
     /*!
      * Schedules the track to be played after the current track is finished.
@@ -150,9 +156,12 @@ private:
 
     static std::unique_ptr<Playlist> create(const QString& name, SettingsManager* settings);
     static std::unique_ptr<Playlist> create(int dbId, const QString& name, int index, SettingsManager* settings);
+    static std::unique_ptr<Playlist> createAuto(int dbId, const QString& name, int index, const QString& query,
+                                                SettingsManager* settings);
 
     void setName(const QString& name);
     void setIndex(int index);
+    void setQuery(const QString& query);
 
     void setModified(bool modified);
     void setTracksModified(bool modified);

--- a/include/core/playlist/playlisthandler.h
+++ b/include/core/playlist/playlisthandler.h
@@ -29,6 +29,7 @@
 #include <QObject>
 
 namespace Fooyin {
+class MusicLibrary;
 class PlayerController;
 class PlaylistHandlerPrivate;
 class SettingsManager;
@@ -39,7 +40,8 @@ class FYCORE_EXPORT PlaylistHandler : public QObject
 
 public:
     explicit PlaylistHandler(DbConnectionPoolPtr dbPool, std::shared_ptr<AudioLoader> audioLoader,
-                             PlayerController* playerController, SettingsManager* settings, QObject* parent = nullptr);
+                             PlayerController* playerController, MusicLibrary* library, SettingsManager* settings,
+                             QObject* parent = nullptr);
     ~PlaylistHandler() override;
 
     /** Returns the playlist with the @p id if it exists, otherwise nullptr. */
@@ -76,6 +78,8 @@ public:
     /** Creates and returns a temporary playlist called @p name with the provided tracks. If it already exists, the name
      * will be changed. */
     Playlist* createNewTempPlaylist(const QString& name, const TrackList& tracks);
+    /** Returns the autoplaylist called @p name if it exists, otherwise creates it. */
+    Playlist* createAutoPlaylist(const QString& name, const QString& query);
 
     /** Adds @p tracks to the end of the playlist with @p id if found. */
     void appendToPlaylist(const UId& id, const TrackList& tracks);
@@ -136,10 +140,6 @@ signals:
     void tracksRemoved(Fooyin::Playlist* playlist, const std::vector<int>& indexes);
 
 public slots:
-    void populatePlaylists(const Fooyin::TrackList& tracks);
-    void handleTracksChanged(const Fooyin::TrackList& tracks);
-    void handleTracksUpdated(const Fooyin::TrackList& tracks);
-    void handleTracksRemoved(const Fooyin::TrackList& tracks);
     void trackAboutToFinish();
 
 private:

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -118,6 +118,8 @@ namespace Actions {
 constexpr auto AddFiles         = "File.AddFiles";
 constexpr auto AddFolders       = "File.AddFolders";
 constexpr auto NewPlaylist      = "File.NewPlaylist";
+constexpr auto NewAutoPlaylist  = "File.NewAutoPlaylist";
+constexpr auto EditAutoPlaylist = "File.EditAutoPlaylist";
 constexpr auto RemovePlaylist   = "File.RemovePlaylist";
 constexpr auto LoadPlaylist     = "File.LoadPlaylist";
 constexpr auto SavePlaylist     = "File.SavePlaylist";

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -132,7 +132,6 @@ ApplicationPrivate::ApplicationPrivate(Application* self_)
     : m_self{self_}
     , m_settings{new SettingsManager(Core::settingsPath(), m_self)}
     , m_coreSettings{m_settings}
-    , m_translations{}
     , m_database{new Database(m_self)}
     , m_audioLoader{std::make_shared<AudioLoader>()}
     , m_playerController{new PlayerController(m_settings, m_self)}
@@ -141,8 +140,8 @@ ApplicationPrivate::ApplicationPrivate(Application* self_)
     , m_playlistLoader{std::make_shared<PlaylistLoader>()}
     , m_library{new UnifiedMusicLibrary(m_libraryManager, m_database->connectionPool(), m_playlistLoader, m_audioLoader,
                                         m_settings, m_self)}
-    , m_playlistHandler{new PlaylistHandler(m_database->connectionPool(), m_audioLoader, m_playerController, m_settings,
-                                            m_self)}
+    , m_playlistHandler{new PlaylistHandler(m_database->connectionPool(), m_audioLoader, m_playerController, m_library,
+                                            m_settings, m_self)}
     , m_sortingRegistry{new SortingRegistry(m_settings, m_self)}
     , m_networkManager{new NetworkAccessManager(m_settings, m_self)}
     , m_pluginManager{m_settings}
@@ -429,14 +428,8 @@ Application::Application(QObject* parent)
 
     QObject::connect(p->m_playerController, &PlayerController::trackPlayed, p->m_library,
                      &UnifiedMusicLibrary::trackWasPlayed);
-    QObject::connect(p->m_library, &MusicLibrary::tracksLoaded, p->m_playlistHandler,
-                     &PlaylistHandler::populatePlaylists);
     QObject::connect(p->m_libraryManager, &LibraryManager::libraryAboutToBeRemoved, p->m_playlistHandler,
                      &PlaylistHandler::savePlaylists);
-    QObject::connect(p->m_library, &MusicLibrary::tracksMetadataChanged, p->m_playlistHandler,
-                     &PlaylistHandler::handleTracksChanged);
-    QObject::connect(p->m_library, &MusicLibrary::tracksUpdated, p->m_playlistHandler,
-                     &PlaylistHandler::handleTracksUpdated);
     QObject::connect(&p->m_engine, &EngineHandler::trackAboutToFinish, this, [this]() {
         p->m_playlistHandler->trackAboutToFinish();
         p->m_engine.prepareNextTrack(p->m_playerController->upcomingTrack());

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -28,7 +28,7 @@
 
 #include <QFileInfo>
 
-constexpr auto CurrentSchemaVersion = 13;
+constexpr auto CurrentSchemaVersion = 14;
 
 namespace {
 Fooyin::DbConnection::DbParams dbConnectionParams()

--- a/src/core/database/playlistdatabase.h
+++ b/src/core/database/playlistdatabase.h
@@ -29,6 +29,8 @@ struct PlaylistInfo
     int dbId{-1};
     QString name;
     int index{-1};
+    bool isAutoPlaylist{false};
+    QString query;
 };
 
 class PlaylistDatabase : public DbModule
@@ -37,7 +39,7 @@ public:
     std::vector<PlaylistInfo> getAllPlaylists();
     TrackList getPlaylistTracks(const Playlist& playlist, const std::unordered_map<int, Track>& tracks);
 
-    int insertPlaylist(const QString& name, int index);
+    int insertPlaylist(const QString& name, int index, bool isAutoPlaylist, const QString& autoQuery);
 
     bool savePlaylist(Playlist& playlist);
     bool saveModifiedPlaylists(const PlaylistList& playlists);

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -83,6 +83,8 @@ set(SOURCES
     controls/volumecontrol.h
     dialog/aboutdialog.cpp
     dialog/aboutdialog.h
+    dialog/autoplaylistdialog.cpp
+    dialog/autoplaylistdialog.h
     dialog/exportlayoutdialog.cpp
     dialog/exportlayoutdialog.h
     dialog/propertiesdialog.cpp

--- a/src/gui/dialog/autoplaylistdialog.cpp
+++ b/src/gui/dialog/autoplaylistdialog.cpp
@@ -1,0 +1,284 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "autoplaylistdialog.h"
+
+#include <core/coresettings.h>
+#include <core/playlist/playlist.h>
+#include <core/playlist/playlisthandler.h>
+#include <gui/widgets/scriptlineedit.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+
+constexpr auto SavedQueries = "Playlist/AutoPlaylistQueries";
+
+namespace Fooyin {
+AutoPlaylistDialog::AutoPlaylistDialog(QWidget* parent)
+    : AutoPlaylistDialog{nullptr, nullptr, parent}
+{ }
+
+AutoPlaylistDialog::AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlist* playlist, QWidget* parent)
+    : QDialog{parent}
+    , m_playlistHandler{playlisthandler}
+    , m_playlist{playlist}
+    , m_queryChanged{false}
+    , m_queryBox{new QComboBox(this)}
+    , m_queryEdit{new ScriptTextEdit(this)}
+    , m_loadButton{new QPushButton(tr("&Load"), this)}
+    , m_saveButton{new QPushButton(tr("&Save"), this)}
+    , m_deleteButton{new QPushButton(tr("&Delete"), this)}
+    , m_resetButton{new QPushButton(tr("&Restore Defaults"), this)}
+{
+    setWindowTitle(m_playlist ? tr("Edit Autoplaylist") : tr("Create New Autoplaylist"));
+    setModal(true);
+
+    m_queryBox->setEditable(true);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    m_okButton      = buttonBox->button(QDialogButtonBox::Ok);
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    auto* buttonLayout = new QGridLayout();
+
+    int row{0};
+    buttonLayout->addWidget(m_loadButton, row++, 0);
+    buttonLayout->addWidget(m_saveButton, row++, 0);
+    buttonLayout->addWidget(m_deleteButton, row++, 0);
+    buttonLayout->addWidget(m_resetButton, row++, 0);
+    buttonLayout->setRowStretch(buttonLayout->rowCount(), 1);
+
+    QObject::connect(m_loadButton, &QAbstractButton::clicked, this, &AutoPlaylistDialog::loadQuery);
+    QObject::connect(m_saveButton, &QAbstractButton::clicked, this, &AutoPlaylistDialog::saveQuery);
+    QObject::connect(m_deleteButton, &QAbstractButton::clicked, this, &AutoPlaylistDialog::deleteQuery);
+    QObject::connect(m_resetButton, &QAbstractButton::clicked, this, &AutoPlaylistDialog::resetQueries);
+    QObject::connect(m_queryBox, &QComboBox::editTextChanged, this, &AutoPlaylistDialog::updateButtonState);
+    QObject::connect(m_queryEdit, &QPlainTextEdit::textChanged, this, &AutoPlaylistDialog::updateButtonState);
+
+    auto* layout = new QGridLayout(this);
+
+    row = 0;
+    layout->addLayout(buttonLayout, row, 2, 2, 1);
+    layout->addWidget(new QLabel(tr("Name") + u":", this), row, 0);
+    layout->addWidget(m_queryBox, row++, 1);
+    layout->addWidget(new QLabel(tr("Query") + u":", this), row, 0, Qt::AlignTop);
+    layout->addWidget(m_queryEdit, row++, 1);
+    layout->addWidget(buttonBox, row++, 0, 1, 3);
+    layout->setColumnStretch(1, 1);
+
+    loadQueries();
+    m_queryBox->setEditText({});
+
+    if(m_playlist && m_playlist->isAutoPlaylist()) {
+        m_queryBox->setEditText(m_playlist->name());
+        m_queryEdit->setText(m_playlist->query());
+    }
+
+    updateButtonState();
+    setMinimumWidth(600);
+}
+
+void AutoPlaylistDialog::done(int value)
+{
+    saveQueries();
+    QDialog::done(value);
+}
+
+void AutoPlaylistDialog::accept()
+{
+    const QString name = m_queryBox->currentText();
+
+    if(m_playlistHandler && m_playlist) {
+        m_playlistHandler->createAutoPlaylist(m_playlist->name(), m_queryEdit->text());
+        if(name != m_playlist->name()) {
+            m_playlistHandler->renamePlaylist(m_playlist->id(), name);
+        }
+    }
+
+    emit playlistEdited(name, m_queryEdit->text());
+    QDialog::accept();
+}
+
+void AutoPlaylistDialog::updateButtonState() const
+{
+    const QString currentName = m_queryBox->currentText();
+    const bool canSave        = !currentName.isEmpty() && !m_queryEdit->text().isEmpty();
+
+    m_loadButton->setEnabled(m_queryBox->findText(currentName) >= 0);
+    m_saveButton->setEnabled(canSave);
+    m_deleteButton->setEnabled(m_queryBox->findText(currentName) >= 0);
+    m_resetButton->setEnabled(m_queryChanged);
+    m_okButton->setEnabled(canSave);
+}
+
+AutoPlaylistQuery AutoPlaylistDialog::currentQuery() const
+{
+    AutoPlaylistQuery query;
+    query.name  = m_queryBox->currentText();
+    query.query = m_queryEdit->text();
+    return query;
+}
+
+std::vector<AutoPlaylistQuery>::iterator AutoPlaylistDialog::findQuery(const QString& name)
+{
+    return std::ranges::find_if(m_queries, [&name](const auto& query) { return query.name == name; });
+}
+
+void AutoPlaylistDialog::saveQuery()
+{
+    const QString name = m_queryBox->currentText();
+
+    const AutoPlaylistQuery query = currentQuery();
+
+    auto existingQuery = findQuery(name);
+    if(existingQuery != m_queries.cend()) {
+        QMessageBox msg{QMessageBox::Question, tr("Query already exists"),
+                        tr("Query %1 already exists. Overwrite?").arg(name), QMessageBox::Yes | QMessageBox::No};
+        if(msg.exec() == QMessageBox::Yes) {
+            *existingQuery = query;
+            m_queryBox->setCurrentIndex(m_queryBox->findText(name));
+        }
+    }
+    else {
+        m_queries.push_back(query);
+        m_queryBox->addItem(query.name);
+        m_queryBox->setCurrentIndex(m_queryBox->count() - 1);
+    }
+
+    m_queryChanged = true;
+    updateButtonState();
+}
+
+void AutoPlaylistDialog::loadQuery()
+{
+    if(m_queryBox->count() == 0) {
+        return;
+    }
+
+    const QString name = m_queryBox->currentText();
+
+    auto query = findQuery(name);
+    if(query != m_queries.cend()) {
+        m_queryBox->setEditText(query->name);
+        m_queryEdit->setText(query->query);
+    }
+}
+
+void AutoPlaylistDialog::deleteQuery()
+{
+    if(m_queryBox->count() == 0) {
+        return;
+    }
+
+    const QString name = m_queryBox->currentText();
+
+    auto query = findQuery(name);
+    if(query != m_queries.cend()) {
+        m_queries.erase(query);
+        m_queryBox->removeItem(m_queryBox->findText(name));
+    }
+}
+
+void AutoPlaylistDialog::resetQueries()
+{
+    FySettings settings;
+    settings.remove(QLatin1String{SavedQueries});
+    m_queries.clear();
+    m_queryChanged = false;
+    populateQueries();
+    m_queryBox->setEditText({});
+}
+
+void AutoPlaylistDialog::saveQueries() const
+{
+    if(!m_queryChanged) {
+        return;
+    }
+
+    QByteArray byteArray;
+    QDataStream stream(&byteArray, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    stream << static_cast<qint32>(m_queries.size());
+
+    for(const auto& query : m_queries) {
+        stream << query;
+    }
+
+    FySettings settings;
+    settings.setValue(QLatin1String{SavedQueries}, byteArray);
+}
+
+void AutoPlaylistDialog::loadQueries()
+{
+    const FySettings settings;
+    QByteArray byteArray = settings.value(QLatin1String{SavedQueries}).toByteArray();
+
+    if(!byteArray.isEmpty()) {
+        QDataStream stream(&byteArray, QIODevice::ReadOnly);
+        stream.setVersion(QDataStream::Qt_6_0);
+
+        qint32 size;
+        stream >> size;
+
+        while(size > 0) {
+            --size;
+
+            AutoPlaylistQuery query;
+            stream >> query;
+
+            m_queries.push_back(query);
+        }
+
+        m_queryChanged = true;
+    }
+
+    populateQueries();
+}
+
+void AutoPlaylistDialog::populateQueries()
+{
+    m_queryBox->clear();
+
+    if(m_queries.empty()) {
+        loadDefaultQueries();
+    }
+
+    for(const auto& query : m_queries) {
+        m_queryBox->addItem(query.name);
+    }
+}
+
+void AutoPlaylistDialog::loadDefaultQueries()
+{
+    m_queries = {{tr("Most Played"), QStringLiteral("playcount>0 LIMIT 25 SORT- playcount")},
+                 {tr("Recently Added"), QStringLiteral("addedtime DURING LAST 2 WEEKS SORT- addedtime")},
+                 {tr("Last Played 2 Weeks"), QStringLiteral("lastplayed DURING LAST 2 WEEKS SORT- lastplayed")},
+                 {tr("Has Lyrics"), QStringLiteral("lyrics PRESENT")}};
+}
+} // namespace Fooyin
+
+#include "moc_autoplaylistdialog.cpp"

--- a/src/gui/dialog/autoplaylistdialog.h
+++ b/src/gui/dialog/autoplaylistdialog.h
@@ -1,0 +1,101 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QDialog>
+
+class QCheckBox;
+class QComboBox;
+class QLineEdit;
+
+namespace Fooyin {
+class Playlist;
+class PlaylistHandler;
+class ScriptTextEdit;
+
+struct AutoPlaylistQuery
+{
+    QString name;
+    QString query;
+
+    friend QDataStream& operator<<(QDataStream& stream, const AutoPlaylistQuery& preset)
+    {
+        static constexpr int version{1};
+        stream << version;
+        stream << preset.name;
+        stream << preset.query;
+
+        return stream;
+    }
+
+    friend QDataStream& operator>>(QDataStream& stream, AutoPlaylistQuery& preset)
+    {
+        int version{0};
+        stream >> version;
+        stream >> preset.name;
+        stream >> preset.query;
+
+        return stream;
+    }
+};
+
+class AutoPlaylistDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit AutoPlaylistDialog(QWidget* parent = nullptr);
+    AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlist* playlist, QWidget* parent = nullptr);
+
+    void done(int value) override;
+    void accept() override;
+
+signals:
+    void playlistEdited(const QString& name, const QString& query);
+
+private:
+    void updateButtonState() const;
+
+    [[nodiscard]] AutoPlaylistQuery currentQuery() const;
+    std::vector<AutoPlaylistQuery>::iterator findQuery(const QString& name);
+    void saveQuery();
+    void loadQuery();
+    void deleteQuery();
+    void resetQueries();
+
+    void saveQueries() const;
+    void loadQueries();
+    void populateQueries();
+    void loadDefaultQueries();
+
+    PlaylistHandler* m_playlistHandler;
+    Playlist* m_playlist;
+    std::vector<AutoPlaylistQuery> m_queries;
+    bool m_queryChanged;
+
+    QComboBox* m_queryBox;
+    ScriptTextEdit* m_queryEdit;
+    QPushButton* m_loadButton;
+    QPushButton* m_saveButton;
+    QPushButton* m_deleteButton;
+    QPushButton* m_resetButton;
+    QPushButton* m_okButton;
+};
+} // namespace Fooyin

--- a/src/gui/menubar/filemenu.cpp
+++ b/src/gui/menubar/filemenu.cpp
@@ -67,6 +67,14 @@ FileMenu::FileMenu(ActionManager* actionManager, SettingsManager* settings, QObj
     fileMenu->addAction(newPlaylistCommand, Actions::Groups::Two);
     QObject::connect(newPlaylist, &QAction::triggered, this, &FileMenu::requestNewPlaylist);
 
+    auto* newAutoPlaylist = new QAction(tr("&New autoplaylist"), this);
+    newAutoPlaylist->setStatusTip(tr("Create a new autoplaylist"));
+    auto* newAutoPlaylistCommand
+        = m_actionManager->registerAction(newAutoPlaylist, Constants::Actions::NewAutoPlaylist);
+    newAutoPlaylistCommand->setCategories(fileCategory);
+    fileMenu->addAction(newAutoPlaylistCommand, Actions::Groups::Two);
+    QObject::connect(newAutoPlaylist, &QAction::triggered, this, &FileMenu::requestNewAutoPlaylist);
+
     auto* loadPlaylist = new QAction(tr("&Load playlist…"), this);
     loadPlaylist->setStatusTip(tr("Load the playlist from the specified file"));
     auto* loadPlaylistCommand = m_actionManager->registerAction(loadPlaylist, Constants::Actions::LoadPlaylist);

--- a/src/gui/menubar/filemenu.h
+++ b/src/gui/menubar/filemenu.h
@@ -37,6 +37,7 @@ signals:
     void requestAddFiles();
     void requestAddFolders();
     void requestNewPlaylist();
+    void requestNewAutoPlaylist();
     void requestLoadPlaylist();
     void requestSavePlaylist();
     void requestSaveAllPlaylists();

--- a/src/gui/playlist/organiser/playlistorganiser.h
+++ b/src/gui/playlist/organiser/playlistorganiser.h
@@ -28,6 +28,7 @@ namespace Fooyin {
 class ActionManager;
 class Command;
 class PlayerController;
+class PlaylistHandler;
 class PlaylistInteractor;
 class PlaylistOrganiserModel;
 class SettingsManager;
@@ -52,7 +53,8 @@ private:
     void selectionChanged();
     void selectCurrentPlaylist();
     void createGroup(const QModelIndex& index) const;
-    void createPlaylist(const QModelIndex& index);
+    void createPlaylist(const QModelIndex& index, bool autoPlaylist);
+    void editAutoPlaylist(const QModelIndex& index);
 
     void filesToPlaylist(const QList<QUrl>& urls, const UId& id);
     void filesToGroup(const QList<QUrl>& urls, const QString& group, int index);
@@ -77,6 +79,10 @@ private:
     Command* m_newGroupCmd;
     QAction* m_newPlaylist;
     Command* m_newPlaylistCmd;
+    QAction* m_newAutoPlaylist;
+    Command* m_newAutoPlaylistCmd;
+    QAction* m_editAutoPlaylist;
+    Command* m_editAutoPlaylistCmd;
 
     UId m_currentPlaylistId;
     bool m_creatingPlaylist{false};

--- a/src/gui/playlist/playlistcontroller.h
+++ b/src/gui/playlist/playlistcontroller.h
@@ -30,6 +30,7 @@ class QMenu;
 class QUndoCommand;
 
 namespace Fooyin {
+class Application;
 class PlayerController;
 class Playlist;
 class PlaylistColumnRegistry;
@@ -37,7 +38,6 @@ class PlaylistControllerPrivate;
 class PlaylistHandler;
 struct PlaylistTrack;
 class PresetRegistry;
-class SettingsManager;
 enum class TrackAction;
 class TrackSelectionController;
 
@@ -52,9 +52,7 @@ class PlaylistController : public QObject
     Q_OBJECT
 
 public:
-    PlaylistController(PlaylistHandler* handler, PlayerController* playerController,
-                       TrackSelectionController* selectionController, SettingsManager* settings,
-                       QObject* parent = nullptr);
+    PlaylistController(Application* app, TrackSelectionController* selectionController, QObject* parent = nullptr);
     ~PlaylistController() override;
 
     [[nodiscard]] PlayerController* playerController() const;
@@ -79,6 +77,7 @@ public:
     void focusPlaylist();
 
     [[nodiscard]] bool currentIsActive() const;
+    [[nodiscard]] bool currentIsAuto() const;
     [[nodiscard]] Playlist* currentPlaylist() const;
     [[nodiscard]] UId currentPlaylistId() const;
 

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -92,7 +92,7 @@ private:
     void tabChanged(int index) const;
     void tabMoved(int from, int to) const;
 
-    void playlistChanged(Playlist* oldPlaylist, Playlist* playlist) const;
+    void playlistChanged(Playlist* oldPlaylist, Playlist* playlist);
     void activatePlaylistChanged(Playlist* playlist);
     void playlistRenamed(const Playlist* playlist) const;
 

--- a/src/gui/playlist/playlistwidget_p.h
+++ b/src/gui/playlist/playlistwidget_p.h
@@ -117,6 +117,7 @@ public:
     void filterTracks(const PlaylistTrackList& tracks);
 
     void setSingleMode(bool enabled);
+    void setReadOnly(bool readOnly, bool allowSorting) const;
     void updateSpans();
     void customHeaderMenuRequested(const QPoint& pos);
 


### PR DESCRIPTION
Adds initial support for autoplaylists. 

Autoplaylists are playlists generated from a query. They are automatically populated, which means their tracks cannot be edited. They will also regenerate whenever the music library changes i.e. tracks added, deleted or changed.

