### PR TITLE
Fix M3U extension (was M3)

### DIFF
--- a/src/core/playlist/parsers/m3uparser.cpp
+++ b/src/core/playlist/parsers/m3uparser.cpp
@@ -95,7 +95,7 @@ QString M3uParser::name() const
 
 QStringList M3uParser::supportedExtensions() const
 {
-    static const QStringList extensions{u"m3"_s, u"m3u8"_s};
+    static const QStringList extensions{u"m3u"_s, u"m3u8"_s};
     return extensions;
 }
 

--- a/src/core/playlist/playlist.cpp
+++ b/src/core/playlist/playlist.cpp
@@ -665,7 +665,7 @@ void Playlist::resetFlags()
 
 QStringList Playlist::supportedPlaylistExtensions()
 {
-    static const QStringList supportedExtensions = {u"cue"_s, u"m3"_s, u"m3u8"_s};
+    static const QStringList supportedExtensions = {u"cue"_s, u"m3u"_s, u"m3u8"_s};
     return supportedExtensions;
 }
 


### PR DESCRIPTION
This looks like there was some sort of search and replace for the sequence `u"`