### PR TITLE
Add support for saving embedded artwork

### DIFF
--- a/include/core/engine/audioinput.h
+++ b/include/core/engine/audioinput.h
@@ -149,6 +149,8 @@ public:
     [[nodiscard]] virtual QStringList extensions() const = 0;
     /* Returns @c true if embedded album artwork can be read. */
     [[nodiscard]] virtual bool canReadCover() const = 0;
+    /* Returns @c true if embedded album artwork can be written. */
+    [[nodiscard]] virtual bool canWriteCover() const;
     /* Returns @c true if this reader supports writing metadata/tags to file. */
     [[nodiscard]] virtual bool canWriteMetaData() const = 0;
     /*!
@@ -185,6 +187,12 @@ public:
      * @returns whether the track was written successfully.
      */
     [[nodiscard]] virtual bool writeTrack(const AudioSource& source, const Track& track, WriteOptions options);
+    /*!
+     * Writes the cover for the given Track @p track to file.
+     * Will only be called after a successful @fn init call.
+     * @returns whether the cover was written successfully.
+     */
+    [[nodiscard]] virtual bool writeCover(const AudioSource& source, const Track& track, const TrackCovers& covers);
 };
 using ReaderCreator = std::function<std::unique_ptr<AudioReader>()>;
 

--- a/include/core/engine/audioloader.h
+++ b/include/core/engine/audioloader.h
@@ -62,6 +62,7 @@ public:
     [[nodiscard]] bool readTrackMetadata(Track& track) const;
     [[nodiscard]] QByteArray readTrackCover(const Track& track, Track::Cover cover) const;
     [[nodiscard]] bool writeTrackMetadata(const Track& track, AudioReader::WriteOptions options) const;
+    [[nodiscard]] bool writeTrackCover(const Track& track, const TrackCovers& coverData) const;
 
     void addDecoder(const QString& name, const DecoderCreator& creator, int priority = -1);
     void addReader(const QString& name, const ReaderCreator& creator, int priority = -1);

--- a/include/core/library/musiclibrary.h
+++ b/include/core/library/musiclibrary.h
@@ -147,6 +147,12 @@ public:
     virtual void updateTrackMetadata(const TrackList& tracks) = 0;
     /** Updates the metadata in the database for @p tracks and writes metadata to files.  */
     virtual WriteRequest writeTrackMetadata(const TrackList& tracks) = 0;
+    /*!
+     * Writes the covers specified in @p coverData to all files in @p tracks.
+     * @note if a cover's data is empty/null, it will be removed from the file.
+     * @returns a WriteRequest which can be used to cancel the operation.
+     */
+    virtual WriteRequest writeTrackCovers(const TrackCoverData& coverData) = 0;
 
     /** Updates the statistics (playcount, rating etc) in the database for @p tracks.  */
     virtual void updateTrackStats(const TrackList& tracks) = 0;

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -24,6 +24,8 @@
 #include <QList>
 #include <QSharedDataPointer>
 
+#include <map>
+
 namespace Fooyin {
 class Track;
 class TrackPrivate;
@@ -52,6 +54,7 @@ public:
         Front = 0,
         Back,
         Artist,
+        Other
     };
 
     using ExtraTags       = QMap<QString, QStringList>;
@@ -258,4 +261,17 @@ private:
     QSharedDataPointer<TrackPrivate> p;
 };
 FYCORE_EXPORT size_t qHash(const Track& track);
+
+struct CoverImage
+{
+    QString mimeType;
+    QByteArray data;
+};
+using TrackCovers = std::map<Track::Cover, CoverImage>;
+
+struct TrackCoverData
+{
+    TrackList tracks;
+    TrackCovers coverData;
+};
 } // namespace Fooyin

--- a/src/core/engine/audioinput.cpp
+++ b/src/core/engine/audioinput.cpp
@@ -39,6 +39,11 @@ int AudioDecoder::bitrate() const
 
 void AudioDecoder::start() { }
 
+bool AudioReader::canWriteCover() const
+{
+    return canWriteMetaData();
+}
+
 int AudioReader::subsongCount() const
 {
     return 1;
@@ -55,6 +60,11 @@ QByteArray AudioReader::readCover(const AudioSource& /*source*/, const Track& /*
 }
 
 bool AudioReader::writeTrack(const AudioSource& /*source*/, const Track& /*track*/, WriteOptions /*options*/)
+{
+    return false;
+}
+
+bool AudioReader::writeCover(const AudioSource& /*source*/, const Track& /*track*/, const TrackCovers& /*covers*/)
 {
     return false;
 }

--- a/src/core/engine/audioloader.cpp
+++ b/src/core/engine/audioloader.cpp
@@ -388,6 +388,31 @@ bool AudioLoader::writeTrackMetadata(const Track& track, AudioReader::WriteOptio
     return decoder->writeTrack(source, track, options);
 }
 
+bool AudioLoader::writeTrackCover(const Track& track, const TrackCovers& coverData) const
+{
+    if(track.isInArchive()) {
+        return false;
+    }
+
+    const std::shared_lock lock{p->m_mutex};
+
+    auto* decoder = readerForTrack(track);
+    if(!decoder || !decoder->canWriteCover()) {
+        return false;
+    }
+
+    AudioSource source;
+    source.filepath = track.filepath();
+    QFile file{track.filepath()};
+    if(!file.open(QIODeviceBase::ReadWrite)) {
+        qCWarning(AUD_LDR) << "Failed to open file:" << source.filepath;
+        return false;
+    }
+    source.device = &file;
+
+    return decoder->writeCover(source, track, coverData);
+}
+
 void AudioLoader::addDecoder(const QString& name, const DecoderCreator& creator, int priority)
 {
     if(!creator) {

--- a/src/core/engine/taglibparser.h
+++ b/src/core/engine/taglibparser.h
@@ -34,5 +34,6 @@ public:
     [[nodiscard]] bool readTrack(const AudioSource& source, Track& track) override;
     [[nodiscard]] QByteArray readCover(const AudioSource& source, const Track& track, Track::Cover cover) override;
     [[nodiscard]] bool writeTrack(const AudioSource& source, const Track& track, WriteOptions options) override;
+    [[nodiscard]] bool writeCover(const AudioSource& source, const Track& track, const TrackCovers& covers) override;
 };
 } // namespace Fooyin

--- a/src/core/library/librarythreadhandler.cpp
+++ b/src/core/library/librarythreadhandler.cpp
@@ -489,6 +489,19 @@ WriteRequest LibraryThreadHandler::writeUpdatedTracks(const TrackList& tracks)
     return request;
 }
 
+WriteRequest LibraryThreadHandler::writeTrackCovers(const TrackCoverData& tracks)
+{
+    WriteRequest request;
+    request.cancel = [this]() {
+        p->m_trackDatabaseManager.stopThread();
+    };
+
+    QMetaObject::invokeMethod(&p->m_trackDatabaseManager,
+                              [this, tracks]() { p->m_trackDatabaseManager.writeCovers(tracks); });
+
+    return request;
+}
+
 void LibraryThreadHandler::saveUpdatedTrackStats(const TrackList& tracks)
 {
     p->m_tracksPendingUpdate.insert(p->m_tracksPendingUpdate.end(), tracks.cbegin(), tracks.cend());

--- a/src/core/library/librarythreadhandler.h
+++ b/src/core/library/librarythreadhandler.h
@@ -34,6 +34,7 @@ struct ScanProgress;
 struct ScanResult;
 struct ScanRequest;
 class SettingsManager;
+struct TrackCoverData;
 struct WriteRequest;
 
 class LibraryThreadHandler : public QObject
@@ -59,6 +60,7 @@ public:
 
     void saveUpdatedTracks(const TrackList& tracks);
     WriteRequest writeUpdatedTracks(const TrackList& tracks);
+    WriteRequest writeTrackCovers(const TrackCoverData& tracks);
     void saveUpdatedTrackStats(const TrackList& tracks);
 
     void cleanupTracks();

--- a/src/core/library/trackdatabasemanager.h
+++ b/src/core/library/trackdatabasemanager.h
@@ -28,6 +28,7 @@ namespace Fooyin {
 class Database;
 class AudioLoader;
 class SettingsManager;
+struct TrackCoverData;
 
 class TrackDatabaseManager : public Worker
 {
@@ -48,6 +49,7 @@ public slots:
     void getAllTracks();
     void updateTracks(const Fooyin::TrackList& tracks, bool write);
     void updateTrackStats(const Fooyin::TrackList& track);
+    void writeCovers(const Fooyin::TrackCoverData& tracks);
     void cleanupTracks();
 
 private:

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -421,6 +421,11 @@ WriteRequest UnifiedMusicLibrary::writeTrackMetadata(const TrackList& tracks)
     return p->m_threadHandler.writeUpdatedTracks(tracks);
 }
 
+WriteRequest UnifiedMusicLibrary::writeTrackCovers(const TrackCoverData& tracks)
+{
+    return p->m_threadHandler.writeTrackCovers(tracks);
+}
+
 void UnifiedMusicLibrary::updateTrackStats(const TrackList& tracks)
 {
     p->m_threadHandler.saveUpdatedTrackStats(tracks);

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -66,6 +66,7 @@ public:
 
     void updateTrackMetadata(const TrackList& tracks) override;
     WriteRequest writeTrackMetadata(const TrackList& tracks) override;
+    WriteRequest writeTrackCovers(const TrackCoverData& tracks) override;
 
     void updateTrackStats(const TrackList& tracks) override;
     void updateTrackStats(const Track& track) override;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -73,6 +73,10 @@ set(SOURCES
     widgets.cpp
     widgets.h
     windowcontroller.cpp
+    artwork/artworkproperties.cpp
+    artwork/artworkproperties.h
+    artwork/artworkrow.cpp
+    artwork/artworkrow.h
     controls/playercontrol.cpp
     controls/playercontrol.h
     controls/playlistcontrol.cpp

--- a/src/gui/artwork/artworkproperties.cpp
+++ b/src/gui/artwork/artworkproperties.cpp
@@ -1,0 +1,168 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "artworkproperties.h"
+
+#include "artworkrow.h"
+
+#include <core/engine/audioloader.h>
+#include <gui/coverprovider.h>
+
+#include <QFutureWatcher>
+#include <QGridLayout>
+#include <QPainter>
+#include <QtConcurrentMap>
+
+namespace Fooyin {
+ArtworkProperties::ArtworkProperties(AudioLoader* loader, MusicLibrary* library, TrackList tracks, bool readOnly,
+                                     QWidget* parent)
+    : PropertiesTabWidget{parent}
+    , m_audioLoader{loader}
+    , m_library{library}
+    , m_tracks{std::move(tracks)}
+    , m_watcher{new QFutureWatcher<void>(this)}
+    , m_loading{true}
+    , m_writing{false}
+    , m_artworkWidget{new QWidget(this)}
+    , m_rows{new ArtworkRow(u" " + tr("Front Cover"), Track::Cover::Front, readOnly, this),
+             new ArtworkRow(u" " + tr("Back Cover"), Track::Cover::Back, readOnly, this),
+             new ArtworkRow(u" " + tr("Artist"), Track::Cover::Artist, readOnly, this)}
+{
+    auto* layout = new QGridLayout(this);
+    layout->setContentsMargins({});
+
+    auto* artworkLayout = new QGridLayout(m_artworkWidget);
+    artworkLayout->setContentsMargins({});
+
+    layout->addWidget(m_artworkWidget);
+    layout->setRowStretch(layout->rowCount(), 1);
+
+    int row{0};
+    for(ArtworkRow* artworkRow : m_rows) {
+        artworkLayout->addWidget(artworkRow, row++, 0);
+    }
+    artworkLayout->setRowStretch(artworkLayout->rowCount(), 1);
+
+    m_artworkWidget->hide();
+
+    loadTrackArtwork();
+}
+
+ArtworkProperties::~ArtworkProperties()
+{
+    if(m_writeRequest) {
+        m_writeRequest->cancel();
+    }
+    if(m_watcher) {
+        m_watcher->cancel();
+        m_watcher->waitForFinished();
+    }
+}
+
+void ArtworkProperties::loadTrackArtwork()
+{
+    const auto processTrack = [this](const Track& track) {
+        for(ArtworkRow* artworkRow : m_rows) {
+            const QByteArray cover = m_audioLoader->readTrackCover(track, artworkRow->type());
+            QMetaObject::invokeMethod(artworkRow, [artworkRow, cover]() { artworkRow->loadImage(cover); });
+        }
+        m_audioLoader->destroyThreadInstance();
+    };
+
+    const int trackCount = static_cast<int>(m_tracks.size());
+
+    const auto finishLoading = [this, trackCount]() {
+        for(ArtworkRow* artworkRow : m_rows) {
+            artworkRow->finalise(trackCount);
+        }
+
+        m_loading = false;
+        m_artworkWidget->show();
+        update();
+    };
+
+    const auto future = QtConcurrent::map(m_tracks, processTrack);
+    QObject::connect(m_watcher, &QFutureWatcher<void>::finished, this, finishLoading);
+    m_watcher->setFuture(future);
+}
+
+QString ArtworkProperties::name() const
+{
+    return tr("Artwork Properties");
+}
+
+QString ArtworkProperties::layoutName() const
+{
+    return QStringLiteral("ArtworkProperties");
+}
+
+void ArtworkProperties::apply()
+{
+    TrackCoverData coverData;
+    coverData.tracks = m_tracks;
+
+    for(ArtworkRow* row : m_rows) {
+        if(row->status() != ArtworkRow::Status::None) {
+            coverData.coverData.emplace(row->type(), CoverImage{row->mimeType(), row->image()});
+            row->reset();
+        }
+    }
+
+    QObject::connect(
+        m_library, &MusicLibrary::tracksMetadataChanged, this,
+        [this]() {
+            m_writeRequest = {};
+            m_writing      = false;
+            m_artworkWidget->show();
+            update();
+        },
+        Qt::SingleShotConnection);
+
+    m_writing = true;
+    m_artworkWidget->hide();
+    update();
+
+    m_writeRequest = m_library->writeTrackCovers(coverData);
+    std::ranges::for_each(m_tracks, CoverProvider::removeFromCache);
+}
+
+void ArtworkProperties::paintEvent(QPaintEvent* event)
+{
+    QPainter painter{this};
+
+    auto drawCentreText = [this, &painter](const QString& text) {
+        QRect textRect = painter.fontMetrics().boundingRect(text);
+        textRect.moveCenter(rect().center());
+        painter.drawText(textRect, Qt::AlignCenter, text);
+    };
+
+    if(m_loading) {
+        drawCentreText(tr("Loading artwork…"));
+        return;
+    }
+    if(m_writing) {
+        drawCentreText(tr("Saving artwork to files…"));
+        return;
+    }
+
+    PropertiesTabWidget::paintEvent(event);
+}
+} // namespace Fooyin
+
+#include "moc_artworkproperties.cpp"

--- a/src/gui/artwork/artworkproperties.h
+++ b/src/gui/artwork/artworkproperties.h
@@ -1,0 +1,68 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/library/musiclibrary.h>
+#include <gui/propertiesdialog.h>
+
+#include <QFutureWatcher>
+
+class QGridLayout;
+class QLabel;
+class QPushButton;
+
+namespace Fooyin {
+class ArtworkRow;
+class AudioLoader;
+class MusicLibrary;
+
+class ArtworkProperties : public PropertiesTabWidget
+{
+    Q_OBJECT
+
+public:
+    ArtworkProperties(AudioLoader* loader, MusicLibrary* library, TrackList tracks, bool readOnly,
+                      QWidget* parent = nullptr);
+    ~ArtworkProperties() override;
+
+    void loadTrackArtwork();
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+
+    void apply() override;
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    AudioLoader* m_audioLoader;
+    MusicLibrary* m_library;
+
+    TrackList m_tracks;
+    QFutureWatcher<void>* m_watcher;
+    bool m_loading;
+    bool m_writing;
+
+    QWidget* m_artworkWidget;
+    std::array<ArtworkRow*, 3> m_rows;
+    std::optional<WriteRequest> m_writeRequest;
+};
+} // namespace Fooyin

--- a/src/gui/artwork/artworkrow.cpp
+++ b/src/gui/artwork/artworkrow.cpp
@@ -1,0 +1,260 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "artworkrow.h"
+
+#include <gui/guiconstants.h>
+#include <gui/widgets/overlaywidget.h>
+#include <utils/utils.h>
+
+#include <QBuffer>
+#include <QContextMenuEvent>
+#include <QCryptographicHash>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QImageReader>
+#include <QLabel>
+#include <QMenu>
+#include <QMimeDatabase>
+#include <QPushButton>
+
+constexpr auto ImageSize = 150;
+
+namespace Fooyin {
+ArtworkRow::ArtworkRow(const QString& name, Track::Cover cover, bool readOnly, QWidget* parent)
+    : QWidget{parent}
+    , m_type{cover}
+    , m_name{new QLabel(name, parent)}
+    , m_image{new QLabel(parent)}
+    , m_details{new QLabel(parent)}
+    , m_addButton{new QPushButton(Utils::iconFromTheme(Constants::Icons::Add), tr("Add"), parent)}
+    , m_removeButton{new QPushButton(Utils::iconFromTheme(Constants::Icons::Remove), tr("Remove"), parent)}
+    , m_readOnly{readOnly}
+    , m_status{Status::None}
+    , m_multipleImages{false}
+    , m_addedCount{0}
+    , m_imageCount{0}
+{
+    m_image->setFixedSize(ImageSize, ImageSize);
+    m_addButton->setFixedSize(ImageSize, ImageSize);
+    m_removeButton->setFixedHeight(ImageSize);
+    m_removeButton->setFlat(true);
+    m_addButton->setDisabled(m_readOnly);
+    m_removeButton->setDisabled(m_readOnly);
+
+    m_name->setMinimumWidth(fontMetrics().horizontalAdvance(QStringLiteral(" Front Cover")));
+    m_details->setMinimumWidth(fontMetrics().horizontalAdvance(QStringLiteral("No artwork present")));
+    m_image->setAlignment(Qt::AlignCenter);
+
+    m_image->hide();
+    m_image->setPixmap({});
+    m_addButton->show();
+    m_details->setText(tr("No artwork present"));
+    m_removeButton->hide();
+
+    auto* layout = new QHBoxLayout(this);
+    layout->addWidget(m_name);
+    layout->addWidget(m_image);
+    layout->addWidget(m_addButton);
+    layout->addWidget(m_details);
+    layout->addWidget(m_removeButton);
+    layout->addStretch();
+
+    QObject::connect(m_addButton, &QPushButton::clicked, this, &ArtworkRow::replaceImage);
+    QObject::connect(m_removeButton, &QPushButton::clicked, this, &ArtworkRow::removeImage);
+}
+
+void ArtworkRow::replaceImage()
+{
+    const QString filepath
+        = QFileDialog::getOpenFileName(this, tr("Open Image"), QDir::homePath(), tr("Images") + u" (*.png *.jpg)");
+    if(filepath.isEmpty()) {
+        return;
+    }
+
+    QFile file{filepath};
+    if(!file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+
+    const QByteArray imageData = file.readAll();
+
+    m_multipleImages = false;
+    m_status         = (m_imageData.isEmpty() ? Status::Added : Status::Changed);
+    loadImage(imageData, true);
+    finalise(0);
+}
+
+void ArtworkRow::removeImage()
+{
+    m_image->hide();
+    m_image->setPixmap({});
+    m_addButton->show();
+    m_removeButton->hide();
+    m_details->setText(tr("No artwork present"));
+    m_status = (m_status == Status::Added || m_status == Status::Changed ? Status::None : Status::Removed);
+    m_imageData.clear();
+}
+
+void ArtworkRow::loadImage(const QByteArray& imageData, bool replace)
+{
+    if(imageData.isEmpty()) {
+        if(!replace && !m_imageHash.isEmpty()) {
+            m_multipleImages = true;
+        }
+        ++m_addedCount;
+        return;
+    }
+
+    if(m_addedCount > 0 && m_imageHash.isEmpty()) {
+        m_multipleImages = true;
+    }
+
+    if(!replace) {
+        ++m_imageCount;
+    }
+
+    ++m_addedCount;
+
+    if(m_multipleImages) {
+        return;
+    }
+
+    QCryptographicHash hash{QCryptographicHash::Sha256};
+    hash.addData(imageData);
+    const QByteArray imageHash = hash.result();
+
+    if(!replace && !m_imageHash.isEmpty() && m_imageHash != imageHash) {
+        m_multipleImages = true;
+        return;
+    }
+
+    m_imageData = imageData;
+    m_imageHash = imageHash;
+
+    const QMimeDatabase mimeDb;
+    m_mimeType = mimeDb.mimeTypeForData(m_imageData).name();
+}
+
+void ArtworkRow::finalise(int trackCount)
+{
+    m_addedCount = 0;
+
+    if(m_multipleImages) {
+        m_image->setText(tr("Multiple images"));
+        m_details->setText(tr("%1 of %2 files have artwork").arg(m_imageCount).arg(trackCount));
+        m_image->show();
+        m_addButton->hide();
+        m_removeButton->show();
+    }
+    else if(!m_imageData.isEmpty()) {
+        QBuffer buffer{&m_imageData};
+        const QMimeDatabase mimeDb;
+        const auto mimeType   = mimeDb.mimeTypeForData(&buffer);
+        const auto formatHint = mimeType.preferredSuffix().toLocal8Bit().toLower();
+
+        QImageReader reader{&buffer, formatHint};
+
+        if(!reader.canRead()) {
+            reader.setFormat({});
+            reader.setDevice(&buffer);
+            if(!reader.canRead()) {
+                return;
+            }
+        }
+
+        if(reader.canRead()) {
+            reader.setScaledSize(m_image->size());
+            m_image->setPixmap(QPixmap::fromImageReader(&reader));
+            m_image->show();
+            m_addButton->hide();
+            m_removeButton->show();
+
+            const auto size          = reader.size();
+            const QString format     = mimeType.comment();
+            const qint64 sizeInKB    = m_imageData.size() / 1024;
+            const QString resolution = QStringLiteral("%1x%2").arg(size.width()).arg(size.height());
+            m_details->setText(tr("%1 KB\n%2\n%3").arg(sizeInKB).arg(resolution, format));
+        }
+        else {
+            m_image->hide();
+            m_addButton->show();
+            m_details->clear();
+        }
+    }
+}
+
+void ArtworkRow::reset()
+{
+    m_status = ArtworkRow::Status::None;
+}
+
+Track::Cover ArtworkRow::type() const
+{
+    return m_type;
+}
+
+ArtworkRow::Status ArtworkRow::status() const
+{
+    return m_status;
+}
+
+QString ArtworkRow::mimeType() const
+{
+    return m_mimeType;
+}
+
+QByteArray ArtworkRow::image() const
+{
+    return m_imageData;
+}
+
+void ArtworkRow::contextMenuEvent(QContextMenuEvent* event)
+{
+    if(m_readOnly) {
+        return;
+    }
+
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* overlay = new OverlayWidget(parentWidget());
+    QObject::connect(menu, &QMenu::aboutToHide, overlay, &QObject::deleteLater);
+    overlay->setGeometry(geometry());
+    overlay->raise();
+    overlay->show();
+
+    const bool hasExistingImage = m_image->isVisible();
+
+    auto* add = new QAction(hasExistingImage ? tr("Replace image") : tr("Add image"), menu);
+    QObject::connect(add, &QAction::triggered, this, &ArtworkRow::replaceImage);
+
+    menu->addAction(add);
+
+    if(hasExistingImage) {
+        auto* remove = new QAction(tr("Remove"), menu);
+        QObject::connect(remove, &QAction::triggered, this, &ArtworkRow::removeImage);
+        menu->addAction(remove);
+    }
+
+    menu->popup(event->globalPos());
+}
+} // namespace Fooyin
+
+#include "moc_artworkrow.cpp"

--- a/src/gui/artwork/artworkrow.h
+++ b/src/gui/artwork/artworkrow.h
@@ -1,0 +1,78 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/track.h>
+
+#include <QWidget>
+
+class QLabel;
+class QPushButton;
+
+namespace Fooyin {
+class ArtworkRow : public QWidget
+{
+    Q_OBJECT
+
+public:
+    enum class Status : uint8_t
+    {
+        None,
+        Added,
+        Changed,
+        Removed
+    };
+
+    explicit ArtworkRow(const QString& name, Track::Cover cover, bool readOnly, QWidget* parent);
+
+    void replaceImage();
+    void removeImage();
+
+    void loadImage(const QByteArray& imageData, bool replace = false);
+    void finalise(int trackCount);
+    void reset();
+
+    [[nodiscard]] Track::Cover type() const;
+    [[nodiscard]] Status status() const;
+    [[nodiscard]] QString mimeType() const;
+    [[nodiscard]] QByteArray image() const;
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+private:
+    Track::Cover m_type;
+    QLabel* m_name;
+    QLabel* m_image;
+    QLabel* m_details;
+    QPushButton* m_addButton;
+    QPushButton* m_removeButton;
+
+    bool m_readOnly;
+    Status m_status;
+    QByteArray m_imageData;
+    QByteArray m_imageHash;
+    QString m_mimeType;
+
+    bool m_multipleImages;
+    int m_addedCount;
+    int m_imageCount;
+};
+} // namespace Fooyin

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -19,6 +19,7 @@
 
 #include "widgets.h"
 
+#include "artwork/artworkproperties.h"
 #include "controls/playercontrol.h"
 #include "controls/playlistcontrol.h"
 #include "controls/seekbar.h"
@@ -267,6 +268,12 @@ void Widgets::registerPropertiesTabs()
             return !track.hasCue() && !track.isInArchive() && m_core->audioLoader()->canWriteMetadata(track);
         });
         return new ReplayGainWidget(m_core->library(), tracks, !canWrite, m_window);
+    });
+    m_gui->propertiesDialog()->addTab(tr("Artwork"), [this](const TrackList& tracks) {
+        const bool canWrite = std::ranges::all_of(tracks, [this](const Track& track) {
+            return !track.hasCue() && !track.isInArchive() && m_core->audioLoader()->canWriteMetadata(track);
+        });
+        return new ArtworkProperties(m_core->audioLoader().get(), m_core->library(), tracks, !canWrite, m_window);
     });
 }
 


### PR DESCRIPTION
Adds functionality to save/remove embedded artwork via a new properties dialog tab. 

Like saving metadata, only formats readable by TagLib and which are not in archives are supported for now.