### PR TITLE
[plugin] fix messy code when selecting output sound device

### DIFF
--- a/src/plugins/alsa/alsaoutput.cpp
+++ b/src/plugins/alsa/alsaoutput.cpp
@@ -123,11 +123,11 @@ void getPcmDevices(Fooyin::OutputDevices& devices)
         }
 
         if(strcmp(name.str, "default") == 0) {
-            devices.insert(devices.begin(), {QString::fromLatin1(name.str), QString::fromLatin1(desc.str)});
+            devices.insert(devices.begin(), {QString::fromUtf8(name.str), QString::fromUtf8(desc.str)});
         }
         else {
-            devices.emplace_back(QString::fromLatin1(name.str),
-                                 u"%1 - %2"_s.arg(QString::fromLatin1(name.str), QString::fromLatin1(desc.str)));
+            devices.emplace_back(QString::fromUtf8(name.str),
+                                 u"%1 - %2"_s.arg(QString::fromUtf8(name.str), QString::fromUtf8(desc.str)));
         }
     }
 }

--- a/src/plugins/pipewire/pipewireregistry.cpp
+++ b/src/plugins/pipewire/pipewireregistry.cpp
@@ -82,6 +82,6 @@ void PipewireRegistry::onRegistryEvent(void* data, uint32_t /*id*/, uint32_t /*p
     const char* name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
     const char* desc = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
 
-    registry->m_sinks.emplace_back(QString::fromLatin1(name), QString::fromLatin1(desc));
+    registry->m_sinks.emplace_back(QString::fromUtf8(name), QString::fromUtf8(desc));
 }
 } // namespace Fooyin::Pipewire

--- a/src/plugins/sdl/sdloutput.cpp
+++ b/src/plugins/sdl/sdloutput.cpp
@@ -187,7 +187,7 @@ OutputDevices SdlOutput::getAllDevices(bool isCurrentOutput)
 
     const int num = SDL_GetNumAudioDevices(0);
     for(int i = 0; i < num; ++i) {
-        const QString devName = QString::fromLatin1(SDL_GetAudioDeviceName(i, 0));
+        const QString devName = QString::fromUtf8(SDL_GetAudioDeviceName(i, 0));
         if(!devName.isNull()) {
             devices.emplace_back(devName, devName);
         }


### PR DESCRIPTION
IMO `QString::fromLatin1` should never be used. There are a lot places that still uses `fromLatin` that should be double checked.

Fixes #568