### PR TITLE
Add playback setting to load directory when opening file from file browser

### DIFF
--- a/include/core/coresettings.h
+++ b/include/core/coresettings.h
@@ -87,6 +87,7 @@ enum CoreSettings : uint32_t
     LibraryViewPlaylistSortScript = 38 | Type::String,
     OverwriteRatingOnReload       = 39 | Type::Bool,
     OverwritePlaycountOnReload    = 40 | Type::Bool,
+    OpenFileAddDirectory = 41 | Type::Bool,
 };
 Q_ENUM_NS(CoreSettings)
 } // namespace Settings::Core

--- a/include/core/coresettings.h
+++ b/include/core/coresettings.h
@@ -87,7 +87,7 @@ enum CoreSettings : uint32_t
     LibraryViewPlaylistSortScript = 38 | Type::String,
     OverwriteRatingOnReload       = 39 | Type::Bool,
     OverwritePlaycountOnReload    = 40 | Type::Bool,
-    OpenFileAddDirectory = 41 | Type::Bool,
+    OpenFileAddDirectory          = 41 | Type::Bool,
 };
 Q_ENUM_NS(CoreSettings)
 } // namespace Settings::Core

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -104,6 +104,7 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
     m_settings->createSetting<ClearPlaybackQueueOnExit>(false, u"Playback/ClearPlaybackQueueOnExit"_s);
     m_settings->createSetting<OverwriteRatingOnReload>(false, u"Library/OverwriteRatingOnReload"_s);
     m_settings->createSetting<OverwritePlaycountOnReload>(false, u"Library/OverwritePlaycountOnReload"_s);
+    m_settings->createSetting<OpenFileAddDirectory>(false, u"Playlist/OpenFileAddDirectory"_s);
 
     m_settings->createSetting<Internal::MonitorLibraries>(false, u"Library/MonitorLibraries"_s);
     m_settings->createTempSetting<Internal::MuteVolume>(m_settings->value<OutputVolume>());

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -1331,52 +1331,34 @@ void GuiApplicationPrivate::addFolders()
 
 void GuiApplicationPrivate::openFiles(const QList<QUrl>& urls)
 {
-    const bool addDirectory = m_settings->value<Settings::Core::OpenFileAddDirectory>();
+    QList<QUrl> files{urls};
+    QUrl fileToPlay;
 
-    // If the setting is enabled and we're opening a single file
-    if(addDirectory && urls.size() == 1) {
-        const QUrl& url = urls.first();
-        const QFileInfo fileInfo{url.toLocalFile()};
-        const QString directory = fileInfo.absolutePath();
+    if(m_settings->value<Settings::Core::OpenFileAddDirectory>() && urls.size() == 1 && urls.front().isLocalFile()) {
+        const QFileInfo fileInfo{urls.front().toLocalFile()};
+        if(fileInfo.isFile()) {
+            QStringList supportedExtensions
+                = Utils::extensionsToWildcards(m_core->audioLoader()->supportedFileExtensions());
+            supportedExtensions.append(u"*.cue"_s);
 
-        // Get all supported audio files from the directory
-        const QStringList supportedExtensions
-            = Utils::extensionsToWildcards(m_core->audioLoader()->supportedFileExtensions());
-        const QList<QUrl> allFiles = Utils::File::getUrlsInDir(QDir{directory}, supportedExtensions);
-
-        // Find the index of the opened file in the directory's file list
-        int playIndex = -1;
-        for(int i = 0; i < allFiles.size(); ++i) {
-            if(allFiles.at(i).path() == url.path()) {
-                playIndex = i;
-                break;
+            const QList<QUrl> dirFiles = Utils::File::getUrlsInDir(QDir{fileInfo.absolutePath()}, supportedExtensions);
+            if(!dirFiles.empty()) {
+                files      = dirFiles;
+                fileToPlay = urls.front();
             }
         }
-
-        // Scan the files and create/replace playlist
-        const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
-        m_playlistInteractor.filesToTracks(allFiles, [this, playlistName, playIndex](const TrackList& scannedTracks) {
-            // Replace existing playlist with new tracks
-            if(auto* playlist = m_playlistHandler->createPlaylist(playlistName, scannedTracks)) {
-                if(playIndex >= 0) {
-                    playlist->changeCurrentIndex(playIndex);
-                    m_playlistHandler->startPlayback(playlist);
-                    // Show the currently playing track in the playlist
-                    // Wait for the playlist to be loaded before showing the track
-                    QTimer::singleShot(500, m_self, [this]() { m_playlistController->showNowPlaying(); });
-                }
-            }
-        });
     }
-    // Default behavior
+
+    const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
+    const bool replacePlaylist = m_settings->value<Settings::Core::OpenFilesSendTo>();
+    if(!fileToPlay.isEmpty()) {
+        m_playlistInteractor.filesToNewPlaylist(playlistName, files, fileToPlay, replacePlaylist, true);
+    }
+    else if(replacePlaylist) {
+        m_playlistInteractor.filesToNewPlaylistReplace(playlistName, files, true);
+    }
     else {
-        const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
-        if(m_settings->value<Settings::Core::OpenFilesSendTo>()) {
-            m_playlistInteractor.filesToNewPlaylistReplace(playlistName, urls, true);
-        }
-        else {
-            m_playlistInteractor.filesToNewPlaylist(playlistName, urls, true);
-        }
+        m_playlistInteractor.filesToNewPlaylist(playlistName, files, true);
     }
 }
 

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -89,6 +89,7 @@
 #include <utils/settings/advancedsettingsregistry.h>
 #include <utils/settings/settingsdialogcontroller.h>
 #include <utils/settings/settingsmanager.h>
+#include <utils/fileutils.h>
 #include <utils/utils.h>
 
 #include <QAction>
@@ -1330,12 +1331,54 @@ void GuiApplicationPrivate::addFolders()
 
 void GuiApplicationPrivate::openFiles(const QList<QUrl>& urls)
 {
-    const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
-    if(m_settings->value<Settings::Core::OpenFilesSendTo>()) {
-        m_playlistInteractor.filesToNewPlaylistReplace(playlistName, urls, true);
+    const bool addDirectory = m_settings->value<Settings::Core::OpenFileAddDirectory>();
+    
+    // If the setting is enabled and we're opening a single file
+    if(addDirectory && urls.size() == 1) {
+        const QUrl& url = urls.first();
+        const QFileInfo fileInfo{url.toLocalFile()};
+        const QString directory = fileInfo.absolutePath();
+        
+        // Get all supported audio files from the directory
+        const QStringList supportedExtensions
+            = Utils::extensionsToWildcards(m_core->audioLoader()->supportedFileExtensions());
+        const QList<QUrl> allFiles = Utils::File::getUrlsInDir(QDir{directory}, supportedExtensions);
+        
+        // Find the index of the opened file in the directory's file list
+        int playIndex = -1;
+        for(int i = 0; i < allFiles.size(); ++i) {
+            if(allFiles.at(i).path() == url.path()) {
+                playIndex = i;
+                break;
+            }
+        }
+        
+        // Scan the files and create/replace playlist
+        const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
+        m_playlistInteractor.filesToTracks(allFiles, [this, playlistName, playIndex](const TrackList& scannedTracks) {
+            // Replace existing playlist with new tracks
+            if(auto* playlist = m_playlistHandler->createPlaylist(playlistName, scannedTracks)) {
+                if(playIndex >= 0) {
+                    playlist->changeCurrentIndex(playIndex);
+                    m_playlistHandler->startPlayback(playlist);
+                    // Show the currently playing track in the playlist
+                    // Wait for the playlist to be loaded before showing the track
+                    QTimer::singleShot(500, m_self, [this]() {
+                        m_playlistController->showNowPlaying();
+                    });
+                }
+            }
+        });
     }
+    // Default behavior
     else {
-        m_playlistInteractor.filesToNewPlaylist(playlistName, urls, true);
+        const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
+        if(m_settings->value<Settings::Core::OpenFilesSendTo>()) {
+            m_playlistInteractor.filesToNewPlaylistReplace(playlistName, urls, true);
+        }
+        else {
+            m_playlistInteractor.filesToNewPlaylist(playlistName, urls, true);
+        }
     }
 }
 

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -85,11 +85,11 @@
 #include <utils/actions/actionmanager.h>
 #include <utils/actions/command.h>
 #include <utils/audioutils.h>
+#include <utils/fileutils.h>
 #include <utils/logging/logwidget.h>
 #include <utils/settings/advancedsettingsregistry.h>
 #include <utils/settings/settingsdialogcontroller.h>
 #include <utils/settings/settingsmanager.h>
-#include <utils/fileutils.h>
 #include <utils/utils.h>
 
 #include <QAction>
@@ -1332,18 +1332,18 @@ void GuiApplicationPrivate::addFolders()
 void GuiApplicationPrivate::openFiles(const QList<QUrl>& urls)
 {
     const bool addDirectory = m_settings->value<Settings::Core::OpenFileAddDirectory>();
-    
+
     // If the setting is enabled and we're opening a single file
     if(addDirectory && urls.size() == 1) {
         const QUrl& url = urls.first();
         const QFileInfo fileInfo{url.toLocalFile()};
         const QString directory = fileInfo.absolutePath();
-        
+
         // Get all supported audio files from the directory
         const QStringList supportedExtensions
             = Utils::extensionsToWildcards(m_core->audioLoader()->supportedFileExtensions());
         const QList<QUrl> allFiles = Utils::File::getUrlsInDir(QDir{directory}, supportedExtensions);
-        
+
         // Find the index of the opened file in the directory's file list
         int playIndex = -1;
         for(int i = 0; i < allFiles.size(); ++i) {
@@ -1352,7 +1352,7 @@ void GuiApplicationPrivate::openFiles(const QList<QUrl>& urls)
                 break;
             }
         }
-        
+
         // Scan the files and create/replace playlist
         const QString playlistName = m_settings->value<Settings::Core::OpenFilesPlaylist>();
         m_playlistInteractor.filesToTracks(allFiles, [this, playlistName, playIndex](const TrackList& scannedTracks) {
@@ -1363,9 +1363,7 @@ void GuiApplicationPrivate::openFiles(const QList<QUrl>& urls)
                     m_playlistHandler->startPlayback(playlist);
                     // Show the currently playing track in the playlist
                     // Wait for the playlist to be loaded before showing the track
-                    QTimer::singleShot(500, m_self, [this]() {
-                        m_playlistController->showNowPlaying();
-                    });
+                    QTimer::singleShot(500, m_self, [this]() { m_playlistController->showNowPlaying(); });
                 }
             }
         });

--- a/src/gui/playlist/playlistinteractor.cpp
+++ b/src/gui/playlist/playlistinteractor.cpp
@@ -41,6 +41,24 @@ using namespace Qt::StringLiterals;
 
 namespace Fooyin {
 namespace {
+int indexOfFile(const TrackList& tracks, const QUrl& file)
+{
+    const QString filepath = file.toLocalFile();
+    if(filepath.isEmpty()) {
+        return -1;
+    }
+
+    for(int index{0}; const auto& track : tracks) {
+        if(Utils::File::isSamePath(track.filepath(), filepath)
+           || (track.hasCue() && Utils::File::isSamePath(track.cuePath(), filepath))) {
+            return index;
+        }
+        ++index;
+    }
+
+    return -1;
+}
+
 class TrackScanController : public QObject
 {
     Q_OBJECT
@@ -269,6 +287,18 @@ void PlaylistInteractor::filesToNewPlaylist(const QString& playlistName, const Q
     });
 }
 
+void PlaylistInteractor::filesToNewPlaylist(const QString& playlistName, const QList<QUrl>& urls,
+                                            const QUrl& fileToPlay, bool replace, bool play)
+{
+    if(urls.empty()) {
+        return;
+    }
+
+    scanFiles(urls, [this, playlistName, fileToPlay, replace, play](const TrackList& scannedTracks) {
+        tracksToNewPlaylist(playlistName, scannedTracks, indexOfFile(scannedTracks, fileToPlay), replace, play);
+    });
+}
+
 void PlaylistInteractor::filesToNewPlaylistReplace(const QString& playlistName, const QList<QUrl>& urls, bool play)
 {
     if(urls.empty()) {
@@ -363,6 +393,30 @@ void PlaylistInteractor::tracksToNewPlaylistReplace(const QString& playlistName,
     }
 
     activatePlaylist(m_handler->createPlaylist(playlistName, tracks), play);
+}
+
+void PlaylistInteractor::tracksToNewPlaylist(const QString& playlistName, const TrackList& tracks, int indexToPlay,
+                                             bool replace, bool play)
+{
+    if(tracks.empty()) {
+        return;
+    }
+
+    indexToPlay = std::max(indexToPlay, 0);
+
+    if(replace) {
+        activatePlaylist(m_handler->createPlaylist(playlistName, tracks), indexToPlay, play);
+        return;
+    }
+
+    if(auto* playlist = m_handler->playlistByName(playlistName)) {
+        const int firstAddedIndex = playlist->trackCount();
+        appendToPlaylist(playlist, tracks);
+        activatePlaylist(playlist, firstAddedIndex + indexToPlay, play);
+        return;
+    }
+
+    activatePlaylist(m_handler->createPlaylist(playlistName, tracks), indexToPlay, play);
 }
 
 void PlaylistInteractor::tracksToActivePlaylist(const TrackList& tracks)

--- a/src/gui/playlist/playlistinteractor.h
+++ b/src/gui/playlist/playlistinteractor.h
@@ -53,6 +53,8 @@ public:
     void filesToCurrentPlaylist(const QList<QUrl>& urls);
     void filesToCurrentPlaylistReplace(const QList<QUrl>& urls, bool play = false);
     void filesToNewPlaylist(const QString& playlistName, const QList<QUrl>& urls, bool play = false);
+    void filesToNewPlaylist(const QString& playlistName, const QList<QUrl>& urls, const QUrl& fileToPlay, bool replace,
+                            bool play = false);
     void filesToNewPlaylistReplace(const QString& playlistName, const QList<QUrl>& urls, bool play = false);
     void filesToActivePlaylist(const QList<QUrl>& urls);
     void loadPlaylist(const QList<QPair<QString, QUrl>>& playlistData, bool play = false);
@@ -95,6 +97,8 @@ private:
     void activatePlaylist(Playlist* playlist, int indexToPlay, bool play = false) const;
     void appendToPlaylist(Playlist* playlist, const TrackList& tracks) const;
     [[nodiscard]] Playlist* appendOrCreateNamedPlaylist(const QString& playlistName, const TrackList& tracks) const;
+    void tracksToNewPlaylist(const QString& playlistName, const TrackList& tracks, int indexToPlay, bool replace,
+                             bool play = false);
 
     template <typename Func>
     void scanFiles(const QList<QUrl>& urls, Func&& func)

--- a/src/gui/settings/playback/playbackpage.cpp
+++ b/src/gui/settings/playback/playbackpage.cpp
@@ -71,8 +71,6 @@ private:
     QCheckBox* m_skipUnavailable;
     QCheckBox* m_stopIfActiveDeleted;
 
-    QCheckBox* m_openFileAddDirectory;
-
     QSpinBox* m_seekStep;
     QSpinBox* m_seekStepLarge;
     QDoubleSpinBox* m_volumeStep;
@@ -96,9 +94,6 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     , m_rewindPrevious{new QCheckBox(tr("Rewind track on previous"), this)}
     , m_skipUnavailable{new QCheckBox(tr("Skip unavailable tracks"), this)}
     , m_stopIfActiveDeleted{new QCheckBox(tr("Stop playback if the active playlist is deleted"), this)}
-    , m_openFileAddDirectory{new QCheckBox(
-          tr("When opening a file, load all files from its directory into a playlist and play the selected file"),
-          this)}
     , m_seekStep{new QSpinBox(this)}
     , m_seekStepLarge{new QSpinBox(this)}
     , m_volumeStep{new QDoubleSpinBox(this)}
@@ -146,8 +141,6 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_skipUnavailable, row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_stopIfActiveDeleted, row++, 0, 1, 2);
-    generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
-    generalGroupLayout->addWidget(m_openFileAddDirectory, row++, 0, 1, 2);
     generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_playedSlider, row++, 0, 1, 2);
     generalGroupLayout->setColumnStretch(1, 1);
@@ -218,7 +211,6 @@ void PlaybackPageWidget::load()
     m_skipUnavailable->setChecked(
         m_settings->fileValue(Settings::Core::Internal::PlaylistSkipUnavailable, false).toBool());
     m_stopIfActiveDeleted->setChecked(m_settings->value<Settings::Core::StopIfActivePlaylistDeleted>());
-    m_openFileAddDirectory->setChecked(m_settings->value<Settings::Core::OpenFileAddDirectory>());
 
     m_seekStep->setValue(m_settings->value<Settings::Gui::SeekStepSmall>());
     m_seekStepLarge->setValue(m_settings->value<Settings::Gui::SeekStepLarge>());
@@ -246,7 +238,6 @@ void PlaybackPageWidget::apply()
     m_settings->set<Settings::Core::RewindPreviousTrack>(m_rewindPrevious->isChecked());
     m_settings->fileSet(Settings::Core::Internal::PlaylistSkipUnavailable, m_skipUnavailable->isChecked());
     m_settings->set<Settings::Core::StopIfActivePlaylistDeleted>(m_stopIfActiveDeleted->isChecked());
-    m_settings->set<Settings::Core::OpenFileAddDirectory>(m_openFileAddDirectory->isChecked());
 
     m_settings->set<Settings::Gui::SeekStepSmall>(m_seekStep->value());
     m_settings->set<Settings::Gui::SeekStepLarge>(m_seekStepLarge->value());
@@ -274,7 +265,6 @@ void PlaybackPageWidget::reset()
     m_settings->reset<Settings::Core::RewindPreviousTrack>();
     m_settings->fileRemove(Settings::Core::Internal::PlaylistSkipUnavailable);
     m_settings->reset<Settings::Core::StopIfActivePlaylistDeleted>();
-    m_settings->reset<Settings::Core::OpenFileAddDirectory>();
     m_settings->reset<Settings::Gui::SeekStepSmall>();
     m_settings->reset<Settings::Gui::SeekStepLarge>();
     m_settings->reset<Settings::Gui::VolumeStep>();

--- a/src/gui/settings/playback/playbackpage.cpp
+++ b/src/gui/settings/playback/playbackpage.cpp
@@ -71,6 +71,8 @@ private:
     QCheckBox* m_skipUnavailable;
     QCheckBox* m_stopIfActiveDeleted;
 
+    QCheckBox* m_openFileAddDirectory;
+
     QSpinBox* m_seekStep;
     QSpinBox* m_seekStepLarge;
     QDoubleSpinBox* m_volumeStep;
@@ -94,6 +96,7 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     , m_rewindPrevious{new QCheckBox(tr("Rewind track on previous"), this)}
     , m_skipUnavailable{new QCheckBox(tr("Skip unavailable tracks"), this)}
     , m_stopIfActiveDeleted{new QCheckBox(tr("Stop playback if the active playlist is deleted"), this)}
+    , m_openFileAddDirectory{new QCheckBox(tr("When opening a file, load all files from its directory into a playlist and play the selected file"), this)}
     , m_seekStep{new QSpinBox(this)}
     , m_seekStepLarge{new QSpinBox(this)}
     , m_volumeStep{new QDoubleSpinBox(this)}
@@ -141,6 +144,8 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_skipUnavailable, row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_stopIfActiveDeleted, row++, 0, 1, 2);
+    generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
+    generalGroupLayout->addWidget(m_openFileAddDirectory, row++, 0, 1, 2);
     generalGroupLayout->addWidget(new Spacer(this), row++, 0, 1, 2);
     generalGroupLayout->addWidget(m_playedSlider, row++, 0, 1, 2);
     generalGroupLayout->setColumnStretch(1, 1);
@@ -211,6 +216,7 @@ void PlaybackPageWidget::load()
     m_skipUnavailable->setChecked(
         m_settings->fileValue(Settings::Core::Internal::PlaylistSkipUnavailable, false).toBool());
     m_stopIfActiveDeleted->setChecked(m_settings->value<Settings::Core::StopIfActivePlaylistDeleted>());
+    m_openFileAddDirectory->setChecked(m_settings->value<Settings::Core::OpenFileAddDirectory>());
 
     m_seekStep->setValue(m_settings->value<Settings::Gui::SeekStepSmall>());
     m_seekStepLarge->setValue(m_settings->value<Settings::Gui::SeekStepLarge>());
@@ -238,6 +244,7 @@ void PlaybackPageWidget::apply()
     m_settings->set<Settings::Core::RewindPreviousTrack>(m_rewindPrevious->isChecked());
     m_settings->fileSet(Settings::Core::Internal::PlaylistSkipUnavailable, m_skipUnavailable->isChecked());
     m_settings->set<Settings::Core::StopIfActivePlaylistDeleted>(m_stopIfActiveDeleted->isChecked());
+    m_settings->set<Settings::Core::OpenFileAddDirectory>(m_openFileAddDirectory->isChecked());
 
     m_settings->set<Settings::Gui::SeekStepSmall>(m_seekStep->value());
     m_settings->set<Settings::Gui::SeekStepLarge>(m_seekStepLarge->value());
@@ -265,6 +272,7 @@ void PlaybackPageWidget::reset()
     m_settings->reset<Settings::Core::RewindPreviousTrack>();
     m_settings->fileRemove(Settings::Core::Internal::PlaylistSkipUnavailable);
     m_settings->reset<Settings::Core::StopIfActivePlaylistDeleted>();
+    m_settings->reset<Settings::Core::OpenFileAddDirectory>();
     m_settings->reset<Settings::Gui::SeekStepSmall>();
     m_settings->reset<Settings::Gui::SeekStepLarge>();
     m_settings->reset<Settings::Gui::VolumeStep>();

--- a/src/gui/settings/playback/playbackpage.cpp
+++ b/src/gui/settings/playback/playbackpage.cpp
@@ -96,7 +96,9 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     , m_rewindPrevious{new QCheckBox(tr("Rewind track on previous"), this)}
     , m_skipUnavailable{new QCheckBox(tr("Skip unavailable tracks"), this)}
     , m_stopIfActiveDeleted{new QCheckBox(tr("Stop playback if the active playlist is deleted"), this)}
-    , m_openFileAddDirectory{new QCheckBox(tr("When opening a file, load all files from its directory into a playlist and play the selected file"), this)}
+    , m_openFileAddDirectory{new QCheckBox(
+          tr("When opening a file, load all files from its directory into a playlist and play the selected file"),
+          this)}
     , m_seekStep{new QSpinBox(this)}
     , m_seekStepLarge{new QSpinBox(this)}
     , m_volumeStep{new QDoubleSpinBox(this)}

--- a/src/gui/settings/shellintegrationpage.cpp
+++ b/src/gui/settings/shellintegrationpage.cpp
@@ -52,6 +52,7 @@ private:
     QLineEdit* m_excludeTypes;
     ScriptLineEdit* m_externalSortScript;
     QCheckBox* m_alwaysSend;
+    QCheckBox* m_openFileAddDirectory;
     QLineEdit* m_externalPlaylist;
 };
 
@@ -61,6 +62,7 @@ ShellIntegrationPageWidget::ShellIntegrationPageWidget(SettingsManager* settings
     , m_excludeTypes{new QLineEdit(this)}
     , m_externalSortScript{new ScriptLineEdit(this)}
     , m_alwaysSend{new QCheckBox(tr("Always replace playlist"), this)}
+    , m_openFileAddDirectory{new QCheckBox(tr("Load files from the same folder when opening one file"), this)}
     , m_externalPlaylist{new QLineEdit(this)}
 {
     auto* fileTypesGroup  = new QGroupBox(tr("File Types"), this);
@@ -80,9 +82,13 @@ ShellIntegrationPageWidget::ShellIntegrationPageWidget(SettingsManager* settings
 
     m_externalPlaylist->setToolTip(
         tr("When opening files, always replace the playlist contents with the incoming tracks"));
+    m_openFileAddDirectory->setToolTip(
+        tr("When opening one file from the file manager, add all supported files from the same folder and play the "
+           "opened file"));
 
     row = 0;
     playlistGroupLayout->addWidget(m_alwaysSend, row++, 0, 1, 2);
+    playlistGroupLayout->addWidget(m_openFileAddDirectory, row++, 0, 1, 2);
     playlistGroupLayout->addWidget(new QLabel(tr("Playlist name") + ":"_L1, this), row, 0);
     playlistGroupLayout->addWidget(m_externalPlaylist, row++, 1);
     playlistGroupLayout->addWidget(new QLabel(tr("Sort incoming tracks by") + ":"_L1, this), row, 0);
@@ -109,6 +115,7 @@ void ShellIntegrationPageWidget::load()
     m_excludeTypes->setText(excludeExtensions.join(u';'));
 
     m_alwaysSend->setChecked(m_settings->value<Settings::Core::OpenFilesSendTo>());
+    m_openFileAddDirectory->setChecked(m_settings->value<Settings::Core::OpenFileAddDirectory>());
     m_externalPlaylist->setText(m_settings->value<Settings::Core::OpenFilesPlaylist>());
     m_externalSortScript->setText(m_settings->value<Settings::Core::ExternalSortScript>());
 }
@@ -121,6 +128,7 @@ void ShellIntegrationPageWidget::apply()
                         m_excludeTypes->text().split(u';', Qt::SkipEmptyParts));
 
     m_settings->set<Settings::Core::OpenFilesSendTo>(m_alwaysSend->isChecked());
+    m_settings->set<Settings::Core::OpenFileAddDirectory>(m_openFileAddDirectory->isChecked());
     m_settings->set<Settings::Core::OpenFilesPlaylist>(m_externalPlaylist->text());
     m_settings->set<Settings::Core::ExternalSortScript>(m_externalSortScript->text());
 }
@@ -131,6 +139,7 @@ void ShellIntegrationPageWidget::reset()
     m_settings->fileRemove(Settings::Core::Internal::ExternalExcludeTypes);
 
     m_settings->reset<Settings::Core::OpenFilesSendTo>();
+    m_settings->reset<Settings::Core::OpenFileAddDirectory>();
     m_settings->reset<Settings::Core::OpenFilesPlaylist>();
     m_settings->reset<Settings::Core::ExternalSortScript>();
 }


### PR DESCRIPTION
Adds a new playback setting 'When opening file via file browser open dir to playlist and play opened file' which:

1. When opening a single music file from the file browser
2. Loads all files from the same directory into a playlist
3. Plays the selected file
4. Ensures the playlist scrolls to the playing track

I like this behavior from the old Windows player "Billy MP3"