### PR TITLE
Add sort option to Playlist Organizer context menu

### DIFF
--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -179,13 +179,13 @@ PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistInter
     , m_editAutoPlaylistCmd{actionManager->registerAction(m_editAutoPlaylist, Constants::Actions::EditAutoPlaylist,
                                                           m_context->context())}
 
-    , m_sortAllPlaylistsAsc{new QAction(tr("Sort all playlists"), this)}
-    , m_sortAllPlaylistsAscCmd{actionManager->registerAction(
-          m_sortAllPlaylistsAsc, "PlaylistOrganiser.SortAllPlaylistsAsc", m_context->context())}
+    , m_sortAllPlaylists{new QAction(tr("Sort all playlists"), this)}
+    , m_sortAllPlaylistsCmd{actionManager->registerAction(m_sortAllPlaylists, "PlaylistOrganiser.SortAllPlaylists",
+                                                          m_context->context())}
 
-    , m_sortGroupPlaylistsAsc{new QAction(tr("Sort playlists in this group"), this)}
-    , m_sortGroupPlaylistsAscCmd{actionManager->registerAction(
-          m_sortGroupPlaylistsAsc, "PlaylistOrganiser.SortGroupPlaylistsAsc", m_context->context())}
+    , m_sortGroupPlaylists{new QAction(tr("Sort playlists in group"), this)}
+    , m_sortGroupPlaylistsCmd{actionManager->registerAction(
+          m_sortGroupPlaylists, "PlaylistOrganiser.SortGroupPlaylists", m_context->context())}
 {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -222,30 +222,28 @@ PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistInter
     m_newGroupCmd->setAttribute(ProxyAction::UpdateText);
     m_newGroupCmd->setDefaultShortcut(QKeySequence::AddTab);
 
-    m_sortAllPlaylistsAscCmd->setCategories(organiserCategory);
-    m_sortAllPlaylistsAsc->setStatusTip(tr("Sort all playlists"));
-    m_sortGroupPlaylistsAscCmd->setCategories(organiserCategory);
-    m_sortGroupPlaylistsAsc->setStatusTip(tr("Sort all playlists in this group"));
+    m_sortAllPlaylistsCmd->setCategories(organiserCategory);
+    m_sortAllPlaylists->setStatusTip(tr("Sort all playlists alphabetically"));
+    m_sortGroupPlaylistsCmd->setCategories(organiserCategory);
+    m_sortGroupPlaylists->setStatusTip(tr("Sort playlists in the selected group alphabetically"));
+
+    const auto sortAndRestoreState = [this](auto&& sortFn) {
+        const QByteArray state = saveExpandedState(m_organiserTree, m_model);
+        sortFn();
+        restoreExpandedState(m_organiserTree, m_model, state);
+    };
 
     QAction::connect(m_newGroup, &QAction::triggered, this, [this]() {
         const auto indexes = m_organiserTree->selectionModel()->selectedIndexes();
         createGroup(indexes.empty() ? QModelIndex{} : indexes.front());
     });
-    QAction::connect(m_sortAllPlaylistsAsc, &QAction::triggered, this, [this]() {
-        m_model->sortAllPlaylists(PlaylistOrganiserModel::SortOrder::Ascending);
-
-        // Restore State of expanded TreeItems
-        const auto state = m_settings->fileValue(OrganiserState).toByteArray();
-        restoreExpandedState(m_organiserTree, m_model, state);
+    QAction::connect(m_sortAllPlaylists, &QAction::triggered, this, [this, sortAndRestoreState]() {
+        sortAndRestoreState([this]() { m_model->sortAllPlaylists(PlaylistOrganiserModel::SortOrder::Ascending); });
     });
-    QAction::connect(m_sortGroupPlaylistsAsc, &QAction::triggered, this, [this]() {
+    QAction::connect(m_sortGroupPlaylists, &QAction::triggered, this, [this, sortAndRestoreState]() {
         const auto indexes = m_organiserTree->selectionModel()->selectedIndexes();
-
-        m_model->sortGroupPlaylists(indexes, PlaylistOrganiserModel::SortOrder::Ascending);
-
-        // Restore State of expanded TreeItems
-        const auto state = m_settings->fileValue(OrganiserState).toByteArray();
-        restoreExpandedState(m_organiserTree, m_model, state);
+        sortAndRestoreState(
+            [this, indexes]() { m_model->sortGroupPlaylists(indexes, PlaylistOrganiserModel::SortOrder::Ascending); });
     });
     QObject::connect(m_removePlaylist, &QAction::triggered, this,
                      [this]() { m_model->removeItems(m_organiserTree->selectionModel()->selectedIndexes()); });
@@ -376,6 +374,14 @@ void PlaylistOrganiser::contextMenuEvent(QContextMenuEvent* event)
     menu->addAction(m_newAutoPlaylistCmd->action());
     menu->addAction(m_newGroupCmd->action());
 
+    menu->addSeparator();
+
+    menu->addAction(m_sortAllPlaylistsCmd->action());
+    menu->addAction(m_sortGroupPlaylistsCmd->action());
+    m_sortGroupPlaylists->setEnabled(groupCount == 1 && playlistCount == 0); // only enable if a group is selected
+
+    menu->addSeparator();
+
     if(index.data(PlaylistOrganiserItem::ItemType).toInt() == PlaylistOrganiserItem::PlaylistItem) {
         if(auto* savePlaylist = m_actionManager->command(Constants::Actions::SavePlaylist)) {
             menu->addSeparator();
@@ -395,13 +401,6 @@ void PlaylistOrganiser::contextMenuEvent(QContextMenuEvent* event)
 
     menu->addAction(m_renameCmd->action());
     menu->addAction(m_removeCmd->action());
-
-    menu->addSeparator();
-
-    menu->addAction(m_sortAllPlaylistsAscCmd->action());
-
-    menu->addAction(m_sortGroupPlaylistsAscCmd->action());
-    m_sortGroupPlaylistsAsc->setEnabled(groupCount == 1 && playlistCount == 0); // only enable if a group is selected
 
     menu->popup(event->globalPos());
 }

--- a/src/gui/playlist/organiser/playlistorganiser.h
+++ b/src/gui/playlist/organiser/playlistorganiser.h
@@ -85,11 +85,11 @@ private:
     QAction* m_editAutoPlaylist;
     Command* m_editAutoPlaylistCmd;
 
-    QAction* m_sortAllPlaylistsAsc;
-    Command* m_sortAllPlaylistsAscCmd;
+    QAction* m_sortAllPlaylists;
+    Command* m_sortAllPlaylistsCmd;
 
-    QAction* m_sortGroupPlaylistsAsc;
-    Command* m_sortGroupPlaylistsAscCmd;
+    QAction* m_sortGroupPlaylists;
+    Command* m_sortGroupPlaylistsCmd;
 
     UId m_currentPlaylistId;
     bool m_creatingPlaylist{false};

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -24,6 +24,7 @@
 #include <gui/guiconstants.h>
 #include <gui/iconloader.h>
 #include <utils/datastream.h>
+#include <utils/stringcollator.h>
 #include <utils/utils.h>
 
 #include <QApplication>
@@ -338,32 +339,13 @@ void PlaylistOrganiserModel::playlistRemoved(Playlist* playlist)
 
 void PlaylistOrganiserModel::sortAllPlaylists(const SortOrder order)
 {
-    for(auto& m_node : m_nodes) {
-        // find root
-        if(m_node.second.parent()->type() == PlaylistOrganiserItem::Type::Root) {
-            emit layoutAboutToBeChanged();
-
-            // sort children of root
-            m_node.second.parent()->sortChildren(
-                [order](const PlaylistOrganiserItem* first, const PlaylistOrganiserItem* second) {
-                    if(order == Descending) {
-                        return 0 < QString::localeAwareCompare(first->title(), second->title());
-                    }
-
-                    return 0 >= QString::localeAwareCompare(first->title(), second->title());
-                });
-
-            emit layoutChanged();
-
-            // exit
-            break;
-        }
-    }
+    emit layoutAboutToBeChanged();
+    sortPlaylists(rootItem(), order);
+    emit layoutChanged();
 }
 
 void PlaylistOrganiserModel::sortGroupPlaylists(const QModelIndexList& indices, const SortOrder order)
 {
-    // abort unless we only have a single playlist selected
     if(indices.size() != 1) {
         return;
     }
@@ -375,16 +357,62 @@ void PlaylistOrganiserModel::sortGroupPlaylists(const QModelIndexList& indices, 
     }
 
     emit layoutAboutToBeChanged();
+    sortPlaylists(sortGroup, order);
+    emit layoutChanged();
+}
 
-    // TODO: share this function with sortAllPlaylist somehow
-    sortGroup->sortChildren([order](const PlaylistOrganiserItem* first, const PlaylistOrganiserItem* second) {
-        if(order == Descending) {
-            return 0 < QString::localeAwareCompare(first->title(), second->title());
+void PlaylistOrganiserModel::sortPlaylists(PlaylistOrganiserItem* parent, const SortOrder order)
+{
+    if(!parent) {
+        return;
+    }
+
+    auto children = parent->children();
+    if(children.empty()) {
+        return;
+    }
+
+    std::vector<PlaylistOrganiserItem*> playlists;
+    playlists.reserve(children.size());
+
+    for(auto* child : children) {
+        if(!child) {
+            continue;
         }
-        return 0 >= QString::localeAwareCompare(first->title(), second->title());
+
+        if(child->type() == PlaylistOrganiserItem::PlaylistItem) {
+            playlists.emplace_back(child);
+        }
+        else {
+            sortPlaylists(child, order);
+        }
+    }
+
+    if(playlists.size() < 2) {
+        return;
+    }
+
+    StringCollator collator;
+    collator.setCaseSensitivity(Qt::CaseInsensitive);
+
+    std::ranges::sort(playlists, [&collator, order](auto* first, auto* second) {
+        const int compare = collator.compare(first->title(), second->title());
+        return order == Descending ? compare > 0 : compare < 0;
     });
 
-    emit layoutChanged();
+    auto nextPlaylist = playlists.cbegin();
+    for(auto& child : children) {
+        if(child && child->type() == PlaylistOrganiserItem::PlaylistItem) {
+            child = *nextPlaylist;
+            ++nextPlaylist;
+        }
+    }
+
+    parent->clearChildren();
+    for(auto* child : children) {
+        parent->appendChild(child);
+    }
+    parent->resetChildren();
 }
 
 QModelIndex PlaylistOrganiserModel::indexForPlaylist(Playlist* playlist)

--- a/src/gui/playlist/organiser/playlistorganisermodel.h
+++ b/src/gui/playlist/organiser/playlistorganisermodel.h
@@ -87,6 +87,7 @@ signals:
     void tracksDroppedOnGroup(const std::vector<int>& trackIds, const QString& group, int index);
 
 private:
+    void sortPlaylists(PlaylistOrganiserItem* parent, SortOrder order);
     QByteArray saveIndexes(const QModelIndexList& indexes) const;
     QModelIndexList restoreIndexes(QByteArray data);
     void recurseSaveModel(QDataStream& stream, PlaylistOrganiserItem* parent);


### PR DESCRIPTION
I've added a "sort playlists" and "sort playlists in group" options to the Context menu in the Playlist Organiser.

They sort all playlists, or just playlists inside a group alphabetically, ascending.
I later thought how many people would sort them descending, which would be few, and adding more options would just clutter the menu.

I am pretty sure this isn't ideal, and i haven't done anything with C++ in a long time, but it works pretty well for my purpose.