### PR TITLE
add missing header include for QElapsedTimer class

### DIFF
--- a/src/plugins/vumeter/vumeterwidget.cpp
+++ b/src/plugins/vumeter/vumeterwidget.cpp
@@ -32,8 +32,8 @@
 
 #include <QActionGroup>
 #include <QBasicTimer>
-#include <QElapsedTimer>
 #include <QContextMenuEvent>
+#include <QElapsedTimer>
 #include <QJsonObject>
 #include <QMenu>
 #include <QPainter>

--- a/src/plugins/vumeter/vumeterwidget.cpp
+++ b/src/plugins/vumeter/vumeterwidget.cpp
@@ -32,6 +32,7 @@
 
 #include <QActionGroup>
 #include <QBasicTimer>
+#include <QElapsedTimer>
 #include <QContextMenuEvent>
 #include <QJsonObject>
 #include <QMenu>


### PR DESCRIPTION
This is required in order to use the `QElapsedTimer` class: https://doc.qt.io/qt-6/qelapsedtimer.html

Fixes #724 .