### PR TITLE
[core,gui] Properly update playlist on scheduled change

### DIFF
--- a/src/core/playlist/playlisthandler.cpp
+++ b/src/core/playlist/playlisthandler.cpp
@@ -213,7 +213,7 @@ void PlaylistHandlerPrivate::startNextTrack(const Track& track, int index) const
 PlaylistTrack PlaylistHandlerPrivate::nextTrackChange(int delta)
 {
     if(m_scheduledPlaylist) {
-        m_activePlaylist    = m_scheduledPlaylist;
+        m_self->changeActivePlaylist(m_scheduledPlaylist);
         m_scheduledPlaylist = nullptr;
     }
 

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -500,7 +500,7 @@ void PlaylistTabs::setupConnections()
     QObject::connect(m_playlistController->playerController(), &PlayerController::playStateChanged, this,
                      &PlaylistTabs::playStateChanged);
     QObject::connect(m_playlistHandler, &PlaylistHandler::activePlaylistChanged, this,
-                     &PlaylistTabs::activatePlaylistChanged);
+                     &PlaylistTabs::activePlaylistChanged);
     QObject::connect(m_playlistHandler, &PlaylistHandler::playlistAdded, this, &PlaylistTabs::addPlaylist);
     QObject::connect(m_playlistHandler, &PlaylistHandler::playlistRemoved, this, &PlaylistTabs::removePlaylist);
     QObject::connect(m_playlistHandler, &PlaylistHandler::playlistRenamed, this, &PlaylistTabs::playlistRenamed);
@@ -590,7 +590,7 @@ void PlaylistTabs::playlistChanged(Playlist* /*oldPlaylist*/, Playlist* playlist
     }
 }
 
-void PlaylistTabs::activatePlaylistChanged(Playlist* playlist)
+void PlaylistTabs::activePlaylistChanged(Playlist* playlist)
 {
     if(!playlist) {
         return;

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -93,7 +93,7 @@ private:
     void tabMoved(int from, int to) const;
 
     void playlistChanged(Playlist* oldPlaylist, Playlist* playlist);
-    void activatePlaylistChanged(Playlist* playlist);
+    void activePlaylistChanged(Playlist* playlist);
     void playlistRenamed(const Playlist* playlist) const;
 
     void playStateChanged(Player::PlayState state) const;


### PR DESCRIPTION
Another oneliner (+ typo fix), ran into this while doing #434. This fixes the icon in the tab bar not being updated when switching to a scheduled playlist (reproduced by enabling "Playback Follows Cursor" and switching to a track in a different playlist.)