### PR TITLE
[CI,cmake] Add QCoro as a dependency

### DIFF
--- a/3rdparty/3rdparty.cmake
+++ b/3rdparty/3rdparty.cmake
@@ -1,1 +1,2 @@
 include(3rdparty/kdsingleapplication.cmake)
+include(3rdparty/qcoro.cmake)

--- a/3rdparty/qcoro.cmake
+++ b/3rdparty/qcoro.cmake
@@ -1,0 +1,41 @@
+find_package(QCoro6 0.9.0 QUIET COMPONENTS Core Network)
+
+if(TARGET QCoro6::Core)
+    message(STATUS "Using system QCoro")
+else()
+    message(STATUS "Using 3rd-party QCoro")
+
+    function(setup_qcoro)
+        include(FetchContent)
+
+        set(BUILD_SHARED_LIBS OFF)
+        set(BUILD_TESTING OFF)
+        set(QCORO_BUILD_EXAMPLES OFF)
+        set(QCORO_WITH_QTWEBSOCKETS OFF)
+        set(QCORO_WITH_QTQUICK OFF)
+        set(QCORO_WITH_QTDBUS OFF)
+        set(QCORO_DISABLE_DEPRECATED_TASK_H ON)
+        set(QCORO_WITH_QML OFF)
+
+        FetchContent_Declare(
+            qcoro
+            GIT_REPOSITORY https://github.com/qcoro/qcoro.git
+            GIT_TAG v0.12.0
+            SOURCE_SUBDIR "NeedManualAddSubDir"
+        )
+        FetchContent_MakeAvailable(qcoro)
+
+        set(log_level ${CMAKE_MESSAGE_LOG_LEVEL})
+        if (NOT VERBOSE_FETCH)
+          set(CMAKE_MESSAGE_LOG_LEVEL NOTICE)
+        endif()
+
+        add_subdirectory(${qcoro_SOURCE_DIR} ${qcoro_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+        set(CMAKE_MESSAGE_LOG_LEVEL $log_level)
+    endfunction()
+
+    setup_qcoro()
+endif()
+
+qcoro_enable_coroutines()

--- a/BUILD.md
+++ b/BUILD.md
@@ -22,6 +22,7 @@ At least one of the following is required for audio output:
 
 The following libraries are optional:
 * [KDSingleApplication](https://github.com/KDAB/KDSingleApplication) - will use 3rd party dep if not present on system
+* [QCoro](https://github.com/qcoro/qcoro) - will use 3rd party dep if not present on system
 * [libsndfile](https://libsndfile.github.io/libsndfile) - for the sndfile audio input plugin
 * [OpenMPT](https://lib.openmpt.org/libopenmpt) - for the OpenMPT audio input plugin
 * [Game Music Emu](https://github.com/libgme/game-music-emu) - for the GME audio input plugin

--- a/ci/archlinux-depends.sh
+++ b/ci/archlinux-depends.sh
@@ -14,6 +14,7 @@ $SUDO pacman -S --noconfirm --needed \
        qt6-svg \
        qt6-tools \
        kdsingleapplication \
+       qcoro \
        taglib \
        ffmpeg \
        pipewire \

--- a/ci/fedora-depends.sh
+++ b/ci/fedora-depends.sh
@@ -18,6 +18,7 @@ dnf -y install --skip-broken \
      qt6-qtbase-devel \
      qt6-qtsvg-devel \
      qt6-qttools-devel \
+     qcoro-qt6-devel \
      libavcodec-free-devel \
      libavfilter-free-devel \
      libavformat-free-devel \

--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -11,6 +11,7 @@ sudo pkg install -y \
      vulkan-headers \
      alsa-lib \
      qt6-tools \
+     qcoro-qt6 \
      ffmpeg \
      taglib \
      kdsingleapplication \

--- a/ci/ubuntu-depends.sh
+++ b/ci/ubuntu-depends.sh
@@ -49,3 +49,11 @@ case "$CODENAME" in
     $SUDO apt-get install -y libtag-dev
     ;;
 esac
+
+case "$CODENAME" in
+bookworm)
+    ;;
+*)
+    $SUDO apt-get install -y qcoro-qt6-dev
+    ;;
+esac

--- a/cmake/FooyinPackageConfig.cmake
+++ b/cmake/FooyinPackageConfig.cmake
@@ -39,36 +39,45 @@ if(CPACK_GENERATOR STREQUAL "DEB")
     )
 
     # Distro specific packages
-    if("${DIST_RELEASE}" STREQUAL "jammy")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu70")
-    elseif("${DIST_RELEASE}" STREQUAL "mantic")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu72")
-    elseif("${DIST_RELEASE}" STREQUAL "noble")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu74")
-    elseif("${DIST_RELEASE}" STREQUAL "plucky")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu76")
-    elseif("${DIST_RELEASE}" STREQUAL "questing")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu76")
-    elseif("${DIST_RELEASE}" STREQUAL "trixie")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu76")
-    elseif("${DIST_RELEASE}" STREQUAL "forky")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu76")
-    else()
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libicu72")
+    set(ICU_VERSIONS
+        jammy    libicu70
+        mantic   libicu72
+        noble    libicu74
+        plucky   libicu76
+        questing libicu76
+        trixie   libicu76
+        forky    libicu76
+    )
+
+    set(TAGLIB_VERSIONS
+        bookworm libtag1v5
+        noble    libtag1v5
+        plucky   libtag2
+        questing libtag2
+        trixie   libtag2
+        forky    libtag2
+    )
+
+    list(FIND ICU_VERSIONS "${DIST_RELEASE}" idx)
+    if(idx GREATER -1)
+        math(EXPR idx "${idx} + 1")
+        list(GET ICU_VERSIONS ${idx} ICU_VERSION)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, ${ICU_VERSION}")
     endif()
 
-    if("${DIST_RELEASE}" STREQUAL "trixie")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag2")
-    elseif("${DIST_RELEASE}" STREQUAL "forky")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag2")
-    elseif("${DIST_RELEASE}" STREQUAL "bookworm")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag1v5")
-    elseif("${DIST_RELEASE}" STREQUAL "plucky")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag2")
-    elseif("${DIST_RELEASE}" STREQUAL "questing")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag2")
-    elseif("${DIST_RELEASE}" STREQUAL "noble")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libtag1v5")
+    list(FIND TAGLIB_VERSIONS "${DIST_RELEASE}" idx)
+    if(idx GREATER -1)
+        math(EXPR idx "${idx} + 1")
+        list(GET TAGLIB_VERSIONS ${idx} TAGLIB_VERSION)
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, ${TAGLIB_VERSION}")
+    endif()
+
+    if(NOT "${DIST_RELEASE}" STREQUAL "bookworm")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS
+            "${CPACK_DEBIAN_PACKAGE_DEPENDS},
+            libqcoro6core0t64,
+            libqcoro6network0t64"
+        )
     endif()
 endif()
 


### PR DESCRIPTION
This reintroduces QCoro as a project dependency. The library was previously removed due to the limited use of coroutines within the codebase, which made its inclusion unnecessary at the time.

Since then, coroutine usage would benefit us greatly as we make extensive use of classes such as `QNetworkAccessManager` and `QLocalSocket`, both of which involve asynchronous operations. Using coroutines in these cases allows us to replace complex signal–slot chains, significantly improving code readability, maintainability, and overall clarity.