### PR TITLE
[core] Fix playlist auto-export not obeying settings

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -281,7 +281,8 @@ void ApplicationPrivate::exportAllPlaylists()
 
     const QString path = m_settings->fileValue(AutoExportPlaylistsPath, Core::playlistsPath()).toString();
     const QDir playlistPath{path};
-    const auto type          = PlaylistParser::PathType::Auto;
+    const auto pathType = static_cast<PlaylistParser::PathType>(
+        m_settings->fileValue(Settings::Core::Internal::PlaylistSavePathType, 0).toInt());
     const bool writeMetadata = m_settings->fileValue(Settings::Core::Internal::PlaylistSaveMetadata, false).toBool();
 
     auto saveOrDeletePlaylist = [&](Playlist* playlist, bool forceRemove = false) {
@@ -304,7 +305,7 @@ void ApplicationPrivate::exportAllPlaylists()
 
         const QFileInfo info{playlistFile};
         const QDir playlistDir{info.absolutePath()};
-        parser->savePlaylist(&playlistFile, ext, playlist->tracks(), playlistDir, type, writeMetadata);
+        parser->savePlaylist(&playlistFile, ext, playlist->tracks(), playlistDir, pathType, writeMetadata);
     };
 
     auto playlists        = m_playlistHandler->playlists();


### PR DESCRIPTION
Tiny fix for #543. This ultimately means that `ApplicationPrivate::exportAllPlaylists` and `SavePlaylistsDialogue::accept` have very similar logic. I wonder if putting this function into `utils` would be a better move?