### PR TITLE
[draft] ffmpeg chapters

### DIFF
--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -186,7 +186,7 @@ QString convertString(const char* str)
     return QString::fromUtf8(str);
 };
 
-void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
+void parseTag(Fooyin::Track& track, const AVDictionaryEntry* tag, bool isTrack, int nbChapters)
 {
     if(strcasecmp(tag->key, "album") == 0) {
         track.setAlbum(convertString(tag->value));
@@ -198,7 +198,12 @@ void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
         track.setAlbumArtists({convertString(tag->value)});
     }
     else if(strcasecmp(tag->key, "title") == 0) {
-        track.setTitle(convertString(tag->value));
+        if(!isTrack && nbChapters > 1) {
+            track.setAlbum(convertString(tag->value));
+        }
+        else {
+            track.setTitle(convertString(tag->value));
+        }
     }
     else if(strcasecmp(tag->key, "genre") == 0) {
         track.setGenres({convertString(tag->value)});
@@ -254,6 +259,30 @@ void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
         track.addExtraTag(u"PODCASTCATEGORY"_s, convertString(tag->value));
     }
     else if(strncasecmp(tag->key, "ID3V2_PRIV", 10) == 0) { }
+    else if(strcasecmp(tag->key, "REPLAYGAIN_GAIN")) {
+        char* end;
+        const float gain = strtof(tag->value, &end);
+        if(end > tag->value) {
+            if(isTrack) {
+                track.setRGTrackGain(gain);
+            }
+            else {
+                track.setRGAlbumGain(gain);
+            }
+        }
+    }
+    else if(strcasecmp(tag->key, "REPLAYGAIN_PEAK")) {
+        char* end;
+        const float peak = strtof(tag->value, &end);
+        if(end > tag->value) {
+            if(isTrack) {
+                track.setRGTrackPeak(peak);
+            }
+            else {
+                track.setRGAlbumPeak(peak);
+            }
+        }
+    }
     else {
         track.addExtraTag(convertString(tag->key).toUpper(), convertString(tag->value));
     }
@@ -1070,8 +1099,34 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
     }
 
     AVDictionaryEntry* tag{nullptr};
-    while((tag = av_dict_get(p->m_context->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
-        parseTag(track, tag);
+    if(p->m_context->metadata) {
+        while((tag = av_dict_get(p->m_context->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+            parseTag(track, tag, false, _nb_chapters);
+        }
+        tag = nullptr;
+    }
+    if(p->m_context->nb_programs > 0) {
+        AVProgram* program = p->m_context->programs[0];
+        if(program && program->metadata) {
+            while((tag = av_dict_get(program->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+                parseTag(track, tag, false, _nb_chapters);
+            }
+            tag = nullptr;
+        }
+    }
+    if(avStream->metadata) {
+        while((tag = av_dict_get(avStream->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+            parseTag(track, tag, false, _nb_chapters);
+        }
+        tag = nullptr;
+    }
+    if(_subsong < _nb_chapters) {
+        AVChapter* chapter = p->m_context->chapters[_subsong];
+        if(chapter && chapter->metadata) {
+            while((tag = av_dict_get(chapter->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+                parseTag(track, tag, true, _nb_chapters);
+            }
+        }
     }
 
     return true;

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -562,6 +562,8 @@ bool FFmpegInputPrivate::setup(const AudioSource& source, uint64_t duration, uns
     if(createCodec(m_stream.avStream())) {
         m_audioFormat = Utils::audioFormatFromCodec(m_stream.avStream()->codecpar, m_codec.context()->sample_fmt);
         if(subsong < m_context->nb_chapters) {
+            // Chapters require seeking
+            m_options &= ~AudioDecoder::NoSeeking;
             seek(0);
         }
         return true;
@@ -702,24 +704,27 @@ int FFmpegInputPrivate::receiveAVFrames()
         auto sampleCount             = m_audioFormat.bytesPerFrame() * m_frame.sampleCount();
         const uint64_t startTime     = m_codec.context()->codec_id == AV_CODEC_ID_APE ? m_currentPos : m_frame.ptsMs();
         const uint64_t frameDuration = m_frame.sampleCount() * 1000 / m_audioFormat.sampleRate();
-        if(frameDuration > m_endTimeMs - startTime) {
+        if(frameDuration >= m_endTimeMs - startTime) {
             const auto newSampleCount = (m_endTimeMs - startTime) * m_audioFormat.sampleRate() / 1000;
             sampleCount               = m_audioFormat.bytesPerFrame() * newSampleCount;
             m_eof                     = true;
         }
 
+        // Seeking may land before the chapter start time
+        const uint64_t startTimeClipped = std::max(startTime, m_startTimeMs);
+
         if(m_codec.isPlanar()) {
-            m_buffer = {m_audioFormat, startTime - m_startTimeMs};
+            m_buffer = {m_audioFormat, startTimeClipped - m_startTimeMs};
             m_buffer.resize(static_cast<size_t>(sampleCount));
             interleave(m_frame.avFrame()->data, m_buffer);
         }
         else {
             m_buffer = {m_frame.avFrame()->data[0], static_cast<size_t>(sampleCount), m_audioFormat,
-                        startTime - m_startTimeMs};
+                        startTimeClipped - m_startTimeMs};
         }
 
         if(!(m_options & AudioDecoder::NoSeeking)) {
-            // Handle seeking of APE files
+            // Handle inaccurate seeking, including APE files
             if(m_skipBytes > 0) {
                 const auto len = std::min(sampleCount, m_skipBytes);
                 m_skipBytes -= len;
@@ -789,7 +794,7 @@ void FFmpegInputPrivate::readNext()
         }
     }
 
-    if(m_seekPos > 0 && m_codec.context()->codec_id == AV_CODEC_ID_APE) {
+    if(m_seekPos > 0) {
         const auto packetPts = av_rescale_q_rnd(packet->pts, m_timeBase, TimeBaseMs, AVRounding::AV_ROUND_DOWN);
         m_skipBytes          = m_audioFormat.bytesForDuration(std::abs(m_seekPos - packetPts));
     }

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -427,7 +427,7 @@ public:
     { }
 
     void reset();
-    bool setup(const AudioSource& source);
+    bool setup(const AudioSource& source, uint64_t duration, unsigned int subsong);
     void checkIsVbr(const Track& track);
 
     bool createCodec(AVStream* avStream);
@@ -466,6 +466,8 @@ public:
     int m_bitrate{0};
     int m_skipBytes{0};
     int m_consecutiveDecodeErrors{0};
+    uint64_t m_startTimeMs;
+    uint64_t m_endTimeMs;
 };
 
 void FFmpegInputPrivate::reset()
@@ -496,7 +498,7 @@ void FFmpegInputPrivate::reset()
     m_buffer = {};
 }
 
-bool FFmpegInputPrivate::setup(const AudioSource& source)
+bool FFmpegInputPrivate::setup(const AudioSource& source, uint64_t duration, unsigned int subsong)
 {
     reset();
 
@@ -517,8 +519,22 @@ bool FFmpegInputPrivate::setup(const AudioSource& source)
 
     m_timeBase = m_stream.avStream()->time_base;
 
+    if(subsong < m_context->nb_chapters) {
+        AVChapter* chapter  = m_context->chapters[subsong];
+        AVRational timeBase = chapter->time_base;
+        m_startTimeMs       = av_rescale_q(chapter->start, timeBase, TimeBaseMs);
+        m_endTimeMs         = av_rescale_q(chapter->end, timeBase, TimeBaseMs);
+    }
+    else {
+        m_startTimeMs = 0;
+        m_endTimeMs   = duration;
+    }
+
     if(createCodec(m_stream.avStream())) {
         m_audioFormat = Utils::audioFormatFromCodec(m_stream.avStream()->codecpar, m_codec.context()->sample_fmt);
+        if(subsong < m_context->nb_chapters) {
+            seek(0);
+        }
         return true;
     }
 
@@ -654,16 +670,23 @@ int FFmpegInputPrivate::receiveAVFrames()
     m_lastErrorRecoverable    = false;
 
     if(!m_returnFrame) {
-        const auto sampleCount   = m_audioFormat.bytesPerFrame() * m_frame.sampleCount();
-        const uint64_t startTime = m_codec.context()->codec_id == AV_CODEC_ID_APE ? m_currentPos : m_frame.ptsMs();
+        auto sampleCount             = m_audioFormat.bytesPerFrame() * m_frame.sampleCount();
+        const uint64_t startTime     = m_codec.context()->codec_id == AV_CODEC_ID_APE ? m_currentPos : m_frame.ptsMs();
+        const uint64_t frameDuration = m_frame.sampleCount() * 1000 / m_audioFormat.sampleRate();
+        if(frameDuration > m_endTimeMs - startTime) {
+            const auto newSampleCount = (m_endTimeMs - startTime) * m_audioFormat.sampleRate() / 1000;
+            sampleCount               = m_audioFormat.bytesPerFrame() * newSampleCount;
+            m_eof                     = true;
+        }
 
         if(m_codec.isPlanar()) {
-            m_buffer = {m_audioFormat, startTime};
+            m_buffer = {m_audioFormat, startTime - m_startTimeMs};
             m_buffer.resize(static_cast<size_t>(sampleCount));
             interleave(m_frame.avFrame()->data, m_buffer);
         }
         else {
-            m_buffer = {m_frame.avFrame()->data[0], static_cast<size_t>(sampleCount), m_audioFormat, startTime};
+            m_buffer = {m_frame.avFrame()->data[0], static_cast<size_t>(sampleCount), m_audioFormat,
+                        startTime - m_startTimeMs};
         }
 
         if(!(m_options & AudioDecoder::NoSeeking)) {
@@ -691,6 +714,11 @@ int FFmpegInputPrivate::receiveAVFrames()
 void FFmpegInputPrivate::readNext()
 {
     if(!m_isDecoding) {
+        return;
+    }
+
+    if(m_currentPos >= m_endTimeMs) {
+        m_eof = true;
         return;
     }
 
@@ -754,6 +782,8 @@ void FFmpegInputPrivate::seek(uint64_t pos)
     m_consecutiveDecodeErrors = 0;
     m_lastErrorRecoverable    = false;
 
+    pos += m_startTimeMs;
+
     m_seekPos = static_cast<int64_t>(pos);
 
     constexpr static auto min = std::numeric_limits<int64_t>::min();
@@ -795,7 +825,7 @@ std::optional<AudioFormat> FFmpegDecoder::init(const AudioSource& source, const 
 {
     p->m_options = options;
 
-    if(p->setup(source)) {
+    if(p->setup(source, track.duration(), track.subsong())) {
         p->checkIsVbr(track);
         return p->m_audioFormat;
     }
@@ -947,9 +977,21 @@ bool FFmpegReader::canWriteMetaData() const
     return false;
 }
 
+int FFmpegReader::subsongCount() const
+{
+    return m_subsongCount;
+}
+
 bool FFmpegReader::init(const AudioSource& source)
 {
-    return p->setup(source);
+    if(p->setup(source)) {
+        m_subsongCount = 1;
+        if(p->m_context->nb_chapters > 0) {
+            m_subsongCount = p->m_context->nb_chapters;
+        }
+        return true;
+    }
+    return false;
 }
 
 bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
@@ -995,14 +1037,27 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
     track.setBitDepth(format.bitsPerSample());
     track.setEncoding(isLossless(codecPar->codec_id) ? u"Lossless"_s : u"Lossy"_s);
 
+    int _subsong     = track.subsong();
+    int _nb_chapters = (int)p->m_context->nb_chapters;
+
     if(track.duration() == 0) {
-        AVRational timeBase = avStream->time_base;
-        auto duration       = avStream->duration;
-        if(duration <= 0 || std::cmp_equal(duration, AV_NOPTS_VALUE)) {
-            duration = p->m_context->duration;
-            timeBase = TimeBaseAv;
+        uint64_t durationMs;
+        if(_subsong < _nb_chapters) {
+            AVChapter* chapter         = p->m_context->chapters[_subsong];
+            AVRational timeBase        = chapter->time_base;
+            const uint64_t startTimeMs = av_rescale_q(chapter->start, timeBase, TimeBaseMs);
+            const uint64_t endTimeMs   = av_rescale_q(chapter->end, timeBase, TimeBaseMs);
+            durationMs                 = endTimeMs - startTimeMs;
         }
-        const uint64_t durationMs = av_rescale_q(duration, timeBase, TimeBaseMs);
+        else {
+            AVRational timeBase = avStream->time_base;
+            auto duration       = avStream->duration;
+            if(duration <= 0 || std::cmp_equal(duration, AV_NOPTS_VALUE)) {
+                duration = p->m_context->duration;
+                timeBase = TimeBaseAv;
+            }
+            durationMs = av_rescale_q(duration, timeBase, TimeBaseMs);
+        }
         track.setDuration(durationMs);
     }
 

--- a/src/core/engine/input/ffmpeg/ffmpeginput.h
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.h
@@ -67,6 +67,7 @@ public:
     [[nodiscard]] QStringList extensions() const override;
     [[nodiscard]] bool canReadCover() const override;
     [[nodiscard]] bool canWriteMetaData() const override;
+    [[nodiscard]] int subsongCount() const override;
 
     [[nodiscard]] bool init(const AudioSource& source) override;
     [[nodiscard]] bool readTrack(const AudioSource& source, Track& track) override;
@@ -75,5 +76,6 @@ public:
 
 private:
     std::unique_ptr<FFmpegReaderPrivate> p;
+    int m_subsongCount;
 };
 } // namespace Fooyin


### PR DESCRIPTION
Here is a draft, showing it's possible to read chapters. With some work, one could even use FFmpeg to write tags by altering the tag dictionaries, then transmuxing to a new file, closing, then moving the new file into place.

There are some workarounds added for now, which allow the tag reader to take priority, or else TagLib will prevent the chapters from being seen.

I'm open to any further work this might need, but perhaps you could take a stab at redoing parts of it.