### PR TITLE
[lyrics] Add forward and rewind buttons for precise timestamp adjustments

### DIFF
--- a/src/plugins/lyrics/lyricseditor.h
+++ b/src/plugins/lyrics/lyricseditor.h
@@ -52,6 +52,8 @@ private:
     void updateButtons();
     void highlightCurrentLine();
     void insertOrUpdateTimestamp();
+    void rewind();
+    void forward();
     void removeTimestamp();
     void removeAllTimestamps();
 
@@ -64,6 +66,8 @@ private:
     QPushButton* m_reset;
 
     QPushButton* m_insert;
+    QPushButton* m_rewind;
+    QPushButton* m_forward;
     QPushButton* m_remove;
     QPushButton* m_removeAll;
 

--- a/src/plugins/lyrics/lyricseditor.h
+++ b/src/plugins/lyrics/lyricseditor.h
@@ -52,8 +52,7 @@ private:
     void updateButtons();
     void highlightCurrentLine();
     void insertOrUpdateTimestamp();
-    void rewind();
-    void forward();
+    void adjustTimestamp();
     void removeTimestamp();
     void removeAllTimestamps();
 


### PR DESCRIPTION
This adds two buttons to the lyrics editor which allows users to adjust the timestamp of a specific line in a song by stepping it forward or backwards by 100ms. Added as a quality of life feature to make corrections less time-consuming.

(feature inspired by [LRCGET](https://github.com/tranxuanthang/lrcget))