### PR TITLE
Add optional SoundTouch DSP plugin (tempo/pitch/rate)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -28,6 +28,7 @@ The following libraries are optional:
 * [Game Music Emu](https://github.com/libgme/game-music-emu) - for the GME audio input plugin
 * [libarchive](https://www.libarchive.org) - for the archive support plugin
 * [libebur128](https://github.com/jiixyj/libebur128) - for the ReplayGain scanner plugin
+* [SoundTouch](https://www.surina.net/soundtouch/) - for the SoundTouch DSP plugin
 
 Platform-specific requirements are listed below.
 
@@ -40,7 +41,7 @@ sudo apt install \
     libasound2-dev libtag1-dev libicu-dev libpipewire-0.3-dev \
     qt6-base-dev libqt6svg6-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
     libavcodec-dev libavformat-dev libavutil-dev libavdevice-dev libswresample-dev \
-    libsndfile1-dev libopenmpt-dev libgme-dev libarchive-dev libebur128-dev
+    libsndfile1-dev libopenmpt-dev libgme-dev libarchive-dev libebur128-dev libsoundtouch-dev
 ```
 
 ### Arch Linux
@@ -50,7 +51,7 @@ sudo pacman -Syu
 sudo pacman -S --needed \
     gcc git cmake pkgconf ninja alsa-lib pipewire icu ffmpeg \
     qt6-base qt6-svg qt6-imageformats qt6-tools kdsingleapplication \
-    taglib libsndfile libopenmpt libgme libarchive libebur128
+    taglib libsndfile libopenmpt libgme libarchive libebur128 soundtouch
 ```
 
 ### Fedora
@@ -62,7 +63,7 @@ sudo dnf install \
     alsa-lib-devel qt6-qtbase-devel qt6-qtsvg-devel qt6-qttools-devel \
     libavcodec-free-devel libavformat-free-devel libavutil-free-devel libswresample-free-devel \
     taglib-devel kdsingleapplication-qt6-devel libicu-devel pipewire-devel \
-    libsndfile-devel libopenmpt-devel game-music-emu-devel libarchive-devel libebur128-devel
+    libsndfile-devel libopenmpt-devel game-music-emu-devel libarchive-devel libebur128-devel soundtouch-devel
 ```
 
 ## Building

--- a/ci/archlinux-depends.sh
+++ b/ci/archlinux-depends.sh
@@ -24,4 +24,5 @@ $SUDO pacman -S --noconfirm --needed \
        libarchive \
        libsndfile \
        libebur128 \
+       soundtouch \
        gtest

--- a/ci/fedora-depends.sh
+++ b/ci/fedora-depends.sh
@@ -33,4 +33,5 @@ dnf -y install --skip-broken \
      libarchive-devel \
      libsndfile-devel \
      libebur128-devel \
+     soundtouch-devel \
      gtest-devel

--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -20,4 +20,5 @@ sudo pkg install -y \
      libopenmpt \
      libarchive \
      ebur128 \
+     soundtouch \
      googletest

--- a/ci/ubuntu-depends.sh
+++ b/ci/ubuntu-depends.sh
@@ -37,6 +37,7 @@ $SUDO apt-get install -y \
         libarchive-dev \
         libsndfile1-dev \
         libebur128-dev \
+        libsoundtouch-dev \
         libgtest-dev
 
 CODENAME=$(lsb_release -sc)

--- a/cmake/FooyinPackaging.cmake
+++ b/cmake/FooyinPackaging.cmake
@@ -61,7 +61,8 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS
         libopenmpt0,
         libarchive13,
         libsndfile1,
-        libebur128-1"
+        libebur128-1,
+        libsoundtouch1"
 )
 
 set(CPACK_RPM_PACKAGE_LICENSE "GPLv3")

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -1,0 +1,54 @@
+# Try to find SoundTouch
+# Once done this will define
+#
+# SoundTouch_FOUND - system has SoundTouch
+# SoundTouch::SoundTouch - the SoundTouch library
+
+find_package(PkgConfig QUIET)
+if (PkgConfig_FOUND)
+    pkg_check_modules(PC_SoundTouch QUIET soundtouch)
+endif ()
+
+find_path(
+        SoundTouch_INCLUDE_DIR
+        NAMES SoundTouch.h
+        HINTS ${PC_SoundTouch_INCLUDE_DIRS}
+        PATH_SUFFIXES soundtouch
+        DOC "SoundTouch include directory"
+)
+mark_as_advanced(SoundTouch_INCLUDE_DIR)
+
+find_library(
+        SoundTouch_LIBRARY
+        NAMES SoundTouch soundtouch
+        HINTS ${PC_SoundTouch_LIBRARY_DIRS}
+        DOC "SoundTouch library"
+)
+mark_as_advanced(SoundTouch_LIBRARY)
+
+if (DEFINED PC_SoundTouch_VERSION AND NOT PC_SoundTouch_VERSION STREQUAL "")
+    set(SoundTouch_VERSION "${PC_SoundTouch_VERSION}")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+        SoundTouch
+        REQUIRED_VARS SoundTouch_LIBRARY SoundTouch_INCLUDE_DIR
+        VERSION_VAR SoundTouch_VERSION
+)
+
+if (SoundTouch_FOUND)
+    set(SoundTouch_LIBRARIES "${SoundTouch_LIBRARY}")
+    set(SoundTouch_INCLUDE_DIRS "${SoundTouch_INCLUDE_DIR}")
+    set(SoundTouch_DEFINITIONS ${PC_SoundTouch_CFLAGS_OTHER})
+
+    if (NOT TARGET SoundTouch::SoundTouch)
+        add_library(SoundTouch::SoundTouch UNKNOWN IMPORTED)
+        set_target_properties(
+                SoundTouch::SoundTouch
+                PROPERTIES IMPORTED_LOCATION "${SoundTouch_LIBRARY}"
+                INTERFACE_COMPILE_OPTIONS "${PC_SoundTouch_CFLAGS_OTHER}"
+                INTERFACE_INCLUDE_DIRECTORIES "${SoundTouch_INCLUDE_DIR}"
+        )
+    endif ()
+endif ()

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(sdl)
 add_subdirectory(scrobbler)
 add_subdirectory(sndfile)
 add_subdirectory(tageditor)
+add_subdirectory(soundtouch)
 add_subdirectory(vumeter)
 add_subdirectory(wavebar)
 

--- a/src/plugins/soundtouch/CMakeLists.txt
+++ b/src/plugins/soundtouch/CMakeLists.txt
@@ -1,0 +1,19 @@
+find_package(SoundTouch QUIET)
+
+if (NOT SoundTouch_FOUND)
+    message(STATUS "SoundTouch not found; skipping soundtouch plugin.")
+    return()
+endif ()
+
+create_fooyin_plugin_internal(
+        soundtouch
+        DEPENDS Fooyin::Core
+                Fooyin::Gui
+                SoundTouch::SoundTouch
+        SOURCES soundtouchdsp.cpp
+                soundtouchdsp.h
+                soundtouchplugin.cpp
+                soundtouchplugin.h
+                soundtouchsettingswidget.cpp
+                soundtouchsettingswidget.h
+)

--- a/src/plugins/soundtouch/soundtouch.json.in
+++ b/src/plugins/soundtouch/soundtouch.json.in
@@ -1,0 +1,15 @@
+{
+    "Name" : "SoundTouch",
+    "Version" : "${FOOYIN_VERSION}",
+    "Author" : "fooyin",
+    "Copyright" : "Copyright © 2026, Luke Taylor <luket@pm.me>",
+    "License" : [ "Fooyin is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
+                  "",
+                  "Fooyin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.",
+                  "",
+                  "You should have received a copy of the GNU General Public License along with Fooyin.  If not, see <http://www.gnu.org/licenses/>"
+                ],
+    "Category" : "Audio.DSP",
+    "Description" : "Adds SoundTouch-based tempo, pitch, and rate DSP nodes",
+    "Url" : "https://github.com/fooyin/fooyin"
+}

--- a/src/plugins/soundtouch/soundtouchdsp.cpp
+++ b/src/plugins/soundtouch/soundtouchdsp.cpp
@@ -1,0 +1,521 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "soundtouchdsp.h"
+
+#include <SoundTouch.h>
+#include <utils/timeconstants.h>
+
+#include <QDataStream>
+#include <QIODevice>
+
+#include <algorithm>
+#include <cmath>
+
+constexpr auto PresetVersion = 1;
+constexpr auto TempoMin      = 0.25;
+constexpr auto TempoMax      = 4.0;
+constexpr auto PitchMin      = -24.0;
+constexpr auto PitchMax      = 24.0;
+constexpr auto RateMin       = 0.25;
+constexpr auto RateMax       = 4.0;
+constexpr auto MinRateScale  = 0.01;
+
+namespace Fooyin {
+SoundTouchDsp::SoundTouchDsp(const Parameter parameter)
+    : m_parameter{parameter}
+    , m_hasOutputCursor{false}
+    , m_outputCursorNs{0}
+    , m_outputCursorFracNs{0.0}
+    , m_inputSourceFrameNs{0.0}
+    , m_tempo{1.0}
+    , m_pitchSemitones{0.0}
+    , m_rate{1.0}
+{ }
+
+SoundTouchDsp::~SoundTouchDsp() = default;
+
+QString SoundTouchDsp::name() const
+{
+    QString baseName        = nameForParameter(m_parameter);
+    const double value      = parameterValue();
+    const double defaultVal = parameterDefaultValue();
+
+    if(std::abs(value - defaultVal) < 0.0001) {
+        return baseName;
+    }
+
+    switch(m_parameter) {
+        case Parameter::Tempo:
+        case Parameter::Rate:
+            return QStringLiteral("%1 (%2%)").arg(baseName, QString::number(value * 100.0, 'f', 1));
+        case Parameter::Pitch:
+            return QStringLiteral("%1 (%2 st)").arg(baseName, QString::number(value, 'f', 2));
+    }
+
+    return baseName;
+}
+
+QString SoundTouchDsp::id() const
+{
+    return idForParameter(m_parameter);
+}
+
+bool SoundTouchDsp::supportsLiveSettings() const
+{
+    return true;
+}
+
+AudioFormat SoundTouchDsp::outputFormat(const AudioFormat& input) const
+{
+    return input;
+}
+
+void SoundTouchDsp::prepare(const AudioFormat& format)
+{
+    m_format = format;
+    recreateProcessor(m_format);
+}
+
+void SoundTouchDsp::process(ProcessingBufferList& chunks)
+{
+    ProcessingBufferList output;
+    output.clear();
+
+    if(!m_processor || !m_format.isValid()) {
+        chunks.clear();
+        return;
+    }
+
+    const size_t count = chunks.count();
+    for(size_t i{0}; i < count; ++i) {
+        const auto* buffer = chunks.item(i);
+
+        if(!buffer || !buffer->isValid() || buffer->frameCount() <= 0) {
+            continue;
+        }
+
+        processBuffer(*buffer, output);
+    }
+
+    chunks.clear();
+
+    const size_t outCount = output.count();
+    for(size_t i{0}; i < outCount; ++i) {
+        const auto* buffer = output.item(i);
+        if(buffer && buffer->isValid()) {
+            chunks.addChunk(*buffer);
+        }
+    }
+}
+
+void SoundTouchDsp::reset()
+{
+    if(m_processor) {
+        m_processor->clear();
+    }
+
+    m_hasOutputCursor    = false;
+    m_outputCursorNs     = 0;
+    m_outputCursorFracNs = 0.0;
+    m_inputSourceFrameNs = 0.0;
+}
+
+void SoundTouchDsp::flush(ProcessingBufferList& chunks, FlushMode mode)
+{
+    if(!m_processor) {
+        return;
+    }
+
+    if(mode == FlushMode::Flush) {
+        reset();
+        return;
+    }
+
+    if(!m_hasOutputCursor) {
+        m_outputCursorNs     = 0;
+        m_hasOutputCursor    = true;
+        m_outputCursorFracNs = 0.0;
+    }
+
+    m_processor->flush();
+    drainProcessor(chunks);
+    m_processor->clear();
+
+    m_hasOutputCursor    = false;
+    m_outputCursorNs     = 0;
+    m_outputCursorFracNs = 0.0;
+    m_inputSourceFrameNs = 0.0;
+}
+
+int SoundTouchDsp::latencyFrames() const
+{
+    if(!m_processor) {
+        return 0;
+    }
+
+    const int latency = m_processor->getSetting(SETTING_INITIAL_LATENCY);
+    return std::max(0, latency);
+}
+
+QByteArray SoundTouchDsp::saveSettings() const
+{
+    QByteArray data;
+    QDataStream stream{&data, QIODevice::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    stream << quint32(PresetVersion);
+    stream << parameterValue();
+
+    return data;
+}
+
+bool SoundTouchDsp::loadSettings(const QByteArray& preset)
+{
+    if(preset.isEmpty()) {
+        return false;
+    }
+
+    QDataStream stream{preset};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    quint32 version{0};
+    stream >> version;
+    if(stream.status() != QDataStream::Ok) {
+        return false;
+    }
+
+    if(version == PresetVersion) {
+        double value = parameterDefaultValue();
+        stream >> value;
+
+        if(stream.status() != QDataStream::Ok) {
+            return false;
+        }
+
+        setParameterValue(value);
+        return true;
+    }
+
+    return false;
+}
+
+SoundTouchDsp::Parameter SoundTouchDsp::parameter() const
+{
+    return m_parameter;
+}
+
+double SoundTouchDsp::parameterValue() const
+{
+    switch(m_parameter) {
+        case Parameter::Tempo:
+            return tempo();
+        case Parameter::Pitch:
+            return pitchSemitones();
+        case Parameter::Rate:
+            return rate();
+    }
+
+    return parameterDefaultValue();
+}
+
+void SoundTouchDsp::setParameterValue(const double value)
+{
+    switch(m_parameter) {
+        case Parameter::Tempo:
+            setTempo(value);
+            break;
+        case Parameter::Pitch:
+            setPitchSemitones(value);
+            break;
+        case Parameter::Rate:
+            setRate(value);
+            break;
+    }
+}
+
+double SoundTouchDsp::parameterDefaultValue() const
+{
+    switch(m_parameter) {
+        case Parameter::Tempo:
+        case Parameter::Rate:
+            return 1.0;
+        case Parameter::Pitch:
+            return 0.0;
+    }
+
+    return 1.0;
+}
+
+void SoundTouchDsp::setTempo(double value)
+{
+    const double clamped = clampTempo(value);
+    if(std::abs(clamped - tempo()) < 0.000001) {
+        return;
+    }
+
+    m_tempo = clamped;
+    configureProcessor();
+}
+
+double SoundTouchDsp::tempo() const
+{
+    return m_tempo;
+}
+
+void SoundTouchDsp::setPitchSemitones(double value)
+{
+    const double clamped = clampPitch(value);
+    if(std::abs(clamped - pitchSemitones()) < 0.000001) {
+        return;
+    }
+
+    m_pitchSemitones = clamped;
+    configureProcessor();
+}
+
+double SoundTouchDsp::pitchSemitones() const
+{
+    return m_pitchSemitones;
+}
+
+void SoundTouchDsp::setRate(double value)
+{
+    const double clamped = clampRate(value);
+    if(std::abs(clamped - rate()) < 0.000001) {
+        return;
+    }
+
+    m_rate = clamped;
+    configureProcessor();
+}
+
+double SoundTouchDsp::rate() const
+{
+    return m_rate;
+}
+
+void SoundTouchDsp::recreateProcessor(const AudioFormat& format)
+{
+    m_processor = std::make_unique<soundtouch::SoundTouch>();
+    m_processor->setSampleRate(static_cast<uint>(std::max(1, format.sampleRate())));
+    m_processor->setChannels(static_cast<uint>(std::max(1, format.channelCount())));
+
+    configureProcessor();
+
+    m_hasOutputCursor    = false;
+    m_outputCursorNs     = 0;
+    m_outputCursorFracNs = 0.0;
+    m_inputSourceFrameNs = 0.0;
+}
+
+void SoundTouchDsp::configureProcessor() const
+{
+    if(!m_processor) {
+        return;
+    }
+
+    float tempoValue{1.0F};
+    float pitchValue{0.0F};
+    float rateValue{1.0F};
+
+    switch(m_parameter) {
+        case Parameter::Tempo:
+            tempoValue = static_cast<float>(tempo());
+            break;
+        case Parameter::Pitch:
+            pitchValue = static_cast<float>(pitchSemitones());
+            break;
+        case Parameter::Rate:
+            rateValue = static_cast<float>(rate());
+            break;
+    }
+
+    m_processor->setTempo(tempoValue);
+    m_processor->setPitchSemiTones(pitchValue);
+    m_processor->setRate(rateValue);
+}
+
+void SoundTouchDsp::processBuffer(const ProcessingBuffer& buffer, ProcessingBufferList& output)
+{
+    const AudioFormat format{buffer.format()};
+    if(!format.isValid()) {
+        return;
+    }
+
+    if(!m_processor || format.sampleRate() != m_format.sampleRate()
+       || format.channelCount() != m_format.channelCount()) {
+        m_format = format;
+        recreateProcessor(m_format);
+    }
+
+    const int channels = std::max(1, m_format.channelCount());
+    const int frames   = buffer.frameCount();
+    if(frames <= 0) {
+        return;
+    }
+
+    const auto input             = buffer.constData();
+    const size_t expectedSamples = static_cast<size_t>(frames) * static_cast<size_t>(channels);
+    if(input.size() < expectedSamples) {
+        return;
+    }
+
+    if(!m_hasOutputCursor) {
+        m_outputCursorNs     = buffer.startTimeNs();
+        m_hasOutputCursor    = true;
+        m_outputCursorFracNs = 0.0;
+    }
+
+    const int sampleRate             = std::max(1, m_format.sampleRate());
+    const double nominalInputFrameNs = static_cast<double>(Time::NsPerSecond) / static_cast<double>(sampleRate);
+    const double inputSourceFrameNs  = buffer.sourceFrameDurationNs() > 0
+                                         ? static_cast<double>(buffer.sourceFrameDurationNs())
+                                         : nominalInputFrameNs;
+
+    if(m_inputSourceFrameNs <= 0.0) {
+        m_inputSourceFrameNs = inputSourceFrameNs;
+    }
+    else {
+        m_inputSourceFrameNs = (m_inputSourceFrameNs * 0.85) + (inputSourceFrameNs * 0.15);
+    }
+
+    m_inputBuffer.resize(expectedSamples);
+    for(size_t i{0}; i < expectedSamples; ++i) {
+        m_inputBuffer[i] = static_cast<float>(input[i]);
+    }
+
+    m_processor->putSamples(m_inputBuffer.data(), static_cast<uint>(frames));
+    drainProcessor(output);
+}
+
+int SoundTouchDsp::drainProcessor(ProcessingBufferList& output)
+{
+    if(!m_processor || !m_format.isValid()) {
+        return 0;
+    }
+
+    const int channels = std::max(1, m_format.channelCount());
+    int producedFrames = 0;
+
+    while(m_processor->numSamples() > 0) {
+        const uint availableFrames = m_processor->numSamples();
+        if(availableFrames == 0) {
+            break;
+        }
+
+        const size_t sampleCount = static_cast<size_t>(availableFrames) * static_cast<size_t>(channels);
+        m_outputBuffer.resize(sampleCount);
+
+        const uint receivedFrames = m_processor->receiveSamples(m_outputBuffer.data(), availableFrames);
+        if(receivedFrames == 0) {
+            break;
+        }
+
+        const size_t receivedSamples = static_cast<size_t>(receivedFrames) * static_cast<size_t>(channels);
+        auto* outBuffer              = output.addItem(m_format, m_outputCursorNs, receivedSamples);
+        if(!outBuffer) {
+            break;
+        }
+
+        auto outData = outBuffer->data();
+        if(outData.size() < receivedSamples) {
+            output.removeByIdx(output.count() - 1);
+            break;
+        }
+
+        for(size_t i{0}; i < receivedSamples; ++i) {
+            outData[i] = static_cast<double>(m_outputBuffer[i]);
+        }
+
+        producedFrames += static_cast<int>(receivedFrames);
+
+        const double sourceScale         = std::max(MinRateScale, tempo() * rate());
+        const int sampleRate             = std::max(1, m_format.sampleRate());
+        const double nominalInputFrameNs = static_cast<double>(Time::NsPerSecond) / static_cast<double>(sampleRate);
+        const double baseInputFrameNs    = m_inputSourceFrameNs > 0.0 ? m_inputSourceFrameNs : nominalInputFrameNs;
+        const double mappedFrameNs       = std::max(1.0, baseInputFrameNs * sourceScale);
+
+        outBuffer->setSourceFrameDurationNs(static_cast<uint64_t>(std::max<int64_t>(1, std::llround(mappedFrameNs))));
+
+        const double advanceNsFull = (static_cast<double>(receivedFrames) * mappedFrameNs) + m_outputCursorFracNs;
+        const uint64_t advanceNs   = static_cast<uint64_t>(std::max(0.0, std::floor(advanceNsFull)));
+
+        m_outputCursorFracNs = advanceNsFull - static_cast<double>(advanceNs);
+        m_outputCursorNs += advanceNs;
+    }
+
+    return producedFrames;
+}
+
+double SoundTouchDsp::clampTempo(double value)
+{
+    return std::clamp(value, TempoMin, TempoMax);
+}
+
+double SoundTouchDsp::clampPitch(double value)
+{
+    return std::clamp(value, PitchMin, PitchMax);
+}
+
+double SoundTouchDsp::clampRate(double value)
+{
+    return std::clamp(value, RateMin, RateMax);
+}
+
+QString SoundTouchDsp::idForParameter(const Parameter parameter)
+{
+    switch(parameter) {
+        case Parameter::Tempo:
+            return QStringLiteral("fooyin.dsp.soundtouch.tempo");
+        case Parameter::Pitch:
+            return QStringLiteral("fooyin.dsp.soundtouch.pitch");
+        case Parameter::Rate:
+            return QStringLiteral("fooyin.dsp.soundtouch.rate");
+    }
+
+    return QStringLiteral("fooyin.dsp.soundtouch");
+}
+
+QString SoundTouchDsp::nameForParameter(const Parameter parameter)
+{
+    switch(parameter) {
+        case Parameter::Tempo:
+            return QStringLiteral("Tempo Shift");
+        case Parameter::Pitch:
+            return QStringLiteral("Pitch Shift");
+        case Parameter::Rate:
+            return QStringLiteral("Playback Rate Shift");
+    }
+
+    return QStringLiteral("SoundTouch");
+}
+
+SoundTouchTempoDsp::SoundTouchTempoDsp()
+    : SoundTouchDsp{Parameter::Tempo}
+{ }
+
+SoundTouchPitchDsp::SoundTouchPitchDsp()
+    : SoundTouchDsp{Parameter::Pitch}
+{ }
+
+SoundTouchRateDsp::SoundTouchRateDsp()
+    : SoundTouchDsp{Parameter::Rate}
+{ }
+} // namespace Fooyin

--- a/src/plugins/soundtouch/soundtouchdsp.h
+++ b/src/plugins/soundtouch/soundtouchdsp.h
@@ -1,0 +1,117 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <SoundTouch.h>
+#include <core/engine/dsp/dspnode.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace Fooyin {
+class SoundTouchDsp : public DspNode
+{
+public:
+    enum class Parameter : uint8_t
+    {
+        Tempo = 0,
+        Pitch,
+        Rate
+    };
+
+    explicit SoundTouchDsp(Parameter parameter);
+    ~SoundTouchDsp() override;
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString id() const override;
+    [[nodiscard]] bool supportsLiveSettings() const override;
+
+    [[nodiscard]] AudioFormat outputFormat(const AudioFormat& input) const override;
+    void prepare(const AudioFormat& format) override;
+    void process(ProcessingBufferList& chunks) override;
+    void reset() override;
+    void flush(ProcessingBufferList& chunks, FlushMode mode) override;
+    [[nodiscard]] int latencyFrames() const override;
+
+    [[nodiscard]] QByteArray saveSettings() const override;
+    bool loadSettings(const QByteArray& preset) override;
+
+    [[nodiscard]] Parameter parameter() const;
+    [[nodiscard]] double parameterValue() const;
+    void setParameterValue(double value);
+    [[nodiscard]] double parameterDefaultValue() const;
+
+    void setTempo(double value);
+    [[nodiscard]] double tempo() const;
+
+    void setPitchSemitones(double value);
+    [[nodiscard]] double pitchSemitones() const;
+
+    void setRate(double value);
+    [[nodiscard]] double rate() const;
+
+private:
+    void recreateProcessor(const AudioFormat& format);
+    void configureProcessor() const;
+    void processBuffer(const ProcessingBuffer& buffer, ProcessingBufferList& output);
+    int drainProcessor(ProcessingBufferList& output);
+    static double clampTempo(double value);
+    static double clampPitch(double value);
+    static double clampRate(double value);
+    [[nodiscard]] static QString idForParameter(Parameter parameter);
+    [[nodiscard]] static QString nameForParameter(Parameter parameter);
+
+    AudioFormat m_format;
+
+    Parameter m_parameter;
+    std::unique_ptr<soundtouch::SoundTouch> m_processor;
+
+    std::vector<float> m_inputBuffer;
+    std::vector<float> m_outputBuffer;
+
+    bool m_hasOutputCursor;
+    uint64_t m_outputCursorNs;
+    double m_outputCursorFracNs;
+    double m_inputSourceFrameNs;
+
+    double m_tempo;
+    double m_pitchSemitones;
+    double m_rate;
+};
+
+class SoundTouchTempoDsp final : public SoundTouchDsp
+{
+public:
+    SoundTouchTempoDsp();
+};
+
+class SoundTouchPitchDsp final : public SoundTouchDsp
+{
+public:
+    SoundTouchPitchDsp();
+};
+
+class SoundTouchRateDsp final : public SoundTouchDsp
+{
+public:
+    SoundTouchRateDsp();
+};
+} // namespace Fooyin

--- a/src/plugins/soundtouch/soundtouchplugin.cpp
+++ b/src/plugins/soundtouch/soundtouchplugin.cpp
@@ -1,0 +1,47 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "soundtouchplugin.h"
+
+#include "soundtouchdsp.h"
+#include "soundtouchsettingswidget.h"
+
+namespace Fooyin::SoundTouch {
+std::vector<DspNode::Entry> SoundTouchPlugin::dspCreators() const
+{
+    auto tempo = std::make_unique<SoundTouchTempoDsp>();
+    auto pitch = std::make_unique<SoundTouchPitchDsp>();
+    auto rate  = std::make_unique<SoundTouchRateDsp>();
+
+    return {
+        {.id = tempo->id(), .name = tempo->name(), .factory = []() { return std::make_unique<SoundTouchTempoDsp>(); }},
+        {.id = pitch->id(), .name = pitch->name(), .factory = []() { return std::make_unique<SoundTouchPitchDsp>(); }},
+        {.id = rate->id(), .name = rate->name(), .factory = []() { return std::make_unique<SoundTouchRateDsp>(); }},
+    };
+}
+
+std::vector<std::unique_ptr<DspSettingsProvider>> SoundTouchPlugin::settingsProviders() const
+{
+    std::vector<std::unique_ptr<DspSettingsProvider>> providers;
+    providers.push_back(std::make_unique<SoundTouchTempoSettingsProvider>());
+    providers.push_back(std::make_unique<SoundTouchPitchSettingsProvider>());
+    providers.push_back(std::make_unique<SoundTouchRateSettingsProvider>());
+    return providers;
+}
+} // namespace Fooyin::SoundTouch

--- a/src/plugins/soundtouch/soundtouchplugin.h
+++ b/src/plugins/soundtouch/soundtouchplugin.h
@@ -1,0 +1,40 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/dsp/dspplugin.h>
+#include <core/plugins/plugin.h>
+#include <gui/plugins/dspguiplugin.h>
+
+namespace Fooyin::SoundTouch {
+class SoundTouchPlugin : public QObject,
+                         public Plugin,
+                         public DspPlugin,
+                         public DspGuiPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.fooyin.fooyin.plugin/1.0" FILE "soundtouch.json")
+    Q_INTERFACES(Fooyin::Plugin Fooyin::DspPlugin Fooyin::DspGuiPlugin)
+
+public:
+    [[nodiscard]] std::vector<DspNode::Entry> dspCreators() const override;
+    [[nodiscard]] std::vector<std::unique_ptr<DspSettingsProvider>> settingsProviders() const override;
+};
+} // namespace Fooyin::SoundTouch

--- a/src/plugins/soundtouch/soundtouchsettingswidget.cpp
+++ b/src/plugins/soundtouch/soundtouchsettingswidget.cpp
@@ -1,0 +1,179 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "soundtouchsettingswidget.h"
+
+#include <gui/widgets/doubleslidereditor.h>
+
+#include <QTimerEvent>
+#include <QVBoxLayout>
+
+#include <memory>
+
+constexpr auto PreviewDebounceMs = 32;
+
+constexpr auto TempoMin = 0.25;
+constexpr auto TempoMax = 4.0;
+constexpr auto PitchMin = -24.0;
+constexpr auto PitchMax = 24.0;
+constexpr auto RateMin  = 0.25;
+constexpr auto RateMax  = 4.0;
+
+namespace {
+std::unique_ptr<Fooyin::SoundTouchDsp> createDsp(const Fooyin::SoundTouchDsp::Parameter parameter)
+{
+    using Parameter = Fooyin::SoundTouchDsp::Parameter;
+
+    switch(parameter) {
+        case Parameter::Tempo:
+            return std::make_unique<Fooyin::SoundTouchTempoDsp>();
+        case Parameter::Pitch:
+            return std::make_unique<Fooyin::SoundTouchPitchDsp>();
+        case Parameter::Rate:
+            return std::make_unique<Fooyin::SoundTouchRateDsp>();
+    }
+
+    return std::make_unique<Fooyin::SoundTouchTempoDsp>();
+}
+
+void configureEditor(Fooyin::DoubleSliderEditor* editor, const Fooyin::SoundTouchDsp::Parameter parameter)
+{
+    using Parameter = Fooyin::SoundTouchDsp::Parameter;
+
+    switch(parameter) {
+        case Parameter::Tempo:
+            editor->setRange(TempoMin, TempoMax);
+            editor->setSingleStep(0.01);
+            editor->setSuffix(QStringLiteral("x"));
+            break;
+        case Parameter::Pitch:
+            editor->setRange(PitchMin, PitchMax);
+            editor->setSingleStep(0.1);
+            editor->setSuffix(QStringLiteral(" st"));
+            break;
+        case Parameter::Rate:
+            editor->setRange(RateMin, RateMax);
+            editor->setSingleStep(0.01);
+            editor->setSuffix(QStringLiteral("x"));
+            break;
+    }
+}
+
+QString editorLabel(const Fooyin::SoundTouchDsp::Parameter parameter)
+{
+    using Parameter = Fooyin::SoundTouchDsp::Parameter;
+
+    switch(parameter) {
+        case Parameter::Tempo:
+            return QObject::tr("Tempo multiplier");
+        case Parameter::Pitch:
+            return QObject::tr("Pitch shift");
+        case Parameter::Rate:
+            return QObject::tr("Rate multiplier");
+    }
+
+    return QObject::tr("SoundTouch");
+}
+} // namespace
+
+namespace Fooyin::SoundTouch {
+SoundTouchSettingsWidget::SoundTouchSettingsWidget(const SoundTouchDsp::Parameter parameter, QWidget* parent)
+    : DspSettingsDialog{parent}
+    , m_parameter{parameter}
+    , m_valueEditor{new DoubleSliderEditor(editorLabel(parameter), this)}
+{
+    auto* layout = contentLayout();
+    layout->addWidget(m_valueEditor);
+
+    QObject::connect(m_valueEditor, &DoubleSliderEditor::valueChanged, this,
+                     [this](double) { m_previewTimer.start(PreviewDebounceMs, this); });
+
+    configureEditor(m_valueEditor, m_parameter);
+}
+
+void SoundTouchSettingsWidget::loadSettings(const QByteArray& settings)
+{
+    auto dsp = createDsp(m_parameter);
+    if(!dsp) {
+        return;
+    }
+
+    dsp->loadSettings(settings);
+    m_valueEditor->setValue(dsp->parameterValue());
+}
+
+QByteArray SoundTouchSettingsWidget::saveSettings() const
+{
+    auto dsp = createDsp(m_parameter);
+    if(!dsp) {
+        return {};
+    }
+
+    dsp->setParameterValue(m_valueEditor->value());
+    return dsp->saveSettings();
+}
+
+void SoundTouchSettingsWidget::restoreDefaults()
+{
+    if(auto dsp = createDsp(m_parameter)) {
+        m_valueEditor->setValue(dsp->parameterDefaultValue());
+    }
+}
+
+void SoundTouchSettingsWidget::timerEvent(QTimerEvent* event)
+{
+    if(event->timerId() == m_previewTimer.timerId()) {
+        m_previewTimer.stop();
+        publishPreviewSettings();
+        return;
+    }
+
+    DspSettingsDialog::timerEvent(event);
+}
+
+QString SoundTouchTempoSettingsProvider::id() const
+{
+    return QStringLiteral("fooyin.dsp.soundtouch.tempo");
+}
+
+DspSettingsDialog* SoundTouchTempoSettingsProvider::createSettingsWidget(QWidget* parent)
+{
+    return new SoundTouchSettingsWidget(SoundTouchDsp::Parameter::Tempo, parent);
+}
+
+QString SoundTouchPitchSettingsProvider::id() const
+{
+    return QStringLiteral("fooyin.dsp.soundtouch.pitch");
+}
+
+DspSettingsDialog* SoundTouchPitchSettingsProvider::createSettingsWidget(QWidget* parent)
+{
+    return new SoundTouchSettingsWidget(SoundTouchDsp::Parameter::Pitch, parent);
+}
+
+QString SoundTouchRateSettingsProvider::id() const
+{
+    return QStringLiteral("fooyin.dsp.soundtouch.rate");
+}
+
+DspSettingsDialog* SoundTouchRateSettingsProvider::createSettingsWidget(QWidget* parent)
+{
+    return new SoundTouchSettingsWidget(SoundTouchDsp::Parameter::Rate, parent);
+}
+} // namespace Fooyin::SoundTouch

--- a/src/plugins/soundtouch/soundtouchsettingswidget.h
+++ b/src/plugins/soundtouch/soundtouchsettingswidget.h
@@ -1,0 +1,72 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "soundtouchdsp.h"
+
+#include <gui/dsp/dspsettingsprovider.h>
+
+#include <QBasicTimer>
+
+namespace Fooyin {
+class DoubleSliderEditor;
+}
+class QTimerEvent;
+
+namespace Fooyin::SoundTouch {
+class SoundTouchSettingsWidget : public DspSettingsDialog
+{
+public:
+    explicit SoundTouchSettingsWidget(SoundTouchDsp::Parameter parameter, QWidget* parent = nullptr);
+
+    void loadSettings(const QByteArray& settings) override;
+    [[nodiscard]] QByteArray saveSettings() const override;
+
+protected:
+    void restoreDefaults() override;
+    void timerEvent(QTimerEvent* event) override;
+
+private:
+    SoundTouchDsp::Parameter m_parameter;
+    DoubleSliderEditor* m_valueEditor;
+    QBasicTimer m_previewTimer;
+};
+
+class SoundTouchTempoSettingsProvider : public DspSettingsProvider
+{
+public:
+    [[nodiscard]] QString id() const override;
+    DspSettingsDialog* createSettingsWidget(QWidget* parent) override;
+};
+
+class SoundTouchPitchSettingsProvider : public DspSettingsProvider
+{
+public:
+    [[nodiscard]] QString id() const override;
+    DspSettingsDialog* createSettingsWidget(QWidget* parent) override;
+};
+
+class SoundTouchRateSettingsProvider : public DspSettingsProvider
+{
+public:
+    [[nodiscard]] QString id() const override;
+    DspSettingsDialog* createSettingsWidget(QWidget* parent) override;
+};
+} // namespace Fooyin::SoundTouch

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,8 @@
     "libopenmpt",
     "libsndfile",
     "libarchive",
-    "libgme"
+    "libgme",
+    "soundtouch"
   ],
   "features": {
     "fooyin-tests": {


### PR DESCRIPTION
This PR adds a new SoundTouch-based DSP plugin and integrates it across build, packaging, and CI.

Included DSPs: 

- SoundTouchTempoDsp
- SoundTouchPitchDsp
- SoundTouchRateDsp