### PR TITLE
[plugins] Scrobble Filtering Feature

### DIFF
--- a/src/plugins/scrobbler/scrobblerservice.h
+++ b/src/plugins/scrobbler/scrobblerservice.h
@@ -21,6 +21,7 @@
 
 #include "scrobblercache.h"
 
+#include <core/scripting/scriptparser.h>
 #include <core/track.h>
 
 #include <QBasicTimer>
@@ -88,6 +89,8 @@ protected:
     QNetworkReply* addReply(QNetworkReply* reply);
     bool removeReply(QNetworkReply* reply);
 
+    bool allowedByFilter(const Track& track);
+
     enum class ReplyResult : uint8_t
     {
         Success = 0,
@@ -111,6 +114,8 @@ protected:
 private:
     NetworkAccessManager* m_network;
     SettingsManager* m_settings;
+
+    ScriptParser m_scriptParser;
 
     ScrobblerAuthSession* m_authSession;
     std::vector<QNetworkReply*> m_replies;

--- a/src/plugins/scrobbler/scrobblersettings.cpp
+++ b/src/plugins/scrobbler/scrobblersettings.cpp
@@ -31,5 +31,7 @@ ScrobblerSettings::ScrobblerSettings(SettingsManager* settings)
     settings->createSetting<ScrobblingEnabled>(false, u"Scrobbling/Enabled"_s);
     settings->createSetting<ScrobblingDelay>(0, u"Scrobbling/Delay"_s);
     settings->createSetting<PreferAlbumArtist>(false, u"Scrobbling/PreferAlbumArtist"_s);
+    settings->createSetting<EnableScrobbleFilter>(false, u"Scrobbling/EnableScrobbleFilter"_s);
+    settings->createSetting<ScrobbleFilter>(u""_s, u"Scrobbling/Filter"_s);
 }
 } // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/scrobblersettings.h
+++ b/src/plugins/scrobbler/scrobblersettings.h
@@ -30,9 +30,11 @@ namespace Settings::Scrobbler {
 Q_NAMESPACE
 enum ScrobblerSettings : uint32_t
 {
-    ScrobblingEnabled = 0 | Type::Bool,
-    ScrobblingDelay   = 1 | Type::Int,
-    PreferAlbumArtist = 2 | Type::Bool,
+    ScrobblingEnabled    = 0 | Type::Bool,
+    ScrobblingDelay      = 1 | Type::Int,
+    PreferAlbumArtist    = 2 | Type::Bool,
+    EnableScrobbleFilter = 3 | Type::Bool,
+    ScrobbleFilter       = 4 | Type::String,
 };
 Q_ENUM_NS(ScrobblerSettings)
 } // namespace Settings::Scrobbler


### PR DESCRIPTION
This commit implements the feature used in the Foobar2000 scrobbling plugin, where queries can be used to filter which tracks are scrobbled.

This was a feature I liked in Foobar2000's plugin, since I used it to listen to lectures and podcasts alongside music and didn't want those scrobbled. It's your call on whether this feature is in scope for Fooyin.