### PR TITLE
[core] Engine: Fix seek interrupting fade-in

### DIFF
--- a/src/core/engine/audioplaybackengine.cpp
+++ b/src/core/engine/audioplaybackengine.cpp
@@ -434,7 +434,7 @@ void AudioPlaybackEngine::seek(uint64_t pos)
         return;
     }
 
-    resetWorkers();
+    resetWorkers(false);
     m_decoder->seek(pos + m_startPosition);
     m_clock.sync(pos);
 
@@ -552,11 +552,11 @@ AudioFormat AudioPlaybackEngine::loadPreparedTrack()
     return format;
 }
 
-void AudioPlaybackEngine::resetWorkers()
+void AudioPlaybackEngine::resetWorkers(bool resetFade)
 {
     m_bufferTimer.stop();
     m_clock.setPaused(true);
-    QMetaObject::invokeMethod(&m_renderer, &AudioRenderer::reset);
+    QMetaObject::invokeMethod(&m_renderer, [this, resetFade]() { m_renderer.reset(resetFade); });
     m_totalBufferTime = 0;
 }
 

--- a/src/core/engine/audioplaybackengine.h
+++ b/src/core/engine/audioplaybackengine.h
@@ -63,7 +63,7 @@ protected:
 private:
     void resetNextTrack();
     AudioFormat loadPreparedTrack();
-    void resetWorkers();
+    void resetWorkers(bool resetFade = true);
     void stopWorkers(bool full = false);
     void startBitrateTimer();
 

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -147,15 +147,18 @@ void AudioRenderer::drainOutput()
     }
 }
 
-void AudioRenderer::reset()
+void AudioRenderer::reset(bool stopFade)
 {
     if(validOutputState()) {
         m_audioOutput->reset();
     }
 
-    resetFade(0);
     resetBuffer();
-    m_fadeVolume = -1;
+
+    if(stopFade) {
+        resetFade(0);
+        m_fadeVolume = -1;
+    }
 }
 
 void AudioRenderer::play()
@@ -192,6 +195,9 @@ void AudioRenderer::play(int fadeLength)
 
 void AudioRenderer::pause()
 {
+    resetFade(0);
+    m_fadingOut = false;
+
     pauseOutput();
 }
 

--- a/src/core/engine/audiorenderer.h
+++ b/src/core/engine/audiorenderer.h
@@ -46,7 +46,7 @@ public:
     void stop();
     void closeOutput();
     void drainOutput();
-    void reset();
+    void reset(bool stopFade);
 
     void play();
     void play(int fadeLength);


### PR DESCRIPTION
Fading in and then seeking during the fade causes the fade to be interrupted and the output volume to stay at whatever it was just before the seek. This is caused by `AudioPlaybackEngine::seek` calling `resetWorkers` which calls `AudioRenderer::resetFade`. Fix this by adding an argument that lets us skip the call.

In addition, call `resetFade` in `pause` to fix a bug where a long fade-in interrupted by an instant pause would not cause the fade timer to be stopped, meaning that another fade-in running before the previous timer was completed would cause the fade direction to flip and trigger a mute (introduced by #258).