### PR TITLE
Add %filesize_natural%

### DIFF
--- a/include/core/constants.h
+++ b/include/core/constants.h
@@ -47,6 +47,7 @@ constexpr auto Comment         = "COMMENT";
 constexpr auto Date            = "DATE";
 constexpr auto Year            = "YEAR";
 constexpr auto FileSize        = "FILESIZE";
+constexpr auto FileSizeNatural = "FILESIZE_NATURAL";
 constexpr auto Bitrate         = "BITRATE";
 constexpr auto SampleRate      = "SAMPLERATE";
 constexpr auto FirstPlayed     = "FIRSTPLAYED";

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -320,7 +320,10 @@ void ScriptRegistryPrivate::addDefaultMetadata()
     m_metadata[QString::fromLatin1(MetaData::Date)]     = &Track::date;
     m_metadata[QString::fromLatin1(MetaData::Year)]     = &Track::year;
     m_metadata[QString::fromLatin1(MetaData::FileSize)] = &Track::fileSize;
-    m_metadata[QString::fromLatin1(MetaData::Bitrate)]  = [this](const Track& track) {
+    m_metadata[QString::fromLatin1(MetaData::FileSizeNatural)] = [this](const Track& track) {
+        return Utils::formatFileSize(track.fileSize());
+    };
+    m_metadata[QString::fromLatin1(MetaData::Bitrate)] = [this](const Track& track) {
         return getBitrate(track);
     };
     m_metadata[QString::fromLatin1(MetaData::SampleRate)] = [](const Track& track) {


### PR DESCRIPTION
Should address #416. A `$round` function seems like a reasonable idea too but I'll keep this PR to one new thing (also this current implementation already rounds down to the first decimal digit... but we could let `formatFileSize` take an additional argument for that).