### PR TITLE
Fixes listenbrainz scrobbling

### DIFF
--- a/src/plugins/scrobbler/listenbrainzservice.cpp
+++ b/src/plugins/scrobbler/listenbrainzservice.cpp
@@ -358,7 +358,10 @@ QJsonObject ListenBrainzService::getTrackMetadata(const Metadata& metadata) cons
         infoObj.insert(u"tracknumber"_s, metadata.trackNum);
     }
     if(!metadata.musicBrainzId.isEmpty()) {
-        infoObj.insert(u"track_mbid"_s, metadata.musicBrainzId);
+        infoObj.insert(u"recording_mbid"_s, metadata.musicBrainzId);
+    }
+    if(!metadata.musicBrainzAlbumId.isEmpty()) {
+        infoObj.insert(u"release_mbid"_s, metadata.musicBrainzAlbumId);
     }
 
     infoObj.insert(u"media_player"_s, QCoreApplication::applicationName());

--- a/src/plugins/scrobbler/scrobblercache.cpp
+++ b/src/plugins/scrobbler/scrobblercache.cpp
@@ -52,6 +52,13 @@ Metadata::Metadata(const Track& track)
             musicBrainzId = values.front();
         }
     }
+
+    if(track.hasExtraTag(u"MUSICBRAINZ_ALBUMID"_s)) {
+        const auto values = track.extraTag(u"MUSICBRAINZ_ALBUMID"_s);
+        if(!values.empty()) {
+            musicBrainzAlbumId = values.front();
+        }
+    }
 }
 
 ScrobblerCache::ScrobblerCache(QString filepath, QObject* parent)
@@ -138,6 +145,7 @@ void ScrobblerCache::readCache()
         metadata.trackNum       = trackObj.value("Track"_L1).toString();
         metadata.duration       = trackObj.value("Duration"_L1).toVariant().toULongLong();
         metadata.musicBrainzId  = trackObj.value("MusicbrainzTrackId"_L1).toString();
+        metadata.musicBrainzAlbumId  = trackObj.value("MusicbrainzAlbumId"_L1).toString();
         const quint64 timestamp = trackObj.value("Timestamp"_L1).toVariant().toULongLong();
 
         if(!metadata.isValid()) {
@@ -214,6 +222,7 @@ void ScrobblerCache::writeCache()
         object["Track"_L1]              = item->metadata.trackNum;
         object["Duration"_L1]           = QJsonValue::fromVariant(static_cast<quint64>(item->metadata.duration));
         object["MusicbrainzTrackId"_L1] = item->metadata.musicBrainzId;
+        object["MusicbrainzAlbumId"_L1] = item->metadata.musicBrainzAlbumId;
         object["Timestamp"_L1]          = QJsonValue::fromVariant(static_cast<quint64>(item->timestamp));
 
         array.append(object);

--- a/src/plugins/scrobbler/scrobblercache.h
+++ b/src/plugins/scrobbler/scrobblercache.h
@@ -38,6 +38,7 @@ public:
     QString trackNum;
     uint64_t duration{0};
     QString musicBrainzId;
+    QString musicBrainzAlbumId;
 
     [[nodiscard]] bool isValid() const
     {


### PR DESCRIPTION
Listenbrainz scrobbling is currently broken in fooyin. I was going to create an issue but figured I'd take a stab at it because this is the only linux music player I don't hate so far and it turned out to be very simple (after being very annoying to wrap my head around with all those tag names). 

I've patched those changes onto my local package and it's working as intended as I type all this so might as well fix it for everyone. I know nothing about c++ whatsoever but this was just some simple copy/pasting.
  
### Why it's broken:
Might be a strong word, it works, it's just very approximative.
Basically, from what I understand, the current MBID passed to Listenbrainz is ignored. The website just uses the general information like track name, artist, duration to make a guess. This results in mistakes when scrobbling.

"track_mbid" is different from fooyin's internal "MUSICBRAINZ_TRACKID", the musicbrainz equivalent is actually "recording_mbid". The "track_mbid" equivalent is "MUSICBRAINZ_TRACKRELEASEID". Which would contain all the information needed, if not for the annoying fact listenbrainz seems to not make use of that ID yet. So fooyin sends a "track_mbid" that contains a value meant for a "recording_mbid" and listenbrainz just shrugs it off because it doesn't match anything and even if it did it probably wouldn't do anything meaningful with it.
Thus the payload contains absolutely no information about the release, and doesn't actually point to a specific recording either.

Example with some random song:
Picard shows the proper release tag on the file
![Image](https://github.com/user-attachments/assets/3feb42af-df1d-46bc-8c35-8fef969a710d)
fooyin is aware of the tag, just calls it album instead of release
![Image](https://github.com/user-attachments/assets/02f6d878-330e-4e2a-8f87-2955f4328c4e)
Listenbrainz defaults to a completely different ID as the correct one is missing from the payloads, assuming I'm listening to some random single thus robbing me of my precious cover art, and "track_mbid" does nothing at all because there's no track associated with that ID (since it's a recording ID)
![Image](https://github.com/user-attachments/assets/e2ba18ef-a689-4bc8-88d2-b85d0190693f)
"mbid_mapping" seems to contain the default values listenbrainz uses when the information is missing from the payload, it gets overridden when the information is present. At least that's the way it appears to behave.

### The fix:
We need to send "release_mbid" (already handled in fooyin as "MUSICBRAINZ_ALBUMID") alongside the (renamed so listenbrainz actually recognizes it) "recording_mbid". A recording can be present in multiple albums (and multiple versions of the same album, and in singles, and in EPs) so just "recording_mbid" isn't enough. This way listenbrainz gets information about the actual release and the track itself within it on top of the more generic information, pretty much eliminating all but the most niche problems I can think of (who puts the same recording twice in one release?).

![Image](https://github.com/user-attachments/assets/92159f9b-44a6-44dd-8aa6-c4b312011e89)
The most recent listen was sent from my patched fooyin, fetching the correct album thanks to the additional information, the 2 others were in 0.8.1 fetching the incorrect default entry leading to a random single with, again, unacceptably, none of the album's cover art.
