### PR TITLE
[core] Add support of audio/x-flac mime type

### DIFF
--- a/src/core/engine/taglibparser.cpp
+++ b/src/core/engine/taglibparser.cpp
@@ -579,7 +579,7 @@ QString codecForMime(const QString& mimeType)
     if(mimeType == "audio/x-wavpack"_L1) {
         return u"WavPack"_s;
     }
-    if(mimeType == "audio/flac"_L1) {
+    if(mimeType == "audio/flac"_L1 || mimeType == "audio/x-flac"_L1) {
         return u"FLAC"_s;
     }
     if(mimeType == "audio/ogg"_L1 || mimeType == "audio/x-vorbis+ogg"_L1 || mimeType == "application/ogg"_L1) {
@@ -2394,7 +2394,7 @@ bool TagLibReader::readTrack(const AudioSource& source, Track& track)
             }
         }
     }
-    else if(mimeType == "audio/flac"_L1) {
+    else if(mimeType == "audio/flac"_L1 || mimeType == "audio/x-flac"_L1) {
 #if(TAGLIB_MAJOR_VERSION >= 2)
         TagLib::FLAC::File file(&stream, true, style, TagLib::ID3v2::FrameFactory::instance());
 #else
@@ -2579,7 +2579,7 @@ QByteArray TagLibReader::readCover(const AudioSource& source, const Track& track
             return readMp4Cover(file.tag(), cover);
         }
     }
-    else if(mimeType == "audio/flac"_L1) {
+    else if(mimeType == "audio/flac"_L1 || mimeType == "audio/x-flac"_L1) {
 #if(TAGLIB_MAJOR_VERSION >= 2)
         TagLib::FLAC::File file(&stream, true, style, TagLib::ID3v2::FrameFactory::instance());
 #else
@@ -2725,7 +2725,7 @@ bool TagLibReader::writeTrack(const AudioSource& source, const Track& track, Aud
             file.save();
         }
     }
-    else if(mimeType == "audio/flac"_L1) {
+    else if(mimeType == "audio/flac"_L1 || mimeType == "audio/x-flac"_L1) {
 #if(TAGLIB_MAJOR_VERSION >= 2)
         TagLib::FLAC::File file(&stream, true, style, TagLib::ID3v2::FrameFactory::instance());
 #else
@@ -2880,7 +2880,7 @@ bool TagLibReader::writeCover(const AudioSource& source, const Track& track, con
             file.save();
         }
     }
-    else if(mimeType == "audio/flac"_L1) {
+    else if(mimeType == "audio/flac"_L1 || mimeType == "audio/x-flac"_L1) {
 #if(TAGLIB_MAJOR_VERSION >= 2)
         TagLib::FLAC::File file(&stream, true, style, TagLib::ID3v2::FrameFactory::instance());
 #else


### PR DESCRIPTION
This change is add support for audio/x-flac mime type which apparently used in Mac OS.  The detailed discussion is here:  https://github.com/fooyin/fooyin/discussions/438

I didn't wrap the change for Mac only as I feel this maybe useful for other distro as well,  and also inline with other mime type coding style.

I know Mac OS probably is not in socpe of this project, so this PR is 'nice to have' change, but as shown in above discussion, it actually worked pretty well in MacOS.

Thanks