### PR TITLE
Make playlist file imports generate separate playlists

### DIFF
--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -1004,10 +1004,15 @@ void GuiApplicationPrivate::loadPlaylist() const
     }
 
     m_settings->fileSet(Settings::Gui::Internal::LastFilePath, files.front());
+    const QList<QPair<QString, QUrl>> info{[&files]() {
+        QList<QPair<QString, QUrl>> list;
+        for(const QUrl& url : files) {
+            list.append(qMakePair(QFileInfo(url.toLocalFile()).completeBaseName(), url));
+        }
+        return list;
+    }()};
 
-    const QFileInfo info{files.front().toLocalFile()};
-
-    m_playlistInteractor.loadPlaylist(info.completeBaseName(), files);
+    m_playlistInteractor.loadPlaylist(info);
 }
 
 void GuiApplicationPrivate::savePlaylist() const

--- a/src/gui/playlist/playlistinteractor.h
+++ b/src/gui/playlist/playlistinteractor.h
@@ -53,7 +53,7 @@ public:
     void filesToNewPlaylistReplace(const QString& playlistName, const QList<QUrl>& urls, bool play = false) const;
     void filesToActivePlaylist(const QList<QUrl>& urls) const;
     void filesToTracks(const QList<QUrl>& urls, const std::function<void(const TrackList&)>& func) const;
-    void loadPlaylist(const QString& playlistName, const QList<QUrl>& urls, bool play = false) const;
+    void loadPlaylist(const QList<QPair<QString, QUrl>>& playlistData, bool play = false) const;
 
     void trackMimeToPlaylist(const QByteArray& data, const UId& id);
 


### PR DESCRIPTION
Quick writeup for fixing #526 , where I zip up the filenames and files and have `PlaylistInteractor::loadPlaylist` iteratively create playlists. Unfortunately changes the interface of `PlaylistInteractor::loadPlaylist`, but that is exclusively used for importing playlist files.