### PR TITLE
[utils] Fix compatibility with Qt 6.10.1

### DIFF
--- a/src/utils/starrating.cpp
+++ b/src/utils/starrating.cpp
@@ -104,7 +104,7 @@ void StarRating::paint(QPainter* painter, const QRect& rect, const QPalette& pal
                                  .arg(m_maxCount)
                                  .arg(mode == EditMode::Editable ? 1 : 0)
                                  .arg(rect.width())
-                                 .arg(alignment);
+                                 .arg(alignment.toInt());
 
     QPixmap pixmap;
     if(!QPixmapCache::find(cacheKey, &pixmap)) {


### PR DESCRIPTION
Starting from Qt 6.10.1, the `QString::arg()` method [no longer accepts implicit conversions](https://doc.qt.io/qt-6/qstring.html#arg-2).
This change broke the `paint` method in `StarRating`.

~This PR applies the recommended fix and casts types explicitly.~
The latest version was modified to use the `.toInt()` method of `Qt::Alignment`, proposed in https://github.com/fooyin/fooyin/issues/779#issuecomment-3604027886
Fixes #779.
