### PR TITLE
CLI - add seek commands

### DIFF
--- a/src/app/commandline.h
+++ b/src/app/commandline.h
@@ -38,6 +38,8 @@ public:
         Stop      = 4,
         Next      = 5,
         Previous  = 6,
+        SeekFwd   = 7,
+        SeekBack  = 8,
     };
 
     explicit CommandLine(int argc = 0, char** argv = nullptr);
@@ -46,6 +48,7 @@ public:
 
     [[nodiscard]] bool empty() const;
     [[nodiscard]] QList<QUrl> files() const;
+    [[nodiscard]] uint64_t seekDelta() const;
     [[nodiscard]] bool skipSingleApp() const;
     [[nodiscard]] PlayerAction playerAction() const;
 
@@ -60,6 +63,7 @@ private:
     char** m_argv;
 #endif
     QList<QUrl> m_files;
+    uint64_t m_seekDelta = 0;
     bool m_skipSingle;
     PlayerAction m_playerAction;
 };

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -70,6 +70,12 @@ void parseCmdOptions(Fooyin::Application& app, Fooyin::GuiApplication& guiApp, C
             case(CommandLine::PlayerAction::Previous):
                 player->previous();
                 break;
+            case(CommandLine::PlayerAction::SeekFwd):
+                player->seekForward(cmdLine.seekDelta());
+                break;
+            case(CommandLine::PlayerAction::SeekBack):
+                player->seekBackward(cmdLine.seekDelta());
+                break;
             case(CommandLine::PlayerAction::None):
                 break;
         }


### PR DESCRIPTION
Added seek commands which could be used for example for global shortcuts. Seek amount is in ms.
E.g.
`fooyin --seek-forward 5000`
will seek/skip 5s forwards. If preferred I can change to a single command and using negative seek time for backward and positive for forward.