### PR TITLE
Fix tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,34 +15,11 @@ function(fooyin_add_test name)
     gtest_discover_tests(${name})
 endfunction()
 
-qt_add_resources(TEST_SOURCES data/audio.qrc)
-qt_add_resources(TEST_SOURCES data/playlists.qrc)
-add_library(fooyin_test_data ${TEST_SOURCES})
-
 fooyin_add_test(test_scriptparser scriptparsertest.cpp)
 fooyin_add_test(test_scriptformatter scriptformattertest.cpp)
 
-fooyin_add_test(test_tagreader tagreadertest.cpp)
-target_link_libraries(
-    test_tagreader
-    PRIVATE fooyin_test_data
-)
+fooyin_add_test(test_tagreader tagreadertest.cpp data/audio.qrc)
+fooyin_add_test(test_tagwriter tagwritertest.cpp data/audio.qrc)
 
-fooyin_add_test(test_tagwriter tagwritertest.cpp)
-target_link_libraries(
-    test_tagwriter
-    PRIVATE fooyin_test_data
-)
-
-fooyin_add_test(test_cueparser cueparsertest.cpp)
-target_link_libraries(
-    test_cueparser
-    PRIVATE fooyin_test_data
-)
-
-fooyin_add_test(test_m3uparser m3uparsertest.cpp)
-target_link_libraries(
-    test_m3uparser
-    PRIVATE fooyin_test_data
-)
-
+fooyin_add_test(test_cueparser cueparsertest.cpp data/playlists.qrc)
+fooyin_add_test(test_m3uparser m3uparsertest.cpp data/playlists.qrc)

--- a/tests/scriptparsertest.cpp
+++ b/tests/scriptparsertest.cpp
@@ -198,7 +198,7 @@ TEST_F(ScriptParserTest, QueryTest)
     track2.setDuration(195000);
     track2.setFileSize(32000000);
     track2.setDate(QStringLiteral("2010-09-15"));
-    track2.setFirstPlayed(QDateTime::currentDateTime().addYears(-3).toMSecsSinceEpoch());
+    track2.setFirstPlayed(QDateTime(QDate(2021, 1, 1), QTime(0, 0, 0)).toMSecsSinceEpoch());
     track2.setLastPlayed(QDateTime::currentDateTime().addDays(-3).toMSecsSinceEpoch());
     track2.setPlayCount(8);
     tracks.push_back(track2);


### PR DESCRIPTION
The test data library is ignored if  `--as-needed` is enabled (which it is by default on some systems).