### PR TITLE
[scripting] Add $round

### DIFF
--- a/src/core/scripting/functions/mathfuncs.cpp
+++ b/src/core/scripting/functions/mathfuncs.cpp
@@ -19,10 +19,12 @@
 
 #include "mathfuncs.h"
 
+#include <QLocale>
+
 #include <random>
 
 namespace {
-uint32_t getRandomNumber(uint32_t min, uint32_t max)
+uint32_t getRandomU32(uint32_t min, uint32_t max)
 {
     std::mt19937 gen{std::random_device{}()};
     std::uniform_int_distribution<uint32_t> dist{min, max};
@@ -111,20 +113,53 @@ QString mod(const QStringList& vec)
 QString rand(const QStringList& vec)
 {
     if(vec.size() < 2) {
-        return QString::number(getRandomNumber(0, std::numeric_limits<uint32_t>::max()));
+        return QString::number(getRandomU32(0, std::numeric_limits<uint32_t>::max() - 1));
     }
 
     bool ok{false};
-    const int min = vec.at(0).toInt(&ok);
+    const int min = vec.at(0).toUInt(&ok);
     if(!ok) {
         return {};
     }
 
-    const int max = vec.at(1).toInt(&ok);
+    const int max = vec.at(1).toUInt(&ok);
     if(!ok) {
         return {};
     }
 
-    return QString::number(getRandomNumber(min, max));
+    return QString::number(getRandomU32(min, max));
+}
+
+QString round(const QStringList& vec)
+{
+    if(vec.size() < 1 || vec.size() > 2) {
+        return {};
+    }
+
+    bool ok{false};
+    const double num = vec.at(0).toDouble(&ok);
+    if(!ok) {
+        return {};
+    }
+
+    if(vec.size() == 1) {
+        return QString::number(num, 'f', QLocale::FloatingPointShortest);
+    }
+
+    const int precision = vec.at(1).toInt(&ok);
+    if(!ok || precision < 0) {
+        return {};
+    }
+
+    auto str = QString::number(num, 'f', precision);
+    if(str.contains(u'.')) {
+        while(str.back() == u'0') {
+            str.chop(1);
+        }
+        if(str.back() == u'.') {
+            str.chop(1);
+        }
+    }
+    return str;
 }
 } // namespace Fooyin::Scripting

--- a/src/core/scripting/functions/mathfuncs.h
+++ b/src/core/scripting/functions/mathfuncs.h
@@ -30,4 +30,5 @@ QString mod(const QStringList& vec);
 QString min(const QStringList& vec);
 QString max(const QStringList& vec);
 QString rand(const QStringList& vec);
+QString round(const QStringList& vec);
 } // namespace Fooyin::Scripting

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -181,7 +181,7 @@ void ScriptRegistryPrivate::addPlaybackVars()
     m_playbackVars[u"PLAYBACK_TIME"_s] = [this]() {
         return Utils::msToString(m_playerController ? m_playerController->currentPosition() : 0);
     };
-    m_playbackVars[u"PLAYBACK_TIME_s"_s] = [this]() {
+    m_playbackVars[u"PLAYBACK_TIME_S"_s] = [this]() {
         return QString::number(m_playerController ? m_playerController->currentPosition() / 1000 : 0);
     };
     m_playbackVars[u"PLAYBACK_TIME_REMAINING"_s] = [this]() {
@@ -233,14 +233,15 @@ void ScriptRegistryPrivate::addLibraryVars()
 
 void ScriptRegistryPrivate::addDefaultFunctions()
 {
-    m_funcs[u"add"_s]  = Scripting::add;
-    m_funcs[u"sub"_s]  = Scripting::sub;
-    m_funcs[u"mul"_s]  = Scripting::mul;
-    m_funcs[u"div"_s]  = Scripting::div;
-    m_funcs[u"min"_s]  = Scripting::min;
-    m_funcs[u"max"_s]  = Scripting::max;
-    m_funcs[u"mod"_s]  = Scripting::mod;
-    m_funcs[u"rand"_s] = Scripting::rand;
+    m_funcs[u"add"_s]   = Scripting::add;
+    m_funcs[u"sub"_s]   = Scripting::sub;
+    m_funcs[u"mul"_s]   = Scripting::mul;
+    m_funcs[u"div"_s]   = Scripting::div;
+    m_funcs[u"min"_s]   = Scripting::min;
+    m_funcs[u"max"_s]   = Scripting::max;
+    m_funcs[u"mod"_s]   = Scripting::mod;
+    m_funcs[u"rand"_s]  = Scripting::rand;
+    m_funcs[u"round"_s] = Scripting::round;
 
     m_funcs[u"num"_s]            = Scripting::num;
     m_funcs[u"replace"_s]        = Scripting::replace;


### PR DESCRIPTION
Resolves #416 

Plus two small fixes:
- Fix `%PLAYBACK_TIME_S%` not being found (we couldn't find it in variable lookup because it wasn't fully uppercase. Introduced in fooyin@c5c6f3f)
- ~~Use `Utils::randomNumber` for `$rand` (we want a signed int, and now the extra function can be deleted)~~ -- Edit: Nevermind this one, let's stick to what fb2k does. Just fix `$rand()` to only handle unsigned ints and rename the helper.