### PR TITLE
ci: Update freebsd-depends.sh

### DIFF
--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -3,28 +3,19 @@
 sudo pkg update
 sudo pkg upgrade -y
 sudo pkg install -y \
-     cmake \
+     cmake-core \
      pkgconf \
      ninja \
-     glib \
-     icu \
-     dbus \
      libgme \
-     libxcb \
      libvgm \
      vulkan-headers \
-     vulkan-loader \
      alsa-lib \
-     qt6-base \
-     qt6-svg \
      qt6-tools \
      ffmpeg \
      taglib \
      kdsingleapplication \
-     pipewire \
      pipewire-spa-oss \
      sdl2 \
      libopenmpt \
      libarchive \
-     libsndfile \
-     libebur128
+     ebur128


### PR DESCRIPTION
Reduce the amount of defined dependencies due to reverse dependencies
* cmake-core contains the binary while cmake is a meta package which pulls in unnecessary dependencies
* Switch from libebur128 to ebur128 which is the default library