### PR TITLE
[gui] Fix PropertiesDialog not auto-defaulting to Ok button

### DIFF
--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -170,6 +170,7 @@ PropertiesDialogWidget::PropertiesDialogWidget(TrackList tracks, PropertiesDialo
 
     m_applyButton = buttonBox->button(QDialogButtonBox::Apply);
     buttonBox->button(QDialogButtonBox::Ok)->setDefault(true);
+    buttonBox->button(QDialogButtonBox::Cancel)->setAutoDefault(false);
     tabWidget->setCurrentIndex(0);
 
     m_toolsButton->setText(tr("Tools"));


### PR DESCRIPTION
Opening the properties dialog, changing the metadata and pressing Enter closes the dialog but discards all changes, because the dialog auto-defaults to the Cancel button. I don't think this was intended, given that `setDefault(true)` is called on Ok. The missing step is to also call `setAutoDefault(false)` on Cancel.