### PR TITLE
Libvgm cmake update

### DIFF
--- a/ci/fedora-build.sh
+++ b/ci/fedora-build.sh
@@ -5,8 +5,7 @@ export FOOYIN_DIR=$PWD
 cmake -S "$FOOYIN_DIR" \
   -G Ninja \
   -B build \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_LIBVGM=OFF
+  -DCMAKE_BUILD_TYPE=Release
 
 cmake --build build
 cd build


### PR DESCRIPTION
Let's see if this fixes CI without disabling libvgm, since libvgm is now fixed upstream.