### PR TITLE
[gme,ompt,libvgm] Fix infinite looping

### DIFF
--- a/src/plugins/gme/gmeinput.h
+++ b/src/plugins/gme/gmeinput.h
@@ -56,7 +56,7 @@ public:
     AudioBuffer readBuffer(size_t bytes) override;
 
 private:
-    DecoderOptions m_options;
+    bool m_repeatTrack;
     FySettings m_settings;
     AudioFormat m_format;
     MusicEmuPtr m_emu;

--- a/src/plugins/gme/gmesettings.cpp
+++ b/src/plugins/gme/gmesettings.cpp
@@ -75,7 +75,7 @@ GmeSettings::GmeSettings(QWidget* parent)
     lengthLayout->addWidget(maxLengthLabel, row, 0);
     lengthLayout->addWidget(m_maxLength, row++, 1);
     lengthLayout->addWidget(loopLabel, row, 0);
-    lengthLayout->addWidget(m_loopCount, row, 1);
+    lengthLayout->addWidget(m_loopCount, row++, 1);
     lengthLayout->addWidget(fadeLabel, row, 0);
     lengthLayout->addWidget(m_fadeLength, row++, 1);
     lengthLayout->setColumnStretch(3, 1);

--- a/src/plugins/libvgm/vgminput.cpp
+++ b/src/plugins/libvgm/vgminput.cpp
@@ -181,6 +181,9 @@ std::optional<AudioFormat> VgmDecoder::init(const AudioSource& source, const Tra
     else if(options & NoInfiniteLooping && isRepeatingTrack()) {
         loopCount = DefaultLoopCount;
     }
+    else if(!(options & NoInfiniteLooping) && isRepeatingTrack()) {
+        loopCount = 0;
+    }
 
     const QByteArray data = source.device->readAll();
     if(data.isEmpty()) {

--- a/src/plugins/libvgm/vgminputsettings.cpp
+++ b/src/plugins/libvgm/vgminputsettings.cpp
@@ -73,7 +73,7 @@ VgmInputSettings::VgmInputSettings(QWidget* parent)
 
     int row{0};
     lengthLayout->addWidget(loopLabel, row, 0);
-    lengthLayout->addWidget(m_loopCount, row, 1);
+    lengthLayout->addWidget(m_loopCount, row++, 1);
     lengthLayout->addWidget(fadeLabel, row, 0);
     lengthLayout->addWidget(m_fadeLength, row++, 1);
     lengthLayout->addWidget(silenceLabel, row, 0);

--- a/src/plugins/openmpt/openmptinput.cpp
+++ b/src/plugins/openmpt/openmptinput.cpp
@@ -93,6 +93,8 @@ std::optional<AudioFormat> OpenMptDecoder::init(const AudioSource& source, const
 
         m_module = std::make_unique<openmpt::module>(data, std::clog, ctls);
 
+        m_module->select_subsong(track.subsong());
+
         int repeat = m_settings->value<Settings::OpenMpt::LoopCount>();
         if(options & NoLooping || options & NoInfiniteLooping) {
             repeat = 0;
@@ -103,7 +105,6 @@ std::optional<AudioFormat> OpenMptDecoder::init(const AudioSource& source, const
         m_module->set_repeat_count(repeat);
 
         setupModule(m_settings, m_module.get());
-        m_module->select_subsong(track.subsong());
     }
     catch(...) {
         qCWarning(OPENMPT) << "Failed to open" << track.filepath();

--- a/src/plugins/openmpt/openmptsettings.cpp
+++ b/src/plugins/openmpt/openmptsettings.cpp
@@ -70,7 +70,7 @@ OpenMptSettings::OpenMptSettings(SettingsManager* settings, QWidget* parent)
 
     auto* loopLabel = new QLabel(tr("Loop count") + ":"_L1, this);
 
-    m_loopCount->setRange(1, 16);
+    m_loopCount->setRange(0, 16);
     m_loopCount->setSingleStep(1);
     m_loopCount->setSuffix(u" "_s + tr("times"));
 


### PR DESCRIPTION
Fixes 42e838cc958e4466b76994b694474409a9bf43a4
Fixes #667

Also fixes preferences dialogs for looping settings, including OpenMPT, where the loop count is additional loops, not counting the initial playthrough.

Also, OpenMPT needs the renderer parameters to be set after selecting the subsong, not before.