### PR TITLE
Build linux binaries for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,10 +100,6 @@ jobs:
           - { os: ubuntu-latest, arch: amd64 }
           - { os: ubuntu-24.04-arm, arch: arm64 }
         debian_version: ['bookworm', 'trixie', 'forky']
-        # linking of fyplugin_discord.so  fails on bookworm on arm64, exclude it
-        exclude:
-          - runner: { os: ubuntu-24.04-arm, arch: arm64 }
-            debian_version: bookworm
     container:
       image: debian:${{matrix.debian_version}}
     steps:


### PR DESCRIPTION
### About this pull request

This pull request updates the build workflow to build binaries for arm64 for the following Linux distributions:

- debian
- fedora
- ubuntu

The code seems to build and run fine as far as I can see. I would like to see binaries made available upstream to make it easier for people to run it.

( I am aware that the number of people running Desktop Linux on arm64 is probably small, but this is a chicken-and-egg problem 😅 )

### Implementation details

This PR uses the [GitHub provided runners for arm64](https://github.com/actions/partner-runner-images) to build binaries for arm64 for the above Linux distributions on ubuntu 24.04.

To provide code-reuse with the already present build steps I have used a matrix variation like so:

```yaml
  <distribution>:
# Add architecture name to differentiate arm64 and amd64 runs of this action
    name: Name (${{matrix.fedora_version}}, ${{ matrix.runner.arch }})
# Use a variation to make the same build steps run on amd64 and arm64
    runs-on: ${{ matrix.runner.os }}
      matrix:
# Define a variation for the name of the image and a shorthand for the name of the architecture
        runner:
          - { os: ubuntu-latest, arch: amd64 }
          - { os: ubuntu-24.04-arm, arch: arm64 }
[...]
      - name: Upload artifacts
        with:
# Add architecture name to make sure uploaded artifacts have unique names
          name: fedora-${{matrix.fedora_version}}-${{ matrix.runner.arch }}
```

Note, ideally I would have liked to use a runner image name closer to the already present `ubuntu-latest` for consistency but AFAIK no  `ubuntu-latest-arm` runner image is available, therefore I have used `ubuntu-24.04-arm`. As of now this should refer to the same ubuntu version.

### Why exclude builds on Debian bookworm

Builds on arm64 on Debian bookworm fail with error messages like this:

```
 FAILED: run/lib/fooyin/plugins/fyplugin_discord.so 
: && /usr/bin/c++ -fPIC -fcoroutines -O3 -DNDEBUG   -shared  -o run/lib/fooyin/plugins/fyplugin_discord.so src/plugins/discord/CMakeFiles/discord.dir/discord_autogen/mocs_compilation.cpp.o src/plugins/discord/CMakeFiles/discord.dir/discordmessage.cpp.o src/plugins/discord/CMakeFiles/discord.dir/discordipcclient.cpp.o src/plugins/discord/CMakeFiles/discord.dir/discordplugin.cpp.o src/plugins/discord/CMakeFiles/discord.dir/settings/discordpage.cpp.o src/plugins/discord/CMakeFiles/discord.dir/settings/discordsettings.cpp.o  -Wl,-rpath,/__w/fooyin/fooyin/build/run/lib/fooyin:  run/lib/fooyin/libfooyin_gui.so.0.0.0  _deps/qcoro-build/qcoro/network/libQCoro6Network.a  run/lib/fooyin/libfooyin_core.so.0.0.0  /usr/lib/aarch64-linux-gnu/libtag.so  run/lib/fooyin/libfooyin_utils.so.0.0.0  /usr/lib/aarch64-linux-gnu/libQt6Widgets.so.6.4.2  /usr/lib/aarch64-linux-gnu/libQt6Gui.so.6.4.2  /usr/lib/aarch64-linux-gnu/libGLX.so  /usr/lib/aarch64-linux-gnu/libOpenGL.so  /usr/lib/aarch64-linux-gnu/libQt6Sql.so.6.4.2  /usr/lib/aarch64-linux-gnu/libQt6Concurrent.so.6.4.2  /usr/lib/aarch64-linux-gnu/libQt6Network.so.6.4.2  _deps/qcoro-build/qcoro/core/libQCoro6Core.a  /usr/lib/aarch64-linux-gnu/libQt6Core.so.6.4.2 && :
/usr/bin/ld: _deps/qcoro-build/qcoro/network/libQCoro6Network.a(qcorolocalsocket.cpp.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `_ZTVN5QCoro6detail16QCoroLocalSocketE' which may bind externally can not be used when making a shared object; recompile with -fPIC
_deps/qcoro-build/qcoro/network/libQCoro6Network.a(qcorolocalsocket.cpp.o): in function `QCoro::detail::QCoroLocalSocket::QCoroLocalSocket(QLocalSocket*)':
qcorolocalsocket.cpp:(.text+0x848): dangerous relocation: unsupported relocation
```
See https://github.com/michaelmnemonic/fooyin/actions/runs/20621798975/job/59225067199#step:7:645 for the full log.

The error message seems related to PIC compilation on Debian bookworm. As I do not have the technical skills to figure out why this breaks specifically on Debian bookworm and how-to fix it I have excluded this combination.

### How this PR was verified

I installed the produced artifacts on a [Lenovo Thinkpad X31s](https://wiki.postmarketos.org/wiki/Lenovo_ThinkPad_X13s_(lenovo-21bx)) -- a notebook based on a Snapdragon 8cx gen 3 -- running Debian 13 like so:

- create a distrobox with the Linux distribution mentioned in the first chapter
- installed the .deb or rpm respectively
- loaded in my music library of roughly ~5000 tracks
- play back a random .flac file and output via pipewire

All artifacts were able to be installed, executed, loaded the library and could be used to play back a .flac file via pipewire.

In addition I have installed the artifact produced for Debian 13 natively and was able to play back my library for several hours without crashes.

### Thanks

Thanks for this great player, btw. I greatly enjoy using it. 😁