### PR TITLE
[plugins] Display audio driver used by SDL2 backend

### DIFF
--- a/src/plugins/sdl/sdlplugin.cpp
+++ b/src/plugins/sdl/sdlplugin.cpp
@@ -21,12 +21,17 @@
 
 #include "sdloutput.h"
 
+#include <SDL2/SDL.h>
+
 using namespace Qt::StringLiterals;
 
 namespace Fooyin::Sdl {
 QString SdlPlugin::name() const
 {
-    return u"SDL2"_s;
+    SDL_Init(SDL_INIT_AUDIO);
+    const QString name = u"SDL2 (%1)"_s.arg(QString::fromLatin1(SDL_GetCurrentAudioDriver()));
+    SDL_Quit();
+    return name;
 }
 
 OutputCreator SdlPlugin::creator() const


### PR DESCRIPTION
Since SDL2 is the only backend supported on Windows and macOS. Make it explicit‌ what audio driver fooyin actually uses.

The default driver can be changed with environment variable `$SDL_AUDIODRIVER`, so I used `SDL_GetCurrentAudioDriver()` instead of `SDL_GetAudioDrvier(0)`

![image](https://github.com/user-attachments/assets/b46f9c17-21e2-4b17-95ec-ef4f8eb523be)
