### PR TITLE
[scrobbler] Add support for custom services

### DIFF
--- a/src/plugins/scrobbler/CMakeLists.txt
+++ b/src/plugins/scrobbler/CMakeLists.txt
@@ -3,12 +3,8 @@ create_fooyin_plugin_internal(
     DEPENDS Fooyin::Core
             Fooyin::Gui
             Qt6::Network
-    SOURCES lastfmservice.cpp
-            lastfmservice.h
-            librefmservice.h
-            librefmservice.cpp
-            listenbrainzservice.cpp
-            listenbrainzservice.h
+    SOURCES customservicedialog.cpp
+            customservicedialog.h
             scrobbler.cpp
             scrobbler.h
             scrobblerauthsession.cpp
@@ -19,10 +15,18 @@ create_fooyin_plugin_internal(
             scrobblerpage.h
             scrobblerplugin.cpp
             scrobblerplugin.h
-            scrobblerservice.cpp
-            scrobblerservice.h
             scrobblersettings.cpp
             scrobblersettings.h
             scrobblertoggle.cpp
             scrobblertoggle.h
+            services/servicedetails.cpp
+            services/servicedetails.h
+            services/lastfmservice.cpp
+            services/lastfmservice.h
+            services/librefmservice.h
+            services/librefmservice.cpp
+            services/listenbrainzservice.cpp
+            services/listenbrainzservice.h
+            services/scrobblerservice.cpp
+            services/scrobblerservice.h
 )

--- a/src/plugins/scrobbler/customservicedialog.cpp
+++ b/src/plugins/scrobbler/customservicedialog.cpp
@@ -1,0 +1,200 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "customservicedialog.h"
+
+#include "scrobbler.h"
+#include "services/scrobblerservice.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Scrobbler {
+CustomServiceDialog::CustomServiceDialog(ScrobblerService* service, Scrobbler* scrobbler, QWidget* parent)
+    : QDialog{parent}
+    , m_editing{service != nullptr}
+    , m_scrobbler{scrobbler}
+    , m_service{service}
+    , m_type{new QComboBox(this)}
+    , m_name{new QLineEdit(this)}
+    , m_url{new QLineEdit(this)}
+    , m_token{new QLineEdit(this)}
+    , m_status{new QLabel(this)}
+{
+    setWindowTitle(tr("Edit Scrobbling Service"));
+
+    auto* typeLabel  = new QLabel(tr("Type") + u":", this);
+    auto* nameLabel  = new QLabel(tr("Name") + u":", this);
+    auto* urlLabel   = new QLabel(tr("URL") + u":", this);
+    auto* tokenLabel = new QLabel(tr("Token") + u":", this);
+
+    // Only ListenBrainz supported for now
+    m_type->addItem(u"ListenBrainz"_s, QVariant::fromValue(ServiceDetails::CustomType::ListenBrainz));
+    // m_type->addItem(u"AudioScrobbler"_s, QVariant::fromValue(ServiceDetails::CustomType::AudioScrobbler));
+    m_type->setEnabled(false);
+
+    const auto updateButtonState = [this](QPushButton* button) {
+        const bool unique = hasUniqueName();
+        if(!unique) {
+            updateStatus(false, tr("A service with that name already exists"));
+        }
+        else {
+            updateStatus(true);
+        }
+
+        button->setEnabled(unique && hasValidDetails());
+    };
+
+    auto* buttonBox
+        = new QDialogButtonBox(QDialogButtonBox::Apply | QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    if(auto* okButton = buttonBox->button(QDialogButtonBox::Ok)) {
+        updateButtonState(okButton);
+        for(const auto& control : {m_name, m_url, m_token}) {
+            QObject::connect(control, &QLineEdit::textChanged, this,
+                             [updateButtonState, okButton]() { updateButtonState(okButton); });
+        }
+    }
+    if(auto* applyButton = buttonBox->button(QDialogButtonBox::Apply)) {
+        applyButton->setText(tr("Test"));
+        updateButtonState(applyButton);
+        for(const auto& control : {m_name, m_url, m_token}) {
+            QObject::connect(control, &QLineEdit::textChanged, this,
+                             [updateButtonState, applyButton]() { updateButtonState(applyButton); });
+        }
+        QObject::connect(applyButton, &QPushButton::clicked, this, &CustomServiceDialog::testService);
+    }
+
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    m_status->setWordWrap(true);
+
+    auto* layout = new QGridLayout(this);
+
+    int row{0};
+    layout->addWidget(nameLabel, row, 0);
+    layout->addWidget(m_name, row++, 1);
+    layout->addWidget(typeLabel, row, 0);
+    layout->addWidget(m_type, row++, 1);
+    layout->addWidget(urlLabel, row, 0);
+    layout->addWidget(m_url, row++, 1);
+    layout->addWidget(tokenLabel, row, 0);
+    layout->addWidget(m_token, row++, 1);
+    layout->addWidget(m_status, row++, 0, 2, 2);
+    layout->setRowStretch(row++, 1);
+    layout->addWidget(buttonBox, row, 1, 1, 1, Qt::AlignRight);
+
+    if(service) {
+        const auto details = service->details();
+        // m_type->setCurrentText(details.customType == ServiceDetails::CustomType::AudioScrobbler ? u"AudioScrobbler"_s
+        //                                                                                         : u"ListenBrainz"_s);
+        m_name->setText(details.name);
+        m_url->setText(details.url.toDisplayString());
+        m_token->setText(details.token);
+    }
+
+    resize(CustomServiceDialog::sizeHint());
+}
+
+CustomServiceDialog::CustomServiceDialog(Scrobbler* scrobbler, QWidget* parent)
+    : CustomServiceDialog{nullptr, scrobbler, parent}
+{
+    setWindowTitle(tr("Add Scrobbling Service"));
+}
+
+ServiceDetails CustomServiceDialog::serviceDetails() const
+{
+    return {.name       = m_name->text(),
+            .url        = QUrl{m_url->text()}.adjusted(QUrl::StripTrailingSlash),
+            .token      = m_token->text(),
+            .customType = static_cast<ServiceDetails::CustomType>(m_type->currentData().toInt()),
+            .isEnabled  = true};
+}
+
+void CustomServiceDialog::accept()
+{
+    QDialog::accept();
+}
+
+QSize CustomServiceDialog::sizeHint() const
+{
+    auto size = m_type->sizeHint();
+    size.rheight() += 200;
+    size.rwidth() += 500;
+    return size;
+}
+
+QSize CustomServiceDialog::minimumSizeHint() const
+{
+    auto size = m_type->minimumSizeHint();
+    size.rheight() += 200;
+    size.rwidth() += 500;
+    return size;
+}
+
+void CustomServiceDialog::testService()
+{
+    if(m_testService) {
+        m_testService->updateDetails(serviceDetails());
+    }
+    else {
+        m_testService = m_scrobbler->createCustomService(serviceDetails());
+        QObject::connect(m_testService.get(), &ScrobblerService::testApiFinished, this,
+                         [this](bool success, const QString& error) {
+                             updateStatus(success, success ? tr("Token authenticated successfully") : error);
+                         });
+    }
+
+    m_testService->testApi();
+}
+
+void CustomServiceDialog::updateStatus(bool success, const QString& message)
+{
+    QPalette palette = m_status->palette();
+
+    if(success) {
+        palette.setColor(QPalette::WindowText, Qt::green);
+    }
+    else {
+        palette.setColor(QPalette::WindowText, Qt::red);
+    }
+
+    m_status->setText(message);
+    m_status->setPalette(palette);
+}
+
+bool CustomServiceDialog::hasUniqueName() const
+{
+    auto* existingService = m_scrobbler->service(m_name->text());
+    return (m_editing && m_service == existingService) || !existingService;
+}
+
+bool CustomServiceDialog::hasValidDetails() const
+{
+    return !m_name->text().isEmpty() && !m_url->text().isEmpty() && !m_token->text().isEmpty();
+}
+} // namespace Fooyin::Scrobbler
+
+#include "moc_customservicedialog.cpp"

--- a/src/plugins/scrobbler/customservicedialog.h
+++ b/src/plugins/scrobbler/customservicedialog.h
@@ -1,0 +1,67 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "services/servicedetails.h"
+
+#include <QDialog>
+
+class QComboBox;
+class QLabel;
+class QLineEdit;
+
+namespace Fooyin::Scrobbler {
+class Scrobbler;
+class ScrobblerService;
+
+class CustomServiceDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    CustomServiceDialog(ScrobblerService* service, Scrobbler* scrobbler, QWidget* parent = nullptr);
+    explicit CustomServiceDialog(Scrobbler* scrobbler, QWidget* parent = nullptr);
+
+    [[nodiscard]] ServiceDetails serviceDetails() const;
+
+    void accept() override;
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+private:
+    void testService();
+    void updateStatus(bool success, const QString& message = {});
+    [[nodiscard]] bool hasUniqueName() const;
+    [[nodiscard]] bool hasValidDetails() const;
+
+    bool m_editing;
+
+    Scrobbler* m_scrobbler;
+    ScrobblerService* m_service;
+    std::unique_ptr<ScrobblerService> m_testService;
+
+    QComboBox* m_type;
+    QLineEdit* m_name;
+    QLineEdit* m_url;
+    QLineEdit* m_token;
+    QLabel* m_status;
+};
+} // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/scrobbler.h
+++ b/src/plugins/scrobbler/scrobbler.h
@@ -19,7 +19,8 @@
 
 #pragma once
 
-#include "scrobblerservice.h"
+#include "services/scrobblerservice.h"
+#include "services/servicedetails.h"
 
 #include <memory>
 #include <vector>
@@ -32,18 +33,34 @@ class PlayerController;
 class SettingsManager;
 
 namespace Scrobbler {
-class Scrobbler
+struct ServiceDetails;
+
+class Scrobbler : public QObject
 {
+    Q_OBJECT
+
 public:
     Scrobbler(PlayerController* playerController, std::shared_ptr<NetworkAccessManager> network,
               SettingsManager* settings);
+    ~Scrobbler() override;
 
     [[nodiscard]] std::vector<ScrobblerService*> services() const;
     [[nodiscard]] ScrobblerService* service(const QString& name) const;
 
+    void updateNowPlaying(const Track& track);
+    void scrobble(const Track& track);
+
+    std::unique_ptr<ScrobblerService> createCustomService(const ServiceDetails& details);
+    ScrobblerService* addCustomService(const ServiceDetails& details, bool init = true);
+    bool removeCustomService(ScrobblerService* service);
+
     void saveCache();
 
 private:
+    void addDefaultServices();
+    void saveServices();
+    void restoreServices();
+
     PlayerController* m_playerController;
     std::shared_ptr<NetworkAccessManager> m_network;
     SettingsManager* m_settings;

--- a/src/plugins/scrobbler/scrobblerplugin.cpp
+++ b/src/plugins/scrobbler/scrobblerplugin.cpp
@@ -40,8 +40,8 @@ void ScrobblerPlugin::initialise(const CorePluginContext& context)
     m_networkAccess    = context.networkAccess;
     m_settings         = context.settingsManager;
 
-    m_scrobbler         = std::make_unique<Scrobbler>(m_playerController, m_networkAccess, m_settings);
     m_scrobblerSettings = std::make_unique<ScrobblerSettings>(m_settings);
+    m_scrobbler         = std::make_unique<Scrobbler>(m_playerController, m_networkAccess, m_settings);
 }
 
 void ScrobblerPlugin::initialise(const GuiPluginContext& context)

--- a/src/plugins/scrobbler/scrobblersettings.cpp
+++ b/src/plugins/scrobbler/scrobblersettings.cpp
@@ -33,5 +33,6 @@ ScrobblerSettings::ScrobblerSettings(SettingsManager* settings)
     settings->createSetting<PreferAlbumArtist>(false, u"Scrobbling/PreferAlbumArtist"_s);
     settings->createSetting<EnableScrobbleFilter>(false, u"Scrobbling/EnableScrobbleFilter"_s);
     settings->createSetting<ScrobbleFilter>(u""_s, u"Scrobbling/Filter"_s);
+    settings->createSetting<ServicesData>(QByteArray{}, u"Scrobbling/ServicesData"_s);
 }
 } // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/scrobblersettings.h
+++ b/src/plugins/scrobbler/scrobblersettings.h
@@ -35,6 +35,7 @@ enum ScrobblerSettings : uint32_t
     PreferAlbumArtist    = 2 | Type::Bool,
     EnableScrobbleFilter = 3 | Type::Bool,
     ScrobbleFilter       = 4 | Type::String,
+    ServicesData         = 5 | Type::ByteArray,
 };
 Q_ENUM_NS(ScrobblerSettings)
 } // namespace Settings::Scrobbler

--- a/src/plugins/scrobbler/services/lastfmservice.h
+++ b/src/plugins/scrobbler/services/lastfmservice.h
@@ -22,50 +22,42 @@
 #include "scrobblerservice.h"
 
 namespace Fooyin::Scrobbler {
-class ScrobblerAuthSession;
-class ScrobblerCache;
-
-class ListenBrainzService : public ScrobblerService
+class LastFmService : public ScrobblerService
 {
 public:
-    ListenBrainzService(NetworkAccessManager* network, SettingsManager* settings, QObject* parent = nullptr);
+    LastFmService(ServiceDetails service, NetworkAccessManager* network, SettingsManager* settings,
+                  QObject* parent = nullptr);
 
-    [[nodiscard]] QString name() const override;
     [[nodiscard]] QUrl url() const override;
     [[nodiscard]] QUrl authUrl() const override;
+    [[nodiscard]] QString username() const override;
+    [[nodiscard]] bool requiresAuthentication() const override;
     [[nodiscard]] bool isAuthenticated() const override;
 
-    void authenticate() override;
+    void saveSession() override;
     void loadSession() override;
+    void deleteSession() override;
     void logout() override;
 
+    void testApi() override;
     void updateNowPlaying() override;
     void submit() override;
-
-    [[nodiscard]] QString tokenSetting() const override;
-    [[nodiscard]] QUrl tokenUrl() const override;
 
 protected:
     void setupAuthQuery(ScrobblerAuthSession* session, QUrlQuery& query) override;
     void requestAuth(const QString& token) override;
     void authFinished(QNetworkReply* reply) override;
 
-    void timerEvent(QTimerEvent* event) override;
+    ReplyResult getJsonFromReply(QNetworkReply* reply, QJsonObject* obj, QString* errorDesc) override;
 
 private:
-    QNetworkReply* createRequest(const QUrl& url, const QJsonDocument& json);
-    ReplyResult getJsonFromReply(QNetworkReply* reply, QJsonObject* obj, QString* errorDesc) override;
-    [[nodiscard]] QJsonObject getTrackMetadata(const Metadata& metadata) const;
-
+    QNetworkReply* createRequest(const std::map<QString, QString>& params);
     void updateNowPlayingFinished(QNetworkReply* reply);
     void scrobbleFinished(QNetworkReply* reply, const CacheItemList& items);
 
-    QString m_userToken;
-    QString m_accessToken;
-    qint64 m_expiresIn;
-    quint64 m_loginTime;
-    QString m_tokenType;
-    QString m_refreshToken;
-    QBasicTimer m_loginTimer;
+    QString m_apiKey;
+    QString m_secret;
+    QString m_username;
+    QString m_sessionKey;
 };
 } // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/services/librefmservice.cpp
+++ b/src/plugins/scrobbler/services/librefmservice.cpp
@@ -17,18 +17,21 @@
  *
  */
 
-#pragma once
+#include "librefmservice.h"
 
-#include "lastfmservice.h"
+using namespace Qt::StringLiterals;
+
+constexpr auto ApiUrl  = "https://libre.fm/2.0/";
+constexpr auto AuthUrl = "https://libre.fm/api/auth/";
 
 namespace Fooyin::Scrobbler {
-class LibreFmService : public LastFmService
+QUrl LibreFmService::url() const
 {
-public:
-    using LastFmService::LastFmService;
+    return isCustom() ? details().url : QString::fromLatin1(ApiUrl);
+}
 
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QUrl url() const override;
-    [[nodiscard]] QUrl authUrl() const override;
-};
+QUrl LibreFmService::authUrl() const
+{
+    return QString::fromLatin1(AuthUrl);
+}
 } // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/services/librefmservice.h
+++ b/src/plugins/scrobbler/services/librefmservice.h
@@ -17,24 +17,17 @@
  *
  */
 
-#include "librefmservice.h"
+#pragma once
 
-using namespace Qt::StringLiterals;
+#include "lastfmservice.h"
 
-constexpr auto ApiUrl  = "https://libre.fm/2.0/";
-constexpr auto AuthUrl = "https://www.libre.fm/api/auth/";
-
-QString Fooyin::Scrobbler::LibreFmService::name() const
+namespace Fooyin::Scrobbler {
+class LibreFmService : public LastFmService
 {
-    return u"LibreFM"_s;
-}
+public:
+    using LastFmService::LastFmService;
 
-QUrl Fooyin::Scrobbler::LibreFmService::url() const
-{
-    return QString::fromLatin1(ApiUrl);
-}
-
-QUrl Fooyin::Scrobbler::LibreFmService::authUrl() const
-{
-    return QString::fromLatin1(AuthUrl);
-}
+    [[nodiscard]] QUrl url() const override;
+    [[nodiscard]] QUrl authUrl() const override;
+};
+} // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/services/listenbrainzservice.h
+++ b/src/plugins/scrobbler/services/listenbrainzservice.h
@@ -22,38 +22,37 @@
 #include "scrobblerservice.h"
 
 namespace Fooyin::Scrobbler {
-class LastFmService : public ScrobblerService
+class ScrobblerAuthSession;
+class ScrobblerCache;
+
+class ListenBrainzService : public ScrobblerService
 {
 public:
-    LastFmService(NetworkAccessManager* network, SettingsManager* settings, QObject* parent = nullptr);
+    using ScrobblerService::ScrobblerService;
 
-    [[nodiscard]] QString name() const override;
     [[nodiscard]] QUrl url() const override;
-    [[nodiscard]] QUrl authUrl() const override;
-    [[nodiscard]] QString username() const override;
-    [[nodiscard]] bool isAuthenticated() const override;
+    [[nodiscard]] bool requiresAuthentication() const override;
 
+    void saveSession() override;
     void loadSession() override;
-    void logout() override;
+    void deleteSession() override;
 
+    void testApi() override;
     void updateNowPlaying() override;
     void submit() override;
 
-protected:
-    void setupAuthQuery(ScrobblerAuthSession* session, QUrlQuery& query) override;
-    void requestAuth(const QString& token) override;
-    void authFinished(QNetworkReply* reply) override;
-
-    ReplyResult getJsonFromReply(QNetworkReply* reply, QJsonObject* obj, QString* errorDesc) override;
+    [[nodiscard]] QString tokenSetting() const override;
+    [[nodiscard]] QUrl tokenUrl() const override;
 
 private:
-    QNetworkReply* createRequest(const std::map<QString, QString>& params);
+    QNetworkReply* createRequest(const QUrl& url, const QJsonDocument& json);
+    ReplyResult getJsonFromReply(QNetworkReply* reply, QJsonObject* obj, QString* errorDesc) override;
+    [[nodiscard]] QJsonObject getTrackMetadata(const Metadata& metadata) const;
+
+    void testFinished(QNetworkReply* reply);
     void updateNowPlayingFinished(QNetworkReply* reply);
     void scrobbleFinished(QNetworkReply* reply, const CacheItemList& items);
 
-    QString m_apiKey;
-    QString m_secret;
-    QString m_username;
-    QString m_sessionKey;
+    [[nodiscard]] QString userToken() const;
 };
 } // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/services/servicedetails.cpp
+++ b/src/plugins/scrobbler/services/servicedetails.cpp
@@ -1,0 +1,36 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "servicedetails.h"
+
+namespace Fooyin::Scrobbler {
+QDataStream& operator<<(QDataStream& stream, const ServiceDetails& service)
+{
+    stream << service.name;
+    stream << service.customType;
+    return stream;
+}
+
+QDataStream& operator>>(QDataStream& stream, ServiceDetails& service)
+{
+    stream >> service.name;
+    stream >> service.customType;
+    return stream;
+}
+} // namespace Fooyin::Scrobbler

--- a/src/plugins/scrobbler/services/servicedetails.h
+++ b/src/plugins/scrobbler/services/servicedetails.h
@@ -1,0 +1,55 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QDataStream>
+#include <QString>
+#include <QUrl>
+
+namespace Fooyin::Scrobbler {
+struct ServiceDetails
+{
+    enum class CustomType : uint8_t
+    {
+        None = 0,
+        AudioScrobbler,
+        ListenBrainz
+    };
+
+    QString name;
+    QUrl url;
+    QString token;
+    CustomType customType{CustomType::None};
+    bool isEnabled{true};
+
+    [[nodiscard]] bool isValid() const
+    {
+        return !name.isEmpty() && !url.isEmpty();
+    }
+
+    [[nodiscard]] bool isCustom() const
+    {
+        return customType != CustomType::None;
+    }
+
+    friend QDataStream& operator<<(QDataStream& stream, const ServiceDetails& service);
+    friend QDataStream& operator>>(QDataStream& stream, ServiceDetails& service);
+};
+} // namespace Fooyin::Scrobbler


### PR DESCRIPTION
This introduces support for integrating custom scrobbling services, starting with those based on **ListenBrainz**.

## Changes
- **Custom Scrobbling Service Framework**
  - Support for adding custom services via a URL and user token.
  - Architecture allows multiple services to be registered and used concurrently.

- **ListenBrainz**
  - Removed manual authentication flow; scrobbling now requires only a **user token**.

- **Interface**
  - Redesigned service list UI.
  - Added support for enabling or disabling individual services.
  

| Service List | Service Settings |
|--------------|------------------|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/79d03d00-9e69-422e-8cba-a8509555e76a" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/ae9d641a-221c-4f45-89ca-e244fc6a40ee" /> |
