### PR TITLE
Fix encoding for info symbol

### DIFF
--- a/src/gui/settings/searchpage.cpp
+++ b/src/gui/settings/searchpage.cpp
@@ -86,7 +86,7 @@ SearchPageWidget::SearchPageWidget(SettingsManager* settings)
     m_autosearchDelay->addSpecialValue(2, tr("Medium"));
     m_autosearchDelay->addSpecialValue(3, tr("Slow"));
 
-    auto* successHint = new QLabel("🛈 "_L1 + tr("These settings will only apply if autosearch is disabled."), this);
+    auto* successHint = new QLabel(u"🛈 "_s + tr("These settings will only apply if autosearch is disabled."), this);
 
     int row{0};
     searchGroupLayout->addWidget(m_clearOnSuccess, row++, 0, 1, 3);


### PR DESCRIPTION
Another tiny patch, fixing this encoding problem:
![image](https://github.com/user-attachments/assets/cd9890f2-9cc3-43ec-9d4a-566c2ebd6067)
