### PR TITLE
[ci] add FreeBSD

### DIFF
--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -1,0 +1,42 @@
+name: FreeBSD build
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  release:
+    types: [published]
+
+env:
+  BUILD_TESTS: Off
+
+jobs:
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: run VM
+        uses: cross-platform-actions/action@master
+        with:
+          operating_system: freebsd
+          architecture: x86-64
+          cpu_count: 4
+          shell: bash
+          version: '14.2'
+          run: |
+            ./ci/freebsd-depends.sh
+            ./ci/freebsd-build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd-14.2
+          path: pkg

--- a/ci/freebsd-build.sh
+++ b/ci/freebsd-build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export FOOYIN_DIR=$PWD
+
+cmake -S "$FOOYIN_DIR" \
+  -G Ninja \
+  -B build \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build
+cd build
+cpack -G FREEBSD
+mkdir ../pkg
+mv *.pkg ../pkg

--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+sudo pkg update
+sudo pkg upgrade -y
+sudo pkg install -y \
+     cmake \
+     pkgconf \
+     ninja \
+     glib \
+     icu \
+     dbus \
+     libgme \
+     libxcb \
+     libvgm \
+     vulkan-headers \
+     vulkan-loader \
+     alsa-lib \
+     qt6-base \
+     qt6-svg \
+     qt6-tools \
+     ffmpeg \
+     taglib \
+     kdsingleapplication \
+     pipewire \
+     pipewire-spa-oss \
+     sdl2 \
+     libopenmpt \
+     libarchive \
+     libsndfile \
+     libebur128


### PR DESCRIPTION
Tested on host:

```
/下载 
❯ sudo pkg install ./fooyin-0.8.1-FreeBSD.pkg
Updating FreeBSD repository catalogue...
Fetching meta.conf:   0%
FreeBSD repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The following 1 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
        fooyin: 0.8.1

Number of packages to be installed: 1

The process will require 14 MiB more space.

Proceed with this action? [y/N]: y
[1/1] Installing fooyin-0.8.1...
Extracting fooyin-0.8.1: 100%     58 B   0.1kB/s    00:01    
==> Running trigger: desktop-file-utils.ucl
Building cache database of MIME types
==> Running trigger: gtk-update-icon-cache.ucl
Generating GTK icon cache for /usr/local/share/icons/hicolor

~/下载 took 9s 
❯ pkg which (which fooyin)
/usr/local/bin/fooyin was installed by package fooyin-0.8.1

~/下载 
❯ ldd (which fooyin)
/usr/local/bin/fooyin:
        libkdsingleapplication-qt6.so.1.1 => /usr/local/lib/libkdsingleapplication-qt6.so.1.1 (0x2ba84e6f4000)
        libfooyin_gui.so.0.0.0 => /usr/local/bin/../lib/fooyin/libfooyin_gui.so.0.0.0 (0x2ba84ec51000)
        libfooyin_core.so.0.0.0 => /usr/local/bin/../lib/fooyin/libfooyin_core.so.0.0.0 (0x2ba84df92000)
        libQt6Network.so.6 => /usr/local/lib/qt6/libQt6Network.so.6 (0x2ba850158000)
        libtag.so.2 => /usr/local/lib/libtag.so.2 (0x2ba84f283000)
        libavcodec.so.60 => /usr/local/lib/libavcodec.so.60 (0x2ba853800000)
        libavfilter.so.9 => /usr/local/lib/libavfilter.so.9 (0x2ba850dd5000)
        libavformat.so.60 => /usr/local/lib/libavformat.so.60 (0x2ba851b5e000)
        libavutil.so.58 => /usr/local/lib/libavutil.so.58 (0x2ba8578e2000)
        libswresample.so.4 => /usr/local/lib/libswresample.so.4 (0x2ba851e8b000)
        libfooyin_utils.so.0.0.0 => /usr/local/bin/../lib/fooyin/libfooyin_utils.so.0.0.0 (0x2ba85219d000)
        libQt6Widgets.so.6 => /usr/local/lib/qt6/libQt6Widgets.so.6 (0x2ba859200000)
        libQt6Gui.so.6 => /usr/local/lib/qt6/libQt6Gui.so.6 (0x2ba85a800000)
        libGLX.so.0 => /usr/local/lib/libGLX.so.0 (0x2ba852688000)
        libOpenGL.so.0 => /usr/local/lib/libOpenGL.so.0 (0x2ba853234000)
        libQt6Sql.so.6 => /usr/local/lib/qt6/libQt6Sql.so.6 (0x2ba854efb000)
        libQt6Concurrent.so.6 => /usr/local/lib/qt6/libQt6Concurrent.so.6 (0x2ba85689f000)
        libQt6Core.so.6 => /usr/local/lib/qt6/libQt6Core.so.6 (0x2ba85ce00000)
        libc++.so.1 => /lib/libc++.so.1 (0x2ba8559d4000)
        libcxxrt.so.1 => /lib/libcxxrt.so.1 (0x2ba856f8d000)
        libm.so.5 => /lib/libm.so.5 (0x2ba85bf49000)
        libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x2ba85da4a000)
        libthr.so.3 => /lib/libthr.so.3 (0x2ba85e474000)
        libc.so.7 => /lib/libc.so.7 (0x2ba85fd67000)
        libQt6Svg.so.6 => /usr/local/lib/qt6/libQt6Svg.so.6 (0x2ba85f022000)
        libbrotlidec.so.1 => /usr/local/lib/libbrotlidec.so.1 (0x2ba86120f000)
        libzstd.so.1 => /usr/local/lib/libzstd.so.1 (0x2ba8601b7000)
        libz.so.6 => /lib/libz.so.6 (0x2ba861cfd000)
        libssl.so.30 => /usr/lib/libssl.so.30 (0x2ba86248b000)
        libcrypto.so.30 => /lib/libcrypto.so.30 (0x2ba86260c000)
        libvpx.so.11 => /usr/local/lib/libvpx.so.11 (0x2ba86457f000)
        libwebpmux.so.3 => /usr/local/lib/libwebpmux.so.3 (0x2ba86333e000)
        liblcms2.so.2 => /usr/local/lib/liblcms2.so.2 (0x2ba863ac5000)
        liblzma.so.5 => /usr/lib/liblzma.so.5 (0x2ba8656b7000)
        libdav1d.so.7 => /usr/local/lib/libdav1d.so.7 (0x2ba8660dd000)
        libaom.so.3 => /usr/local/lib/libaom.so.3 (0x2ba867147000)
        libjxl.so.0.11 => /usr/local/lib/libjxl.so.0.11 (0x2ba868462000)
        libjxl_threads.so.0.11 => /usr/local/lib/libjxl_threads.so.0.11 (0x2ba86a0dc000)
        libmp3lame.so.0 => /usr/local/lib/libmp3lame.so.0 (0x2ba868fc9000)
        libopus.so.0 => /usr/local/lib/libopus.so.0 (0x2ba86be00000)
        libSvtAv1Enc.so.3 => /usr/local/lib/libSvtAv1Enc.so.3 (0x2ba86a825000)
        libvorbis.so.0 => /usr/local/lib/libvorbis.so.0 (0x2ba8691ac000)
        libvorbisenc.so.2 => /usr/local/lib/libvorbisenc.so.2 (0x2ba86cdde000)
        libwebp.so.7 => /usr/local/lib/libwebp.so.7 (0x2ba86cf7f000)
        libx264.so.164 => /usr/local/lib/libx264.so.164 (0x2ba86efb0000)
        libx265.so.209 => /usr/local/lib/libx265.so.209 (0x2ba87067d000)
        libva.so.2 => /usr/local/lib/libva.so.2 (0x2ba86d0c3000)
        libswscale.so.7 => /usr/local/lib/libswscale.so.7 (0x2ba86d190000)
        libpostproc.so.57 => /usr/local/lib/libpostproc.so.57 (0x2ba86d347000)
        libharfbuzz.so.0 => /usr/local/lib/libharfbuzz.so.0 (0x2ba86e0f9000)
        libplacebo.so.351 => /usr/local/lib/libplacebo.so.351 (0x2ba86f58b000)
        libvmaf.so.3 => /usr/local/lib/libvmaf.so.3 (0x2ba871b98000)
        libass.so.9 => /usr/local/lib/libass.so.9 (0x2ba872f40000)
        libshaderc_shared.so.1 => /usr/local/lib/libshaderc_shared.so.1 (0x2ba875200000)
        libfontconfig.so.1 => /usr/local/lib/libfontconfig.so.1 (0x2ba871ece000)
        libfreetype.so.6 => /usr/local/lib/libfreetype.so.6 (0x2ba873d70000)
        libxml2.so.2 => /usr/local/lib/libxml2.so.2 (0x2ba8746e2000)
        libbz2.so.4 => /usr/lib/libbz2.so.4 (0x2ba872cb4000)
        libgmp.so.10 => /usr/local/lib/libgmp.so.10 (0x2ba875b08000)
        libgnutls.so.30 => /usr/local/lib/libgnutls.so.30 (0x2ba876c69000)
        libva-drm.so.2 => /usr/local/lib/libva-drm.so.2 (0x2ba875d9b000)
        libva-x11.so.2 => /usr/local/lib/libva-x11.so.2 (0x2ba87763b000)
        libvdpau.so.1 => /usr/local/lib/libvdpau.so.1 (0x2ba877f37000)
        libX11.so.6 => /usr/local/lib/libX11.so.6 (0x2ba87987a000)
        libdrm.so.2 => /usr/local/lib/libdrm.so.2 (0x2ba877f3e000)
        libicuuc.so.76 => /usr/local/lib/libicuuc.so.76 (0x2ba878e6c000)
        libicui18n.so.76 => /usr/local/lib/libicui18n.so.76 (0x2ba87a20d000)
        libxkbcommon.so.0 => /usr/local/lib/libxkbcommon.so.0 (0x2ba87b4aa000)
        libEGL.so.1 => /usr/local/lib/libEGL.so.1 (0x2ba87c183000)
        libglib-2.0.so.0 => /usr/local/lib/libglib-2.0.so.0 (0x2ba87d939000)
        libQt6DBus.so.6 => /usr/local/lib/qt6/libQt6DBus.so.6 (0x2ba87c32e000)
        libpng16.so.16 => /usr/local/lib/libpng16.so.16 (0x2ba87d35f000)
        libgthread-2.0.so.0 => /usr/local/lib/libgthread-2.0.so.0 (0x2ba87ebb8000)
        libGLdispatch.so.0 => /usr/local/lib/libGLdispatch.so.0 (0x2ba87e271000)
        libdl.so.1 => /usr/lib/libdl.so.1 (0x2ba87f58d000)
        libkvm.so.7 => /lib/libkvm.so.7 (0x2ba88058b000)
        libprocstat.so.1 => /usr/lib/libprocstat.so.1 (0x2ba8816de000)
        libicudata.so.76 => /usr/local/lib/libicudata.so.76 (0x2ba8809a0000)
        libexecinfo.so.1 => /usr/lib/libexecinfo.so.1 (0x2ba882040000)
        libdouble-conversion.so.3 => /usr/local/lib/libdouble-conversion.so.3 (0x2ba882367000)
        libb2.so.1 => /usr/local/lib/libb2.so.1 (0x2ba882c42000)
        libpcre2-16.so.0 => /usr/local/lib/libpcre2-16.so.0 (0x2ba88383b000)
        librt.so.1 => /lib/librt.so.1 (0x2ba884892000)
        libbrotlicommon.so.1 => /usr/local/lib/libbrotlicommon.so.1 (0x2ba8854da000)
        libmd.so.6 => /lib/libmd.so.6 (0x2ba886fe0000)
        libjxl_cms.so.0.11 => /usr/local/lib/libjxl_cms.so.0.11 (0x2ba886396000)
        libhwy.so.1 => /usr/local/lib/libhwy.so.1 (0x2ba888476000)
        libbrotlienc.so.1 => /usr/local/lib/libbrotlienc.so.1 (0x2ba8878ad000)
        libogg.so.0 => /usr/local/lib/libogg.so.0 (0x2ba88888c000)
        libsharpyuv.so.0 => /usr/local/lib/libsharpyuv.so.0 (0x2ba889299000)
        libgraphite2.so.3 => /usr/local/lib/libgraphite2.so.3 (0x2ba88adbe000)
        libunwind.so.8 => /usr/local/lib/libunwind.so.8 (0x2ba88a253000)
        libvulkan.so.1 => /usr/local/lib/libvulkan.so.1 (0x2ba88bbcb000)
        libfribidi.so.0 => /usr/local/lib/libfribidi.so.0 (0x2ba88beb5000)
        libunibreak.so.6 => /usr/local/lib/libunibreak.so.6 (0x2ba88ce2f000)
        libexpat.so.1 => /usr/local/lib/libexpat.so.1 (0x2ba88d8ee000)
        libintl.so.8 => /usr/local/lib/libintl.so.8 (0x2ba88e608000)
        libp11-kit.so.0 => /usr/local/lib/libp11-kit.so.0 (0x2ba88ebf3000)
        libidn2.so.0 => /usr/local/lib/libidn2.so.0 (0x2ba8900e0000)
        libunistring.so.5 => /usr/local/lib/libunistring.so.5 (0x2ba88fa50000)
        libtasn1.so.6 => /usr/local/lib/libtasn1.so.6 (0x2ba8914e0000)
        libhogweed.so.6 => /usr/local/lib/libhogweed.so.6 (0x2ba890831000)
        libnettle.so.8 => /usr/local/lib/libnettle.so.8 (0x2ba891517000)
        libXext.so.6 => /usr/local/lib/libXext.so.6 (0x2ba891f46000)
        libXfixes.so.3 => /usr/local/lib/libXfixes.so.3 (0x2ba892bc8000)
        libX11-xcb.so.1 => /usr/local/lib/libX11-xcb.so.1 (0x2ba89316a000)
        libxcb.so.1 => /usr/local/lib/libxcb.so.1 (0x2ba894648000)
        libxcb-dri3.so.0 => /usr/local/lib/libxcb-dri3.so.0 (0x2ba893f37000)
        libiconv.so.2 => /usr/local/lib/libiconv.so.2 (0x2ba895826000)
        libpcre2-8.so.0 => /usr/local/lib/libpcre2-8.so.0 (0x2ba89502f000)
        libutil.so.9 => /lib/libutil.so.9 (0x2ba896725000)
        libdbus-1.so.3 => /usr/local/lib/libdbus-1.so.3 (0x2ba896b2b000)
        libelf.so.2 => /lib/libelf.so.2 (0x2ba89865a000)
        libomp.so => /usr/lib/libomp.so (0x2ba897b3d000)
        libffi.so.8 => /usr/local/lib/libffi.so.8 (0x2ba89945f000)
        libXau.so.6 => /usr/local/lib/libXau.so.6 (0x2ba899f7f000)
        libXdmcp.so.6 => /usr/local/lib/libXdmcp.so.6 (0x2ba89aae5000)
        [vdso] (0x2ba84d346000)

~/下载 
❯ uname -a
FreeBSD carter-freebsd 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64
```