### PR TITLE
[core] Scripting: Fix %isplaying%, %ispaused% never being evaluated to false

### DIFF
--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -196,12 +196,16 @@ void ScriptRegistryPrivate::addPlaybackVars()
                 : 0);
     };
     m_playbackVars[u"ISPLAYING"_s] = [this]() {
-        return QString::number(
-            static_cast<int>(m_playerController && m_playerController->playState() == Player::PlayState::Playing));
+        if(m_playerController && m_playerController->playState() == Player::PlayState::Playing) {
+            return u"1"_s;
+        }
+        return QString{};
     };
     m_playbackVars[u"ISPAUSED"_s] = [this]() {
-        return QString::number(
-            static_cast<int>(m_playerController && m_playerController->playState() == Player::PlayState::Paused));
+        if(m_playerController && m_playerController->playState() == Player::PlayState::Paused) {
+            return u"1"_s;
+        }
+        return QString{};
     };
 }
 


### PR DESCRIPTION
`calculateResult` sets the expression result to `false` for empty strings and `true` for non-empty ones. `%isplaying%` and `%ispaused%` always return a non-empty string (either "0" or "1") so they can never be evaluated to false. Fix by returning an empty string in the false case instead of "0".

Fixes #646