### PR TITLE
Add a SuperEQ-based DSP

### DIFF
--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -7,6 +7,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 add_subdirectory(discord)
+add_subdirectory(equaliser)
 add_subdirectory(fileops)
 add_subdirectory(filters)
 add_subdirectory(gme)

--- a/src/plugins/equaliser/CMakeLists.txt
+++ b/src/plugins/equaliser/CMakeLists.txt
@@ -1,0 +1,17 @@
+create_fooyin_plugin_internal(
+    equaliser
+    DEPENDS Fooyin::Core
+            Fooyin::Gui
+    SOURCES equaliserdsp.cpp
+            equaliserdsp.h
+            equaliserplugin.cpp
+            equaliserplugin.h
+            equalisersettingswidget.cpp
+            equalisersettingswidget.h
+            supereqadapter.cpp
+            supereqadapter.h
+            supereq/supereq_compat.h
+            supereq/paramlist.h
+            supereq/supereq.h
+            supereq/fft.h
+)

--- a/src/plugins/equaliser/equaliser.json.in
+++ b/src/plugins/equaliser/equaliser.json.in
@@ -1,0 +1,15 @@
+{
+    "Name" : "Equaliser",
+    "Version" : "${FOOYIN_VERSION}",
+    "Author" : "fooyin",
+    "Copyright" : "Copyright © 2026, Luke Taylor <luket@pm.me>",
+    "License" : [ "Fooyin is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
+                  "",
+                  "Fooyin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.",
+                  "",
+                  "You should have received a copy of the GNU General Public License along with Fooyin.  If not, see <http://www.gnu.org/licenses/>"
+                ],
+    "Category" : "Audio.DSP",
+    "Description" : "Adds a SuperEQ-based equaliser DSP",
+    "Url" : "https://github.com/fooyin/fooyin"
+}

--- a/src/plugins/equaliser/equaliserdsp.cpp
+++ b/src/plugins/equaliser/equaliserdsp.cpp
@@ -1,0 +1,405 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "equaliserdsp.h"
+
+#include <utils/timeconstants.h>
+
+#include <QIODevice>
+
+#include <algorithm>
+#include <cmath>
+
+constexpr quint32 PresetVersion = 1;
+constexpr auto GainMinDb        = -20.0;
+constexpr auto GainMaxDb        = 20.0;
+constexpr auto NeutralEpsilonDb = 1.0e-9;
+
+namespace {
+uint64_t nominalFrameDurationNs(const int sampleRate)
+{
+    const int safeRate   = std::max(1, sampleRate);
+    const double frameNs = static_cast<double>(Fooyin::Time::NsPerSecond) / static_cast<double>(safeRate);
+    return static_cast<uint64_t>(std::max<int64_t>(1, std::llround(frameNs)));
+}
+} // namespace
+
+namespace Fooyin::Equaliser {
+EqualiserDsp::EqualiserDsp()
+    : m_processor{SuperEq::Processor::DefaultWindowBits}
+    , m_settings{defaultSettings()}
+    , m_appliedSettings{}
+    , m_hasAppliedSettings{false}
+    , m_settingsDirty{true}
+    , m_hasOutputCursor{false}
+    , m_outputCursorNs{0}
+    , m_outputCursorRemainderNs{0.0}
+    , m_outputSourceFrameDurationNs{0}
+{ }
+
+QString EqualiserDsp::name() const
+{
+    return QStringLiteral("Equaliser");
+}
+
+QString EqualiserDsp::id() const
+{
+    return QStringLiteral("fooyin.dsp.equaliser");
+}
+
+bool EqualiserDsp::supportsLiveSettings() const
+{
+    return true;
+}
+
+AudioFormat EqualiserDsp::outputFormat(const AudioFormat& input) const
+{
+    return input;
+}
+
+void EqualiserDsp::prepare(const AudioFormat& format)
+{
+    m_format = format;
+
+    if(!m_format.isValid()) {
+        reset();
+        return;
+    }
+
+    const int channels   = std::max(1, m_format.channelCount());
+    const int sampleRate = std::max(1, m_format.sampleRate());
+
+    m_processor.prepare(channels, static_cast<double>(sampleRate));
+    m_outputScratch.clear();
+
+    m_hasOutputCursor             = false;
+    m_outputCursorNs              = 0;
+    m_outputCursorRemainderNs     = 0.0;
+    m_outputSourceFrameDurationNs = 0;
+
+    m_hasAppliedSettings = false;
+    m_settingsDirty      = true;
+
+    applySettingsIfNeeded();
+}
+
+void EqualiserDsp::process(ProcessingBufferList& chunks)
+{
+    if(applySettingsIfNeeded()) {
+        return;
+    }
+
+    ProcessingBufferList output;
+    output.clear();
+
+    const size_t count = chunks.count();
+    for(size_t i{0}; i < count; ++i) {
+        const auto* buffer = chunks.item(i);
+        if(!buffer || !buffer->isValid() || buffer->frameCount() <= 0) {
+            continue;
+        }
+
+        ensurePreparedFor(buffer->format());
+        if(!m_format.isValid()) {
+            continue;
+        }
+
+        if(!m_hasOutputCursor) {
+            m_outputCursorNs          = buffer->startTimeNs();
+            m_outputCursorRemainderNs = 0.0;
+            m_hasOutputCursor         = true;
+        }
+
+        const uint64_t sourceFrameDurationNs = buffer->sourceFrameDurationNs() > 0
+                                                 ? buffer->sourceFrameDurationNs()
+                                                 : nominalFrameDurationNs(m_format.sampleRate());
+        m_outputSourceFrameDurationNs        = sourceFrameDurationNs;
+
+        const int producedFrames = m_processor.processInterleaved(buffer->constData(), m_outputScratch);
+        if(producedFrames <= 0) {
+            continue;
+        }
+
+        emitOutputChunk(output, producedFrames, sourceFrameDurationNs);
+    }
+
+    chunks.clear();
+
+    const size_t outCount = output.count();
+    for(size_t i{0}; i < outCount; ++i) {
+        const auto* buffer = output.item(i);
+        if(buffer && buffer->isValid()) {
+            chunks.addChunk(*buffer);
+        }
+    }
+}
+
+void EqualiserDsp::reset()
+{
+    m_processor.reset();
+    m_hasOutputCursor             = false;
+    m_outputCursorNs              = 0;
+    m_outputCursorRemainderNs     = 0.0;
+    m_outputSourceFrameDurationNs = 0;
+}
+
+void EqualiserDsp::flush(ProcessingBufferList& chunks, const FlushMode mode)
+{
+    if(mode == FlushMode::Flush) {
+        reset();
+        return;
+    }
+
+    if(!m_format.isValid()) {
+        return;
+    }
+
+    if(applySettingsIfNeeded()) {
+        reset();
+        return;
+    }
+
+    if(!m_hasOutputCursor) {
+        m_hasOutputCursor         = true;
+        m_outputCursorNs          = 0;
+        m_outputCursorRemainderNs = 0.0;
+    }
+
+    const uint64_t sourceFrameDurationNs = m_outputSourceFrameDurationNs > 0
+                                             ? m_outputSourceFrameDurationNs
+                                             : nominalFrameDurationNs(m_format.sampleRate());
+
+    for(;;) {
+        const int producedFrames = m_processor.flushInterleaved(m_outputScratch);
+        if(producedFrames <= 0) {
+            break;
+        }
+
+        emitOutputChunk(chunks, producedFrames, sourceFrameDurationNs);
+    }
+
+    reset();
+}
+
+int EqualiserDsp::latencyFrames() const
+{
+    return isNeutralSettings(m_settings) ? 0 : m_processor.windowLength();
+}
+
+QByteArray EqualiserDsp::saveSettings() const
+{
+    QByteArray data;
+    QDataStream stream{&data, QIODevice::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    stream << quint32(PresetVersion);
+    stream << m_settings.preampDb;
+    for(const double band : m_settings.bandDb) {
+        stream << band;
+    }
+
+    return data;
+}
+
+bool EqualiserDsp::loadSettings(const QByteArray& preset)
+{
+    if(preset.isEmpty()) {
+        return false;
+    }
+
+    QDataStream stream{preset};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    quint32 version{0};
+    Settings s = defaultSettings();
+
+    stream >> version;
+    if(stream.status() != QDataStream::Ok || version != PresetVersion) {
+        return false;
+    }
+
+    stream >> s.preampDb;
+    s.preampDb = clampGainDb(s.preampDb);
+
+    for(double& band : s.bandDb) {
+        stream >> band;
+        band = clampGainDb(band);
+    }
+
+    if(stream.status() != QDataStream::Ok) {
+        return false;
+    }
+
+    publishSettings(s);
+    return true;
+}
+
+void EqualiserDsp::setPreampDb(const double value)
+{
+    Settings next = m_settings;
+    next.preampDb = clampGainDb(value);
+    publishSettings(next);
+}
+
+double EqualiserDsp::preampDb() const
+{
+    return m_settings.preampDb;
+}
+
+void EqualiserDsp::setBandDb(const int band, const double value)
+{
+    if(band < 0 || band >= BandCount) {
+        return;
+    }
+
+    Settings next                          = m_settings;
+    next.bandDb[static_cast<size_t>(band)] = clampGainDb(value);
+    publishSettings(next);
+}
+
+double EqualiserDsp::bandDb(const int band) const
+{
+    if(band < 0 || band >= BandCount) {
+        return 0.0;
+    }
+
+    return m_settings.bandDb[static_cast<size_t>(band)];
+}
+
+EqualiserDsp::Settings EqualiserDsp::defaultSettings()
+{
+    Settings s;
+    s.preampDb = 0.0;
+    s.bandDb.fill(0.0);
+    return s;
+}
+
+double EqualiserDsp::clampGainDb(const double value)
+{
+    return std::clamp(value, GainMinDb, GainMaxDb);
+}
+
+bool EqualiserDsp::isNeutralSettings(const Settings& settings)
+{
+    if(std::abs(settings.preampDb) > NeutralEpsilonDb) {
+        return false;
+    }
+
+    return std::ranges::all_of(settings.bandDb,
+                               [](const double bandDb) { return std::abs(bandDb) <= NeutralEpsilonDb; });
+}
+
+bool EqualiserDsp::settingsEqual(const Settings& lhs, const Settings& rhs)
+{
+    if(std::abs(lhs.preampDb - rhs.preampDb) > NeutralEpsilonDb) {
+        return false;
+    }
+
+    for(size_t i{0}; i < lhs.bandDb.size(); ++i) {
+        if(std::abs(lhs.bandDb[i] - rhs.bandDb[i]) > NeutralEpsilonDb) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void EqualiserDsp::publishSettings(const Settings& settings)
+{
+    if(settingsEqual(settings, m_settings)) {
+        return;
+    }
+
+    m_settings      = settings;
+    m_settingsDirty = true;
+}
+
+bool EqualiserDsp::applySettingsIfNeeded()
+{
+    const Settings& current = m_settings;
+    const bool neutral      = isNeutralSettings(current);
+
+    if(!m_settingsDirty && m_hasAppliedSettings) {
+        return neutral;
+    }
+
+    const bool wasNeutral = m_hasAppliedSettings && isNeutralSettings(m_appliedSettings);
+
+    if(neutral) {
+        if(!wasNeutral) {
+            reset();
+        }
+    }
+    else {
+        m_processor.setGainDb(current.preampDb, current.bandDb);
+    }
+
+    m_appliedSettings    = current;
+    m_hasAppliedSettings = true;
+    m_settingsDirty      = false;
+    return neutral;
+}
+
+void EqualiserDsp::ensurePreparedFor(const AudioFormat& format)
+{
+    const AudioFormat expected = outputFormat(format);
+    if(!m_format.isValid() || m_format.sampleRate() != expected.sampleRate()
+       || m_format.channelCount() != expected.channelCount()) {
+        prepare(expected);
+    }
+}
+
+void EqualiserDsp::emitOutputChunk(ProcessingBufferList& output, const int frames, const uint64_t sourceFrameDurationNs)
+{
+    if(frames <= 0 || !m_format.isValid()) {
+        return;
+    }
+
+    const int channels       = std::max(1, m_format.channelCount());
+    const size_t sampleCount = static_cast<size_t>(frames) * static_cast<size_t>(channels);
+
+    ProcessingBuffer out{m_format, m_outputCursorNs};
+    out.resizeSamples(sampleCount);
+
+    auto outData           = out.data();
+    const size_t copyCount = std::min(outData.size(), m_outputScratch.size());
+    for(size_t i{0}; i < copyCount; ++i) {
+        outData[i] = m_outputScratch[i];
+    }
+
+    out.setSourceFrameDurationNs(sourceFrameDurationNs);
+    output.addChunk(out);
+
+    advanceOutputCursor(frames, sourceFrameDurationNs);
+}
+
+void EqualiserDsp::advanceOutputCursor(const int frames, const uint64_t sourceFrameDurationNs)
+{
+    if(frames <= 0 || sourceFrameDurationNs == 0) {
+        return;
+    }
+
+    const double advanceNsFull
+        = (static_cast<double>(frames) * static_cast<double>(sourceFrameDurationNs)) + m_outputCursorRemainderNs;
+    const auto advanceNs = static_cast<uint64_t>(std::max(0.0, std::floor(advanceNsFull)));
+
+    m_outputCursorRemainderNs = advanceNsFull - static_cast<double>(advanceNs);
+    m_outputCursorNs += advanceNs;
+}
+} // namespace Fooyin::Equaliser

--- a/src/plugins/equaliser/equaliserdsp.h
+++ b/src/plugins/equaliser/equaliserdsp.h
@@ -1,0 +1,92 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "supereqadapter.h"
+
+#include <core/engine/dsp/dspnode.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace Fooyin::Equaliser {
+class EqualiserDsp : public DspNode
+{
+public:
+    static constexpr int BandCount = SuperEq::Processor::BandCount;
+
+    EqualiserDsp();
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString id() const override;
+    [[nodiscard]] bool supportsLiveSettings() const override;
+
+    [[nodiscard]] AudioFormat outputFormat(const AudioFormat& input) const override;
+    void prepare(const AudioFormat& format) override;
+    void process(ProcessingBufferList& chunks) override;
+    void reset() override;
+    void flush(ProcessingBufferList& chunks, FlushMode mode) override;
+    [[nodiscard]] int latencyFrames() const override;
+
+    [[nodiscard]] QByteArray saveSettings() const override;
+    bool loadSettings(const QByteArray& preset) override;
+
+    void setPreampDb(double value);
+    [[nodiscard]] double preampDb() const;
+
+    void setBandDb(int band, double value);
+    [[nodiscard]] double bandDb(int band) const;
+
+private:
+    struct Settings
+    {
+        double preampDb{0.0};
+        std::array<double, BandCount> bandDb{};
+    };
+
+    static Settings defaultSettings();
+    static double clampGainDb(double value);
+    static bool isNeutralSettings(const Settings& settings);
+    static bool settingsEqual(const Settings& lhs, const Settings& rhs);
+
+    void publishSettings(const Settings& settings);
+    bool applySettingsIfNeeded();
+    void ensurePreparedFor(const AudioFormat& format);
+
+    void emitOutputChunk(ProcessingBufferList& output, int frames, uint64_t sourceFrameDurationNs);
+    void advanceOutputCursor(int frames, uint64_t sourceFrameDurationNs);
+
+    AudioFormat m_format;
+    SuperEq::Processor m_processor;
+
+    std::vector<double> m_outputScratch;
+
+    Settings m_settings;
+    Settings m_appliedSettings;
+    bool m_hasAppliedSettings;
+    bool m_settingsDirty;
+
+    bool m_hasOutputCursor;
+    uint64_t m_outputCursorNs;
+    double m_outputCursorRemainderNs;
+    uint64_t m_outputSourceFrameDurationNs;
+};
+} // namespace Fooyin::Equaliser

--- a/src/plugins/equaliser/equaliserplugin.cpp
+++ b/src/plugins/equaliser/equaliserplugin.cpp
@@ -1,0 +1,38 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "equaliserplugin.h"
+
+#include "equaliserdsp.h"
+#include "equalisersettingswidget.h"
+
+namespace Fooyin::Equaliser {
+std::vector<DspNode::Entry> EqualiserPlugin::dspCreators() const
+{
+    auto dsp = std::make_unique<EqualiserDsp>();
+    return {{.id = dsp->id(), .name = dsp->name(), .factory = []() { return std::make_unique<EqualiserDsp>(); }}};
+}
+
+std::vector<std::unique_ptr<DspSettingsProvider>> EqualiserPlugin::settingsProviders() const
+{
+    std::vector<std::unique_ptr<DspSettingsProvider>> providers;
+    providers.push_back(std::make_unique<EqualiserSettingsProvider>());
+    return providers;
+}
+} // namespace Fooyin::Equaliser

--- a/src/plugins/equaliser/equaliserplugin.h
+++ b/src/plugins/equaliser/equaliserplugin.h
@@ -1,0 +1,40 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/dsp/dspplugin.h>
+#include <core/plugins/plugin.h>
+#include <gui/plugins/dspguiplugin.h>
+
+namespace Fooyin::Equaliser {
+class EqualiserPlugin : public QObject,
+                        public Plugin,
+                        public DspPlugin,
+                        public DspGuiPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.fooyin.fooyin.plugin/1.0" FILE "equaliser.json")
+    Q_INTERFACES(Fooyin::Plugin Fooyin::DspPlugin Fooyin::DspGuiPlugin)
+
+public:
+    [[nodiscard]] std::vector<DspNode::Entry> dspCreators() const override;
+    [[nodiscard]] std::vector<std::unique_ptr<DspSettingsProvider>> settingsProviders() const override;
+};
+} // namespace Fooyin::Equaliser

--- a/src/plugins/equaliser/equalisersettingswidget.cpp
+++ b/src/plugins/equaliser/equalisersettingswidget.cpp
@@ -1,0 +1,693 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "equalisersettingswidget.h"
+
+#include "equaliserdsp.h"
+
+#include <core/coresettings.h>
+#include <gui/widgets/tooltip.h>
+
+#include <QComboBox>
+#include <QDataStream>
+#include <QDoubleSpinBox>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QSizePolicy>
+#include <QSlider>
+#include <QSpacerItem>
+#include <QTextStream>
+#include <QTimerEvent>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <utility>
+
+constexpr auto SliderScale           = 10;
+constexpr quint32 PresetStoreVersion = 1;
+constexpr auto PresetsSettingKey     = "DSP/EqualiserPresets";
+constexpr auto LastPresetPathKey     = "DSP/EqualiserLastPresetPath";
+
+namespace {
+constexpr std::array<const char*, 18> BandLabels = {
+    "55 Hz",   "77 Hz",   "110 Hz",  "156 Hz",  "220 Hz", "311 Hz", "440 Hz", "622 Hz", "880 Hz",
+    "1.2 kHz", "1.8 kHz", "2.5 kHz", "3.5 kHz", "5 kHz",  "7 kHz",  "10 kHz", "14 kHz", "20 kHz",
+};
+
+QSlider* makeGainSlider(QWidget* parent)
+{
+    auto* slider = new QSlider(Qt::Vertical, parent);
+
+    slider->setRange(-20 * SliderScale, 20 * SliderScale);
+    slider->setSingleStep(1);
+    slider->setPageStep(5);
+    slider->setTickInterval(50);
+    slider->setTickPosition(QSlider::TicksLeft);
+    slider->setMinimumHeight(220);
+    slider->setMaximumHeight(220);
+
+    return slider;
+}
+
+QLabel* makeBandLabel(const QString& text, QWidget* parent)
+{
+    auto* label = new QLabel(text, parent);
+
+    label->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    return label;
+}
+
+QLabel* makeScaleLabel(const QString& text, QWidget* parent)
+{
+    auto* label = new QLabel(text, parent);
+
+    label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+    return label;
+}
+} // namespace
+
+namespace Fooyin::Equaliser {
+EqualiserSettingsWidget::EqualiserSettingsWidget(QWidget* parent)
+    : DspSettingsDialog{parent}
+    , m_presetBox{new QComboBox(this)}
+    , m_loadPresetButton{new QPushButton(tr("Load"), this)}
+    , m_savePresetButton{new QPushButton(tr("Save"), this)}
+    , m_deletePresetButton{new QPushButton(tr("Delete"), this)}
+    , m_importPresetButton{new QPushButton(tr("Import"), this)}
+    , m_exportPresetButton{new QPushButton(tr("Export"), this)}
+    , m_selectedBandCombo{new QComboBox(this)}
+    , m_selectedBandSpin{new QDoubleSpinBox(this)}
+    , m_preampSlider{makeGainSlider(this)}
+    , m_bandSliders{}
+{
+    setWindowTitle(tr("Equaliser Settings"));
+
+    setRestoreDefaultsVisible(false);
+
+    auto* root = contentLayout();
+
+    auto* row = new QHBoxLayout();
+    row->setContentsMargins(0, 0, 0, 0);
+    row->setSpacing(8);
+
+    const auto addSliderColumn = [this, row](QSlider* slider, const QString& labelText) {
+        auto* col = new QVBoxLayout();
+        col->setContentsMargins(0, 0, 0, 0);
+        col->setSpacing(6);
+        col->addWidget(slider, 1, Qt::AlignHCenter);
+        col->addWidget(makeBandLabel(labelText, this));
+
+        auto* colWidget = new QWidget(this);
+        colWidget->setLayout(col);
+        colWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+        row->addWidget(colWidget, 1);
+    };
+
+    addSliderColumn(m_preampSlider, tr("Preamp"));
+    QObject::connect(m_preampSlider, &QSlider::valueChanged, this, [this](int) {
+        refreshTooltips();
+        m_previewTimer.start(PreviewDebounceMs, this);
+        if(m_preampSlider->isSliderDown()) {
+            updateSliderToolTip(m_preampSlider);
+        }
+    });
+    QObject::connect(m_preampSlider, &QSlider::sliderPressed, this, [this]() { updateSliderToolTip(m_preampSlider); });
+    QObject::connect(m_preampSlider, &QSlider::sliderMoved, this, [this](int) { updateSliderToolTip(m_preampSlider); });
+    QObject::connect(m_preampSlider, &QSlider::sliderReleased, this, [this]() { hideSliderToolTip(); });
+
+    for(size_t i{0}; i < m_bandSliders.size(); ++i) {
+        m_bandSliders[i] = makeGainSlider(this);
+        addSliderColumn(m_bandSliders[i], tr(BandLabels[i]));
+        QObject::connect(m_bandSliders[i], &QSlider::valueChanged, this, [this, i](int) {
+            refreshTooltips();
+            refreshSelectedBandEditor();
+            m_previewTimer.start(PreviewDebounceMs, this);
+            if(m_bandSliders[i]->isSliderDown()) {
+                updateSliderToolTip(m_bandSliders[i]);
+            }
+        });
+        QObject::connect(m_bandSliders[i], &QSlider::sliderPressed, this,
+                         [this, i]() { updateSliderToolTip(m_bandSliders[i]); });
+        QObject::connect(m_bandSliders[i], &QSlider::sliderMoved, this,
+                         [this, i](int) { updateSliderToolTip(m_bandSliders[i]); });
+        QObject::connect(m_bandSliders[i], &QSlider::sliderReleased, this, [this]() { hideSliderToolTip(); });
+    }
+
+    auto* scaleCol = new QVBoxLayout();
+    scaleCol->setContentsMargins(0, 0, 0, 0);
+    scaleCol->setSpacing(6);
+
+    // Keep scale labels aligned to the slider travel only (220 px), so 0 dB
+    // sits exactly at the visual midpoint of the slider range.
+    auto* scaleTrackWidget = new QWidget(this);
+    scaleTrackWidget->setFixedHeight(220);
+
+    auto* trackLayout = new QVBoxLayout(scaleTrackWidget);
+    trackLayout->setContentsMargins(0, 0, 0, 0);
+    trackLayout->setSpacing(0);
+    trackLayout->addWidget(makeScaleLabel(tr("+20 dB"), this), 0, Qt::AlignTop | Qt::AlignRight);
+    trackLayout->addStretch(1);
+    trackLayout->addWidget(makeScaleLabel(tr("+0 dB"), this), 0, Qt::AlignRight);
+    trackLayout->addStretch(1);
+    trackLayout->addWidget(makeScaleLabel(tr("-20 dB"), this), 0, Qt::AlignBottom | Qt::AlignRight);
+
+    scaleCol->addWidget(scaleTrackWidget, 0, Qt::AlignTop | Qt::AlignRight);
+    scaleCol->addSpacerItem(new QSpacerItem(0, 20, QSizePolicy::Minimum, QSizePolicy::Fixed));
+
+    row->addSpacing(4);
+    row->addLayout(scaleCol);
+    root->addLayout(row);
+
+    auto* controlsLayout = new QGridLayout();
+    controlsLayout->setContentsMargins(0, 0, 0, 0);
+    controlsLayout->setHorizontalSpacing(6);
+    controlsLayout->setVerticalSpacing(6);
+
+    auto* zeroButton      = new QPushButton(tr("Zero all"), this);
+    auto* autoButton      = new QPushButton(tr("Auto level"), this);
+    auto* bandEditorLabel = new QLabel(tr("Band:"), this);
+    auto* presetsLabel    = new QLabel(tr("Presets:"), this);
+
+    QObject::connect(zeroButton, &QPushButton::clicked, this, [this]() { zeroAll(); });
+    QObject::connect(autoButton, &QPushButton::clicked, this, [this]() { autoLevel(); });
+
+    for(const auto& bandName : BandLabels) {
+        m_selectedBandCombo->addItem(tr(bandName));
+    }
+
+    m_selectedBandSpin->setRange(-20.0, 20.0);
+    m_selectedBandSpin->setSingleStep(0.1);
+    m_selectedBandSpin->setDecimals(1);
+    m_selectedBandSpin->setSuffix(tr(" dB"));
+
+    m_presetBox->setEditable(true);
+    m_presetBox->setMinimumContentsLength(24);
+    m_presetBox->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    m_presetBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    controlsLayout->addWidget(zeroButton, 0, 0);
+    controlsLayout->addWidget(autoButton, 0, 1);
+    controlsLayout->addWidget(bandEditorLabel, 0, 2);
+    controlsLayout->addWidget(m_selectedBandCombo, 0, 3);
+    controlsLayout->addWidget(m_selectedBandSpin, 0, 4);
+    controlsLayout->addWidget(m_importPresetButton, 0, 6);
+    controlsLayout->addWidget(m_exportPresetButton, 0, 7);
+
+    controlsLayout->addWidget(presetsLabel, 1, 0);
+    controlsLayout->addWidget(m_presetBox, 1, 1, 1, 5);
+    controlsLayout->addWidget(m_loadPresetButton, 1, 6);
+    controlsLayout->addWidget(m_savePresetButton, 1, 7);
+    controlsLayout->addWidget(m_deletePresetButton, 1, 8);
+
+    controlsLayout->setColumnStretch(5, 1);
+    root->addLayout(controlsLayout);
+
+    QObject::connect(m_loadPresetButton, &QPushButton::clicked, this, [this]() { loadPreset(); });
+    QObject::connect(m_savePresetButton, &QPushButton::clicked, this, [this]() { savePreset(); });
+    QObject::connect(m_deletePresetButton, &QPushButton::clicked, this, [this]() { deletePreset(); });
+    QObject::connect(m_importPresetButton, &QPushButton::clicked, this, [this]() { importPreset(); });
+    QObject::connect(m_exportPresetButton, &QPushButton::clicked, this, [this]() { exportPreset(); });
+    QObject::connect(m_selectedBandCombo, &QComboBox::currentIndexChanged, this,
+                     [this](int) { refreshSelectedBandEditor(); });
+    QObject::connect(m_selectedBandSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double value) {
+        const int bandIndex = m_selectedBandCombo->currentIndex();
+        if(bandIndex < 0 || std::cmp_greater_equal(bandIndex, m_bandSliders.size())) {
+            return;
+        }
+        m_bandSliders[static_cast<size_t>(bandIndex)]->setValue(gainDbToSliderValue(value));
+    });
+    QObject::connect(m_presetBox, &QComboBox::currentTextChanged, this, [this]() { updatePresetButtons(); });
+
+    loadStoredPresets();
+    refreshPresets();
+    refreshSelectedBandEditor();
+}
+
+void EqualiserSettingsWidget::loadSettings(const QByteArray& settings)
+{
+    EqualiserDsp dsp;
+    dsp.loadSettings(settings);
+
+    m_preampSlider->setValue(gainDbToSliderValue(dsp.preampDb()));
+    for(size_t i{0}; i < m_bandSliders.size(); ++i) {
+        m_bandSliders[i]->setValue(gainDbToSliderValue(dsp.bandDb(static_cast<int>(i))));
+    }
+
+    refreshTooltips();
+}
+
+QByteArray EqualiserSettingsWidget::saveSettings() const
+{
+    EqualiserDsp dsp;
+    dsp.setPreampDb(sliderValueToGainDb(m_preampSlider->value()));
+    for(size_t i{0}; i < m_bandSliders.size(); ++i) {
+        dsp.setBandDb(static_cast<int>(i), sliderValueToGainDb(m_bandSliders[i]->value()));
+    }
+
+    return dsp.saveSettings();
+}
+
+void EqualiserSettingsWidget::restoreDefaults()
+{
+    zeroAll();
+}
+
+void EqualiserSettingsWidget::loadStoredPresets()
+{
+    m_presets.clear();
+
+    const FySettings settings;
+    auto serializedData = settings.value(QLatin1String(PresetsSettingKey)).toByteArray();
+    if(serializedData.isEmpty()) {
+        return;
+    }
+
+    serializedData = qUncompress(serializedData);
+    if(serializedData.isEmpty()) {
+        return;
+    }
+
+    QDataStream stream{&serializedData, QIODevice::ReadOnly};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    quint32 version{0};
+    qint32 presetCount{0};
+    stream >> version;
+    stream >> presetCount;
+
+    if(stream.status() != QDataStream::Ok || version != PresetStoreVersion || presetCount < 0) {
+        return;
+    }
+
+    for(qint32 i{0}; i < presetCount; ++i) {
+        PresetItem preset;
+        stream >> preset.name;
+        stream >> preset.settings;
+
+        preset.name = preset.name.trimmed();
+        if(stream.status() != QDataStream::Ok || preset.name.isEmpty() || preset.settings.isEmpty()) {
+            m_presets.clear();
+            return;
+        }
+
+        if(presetIndexByName(preset.name) < 0) {
+            m_presets.push_back(std::move(preset));
+        }
+    }
+}
+
+void EqualiserSettingsWidget::saveStoredPresets() const
+{
+    FySettings settings;
+
+    if(m_presets.empty()) {
+        settings.remove(QLatin1String(PresetsSettingKey));
+        return;
+    }
+
+    QByteArray serializedData;
+    QDataStream stream{&serializedData, QIODevice::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    stream << quint32(PresetStoreVersion);
+    stream << static_cast<qint32>(m_presets.size());
+
+    for(const auto& preset : m_presets) {
+        stream << preset.name;
+        stream << preset.settings;
+    }
+
+    settings.setValue(QLatin1String(PresetsSettingKey), qCompress(serializedData, 9));
+}
+
+int EqualiserSettingsWidget::presetIndexByName(const QString& name) const
+{
+    const QString trimmedName = name.trimmed();
+    if(trimmedName.isEmpty()) {
+        return -1;
+    }
+
+    for(size_t i{0}; i < m_presets.size(); ++i) {
+        if(m_presets[i].name == trimmedName) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void EqualiserSettingsWidget::refreshPresets()
+{
+    const QString currentText = m_presetBox->currentText().trimmed();
+
+    m_presetBox->clear();
+    for(const auto& preset : m_presets) {
+        m_presetBox->addItem(preset.name);
+    }
+
+    if(!currentText.isEmpty()) {
+        const int idx = m_presetBox->findText(currentText);
+        if(idx >= 0) {
+            m_presetBox->setCurrentIndex(idx);
+        }
+        else {
+            m_presetBox->setEditText(currentText);
+        }
+    }
+
+    updatePresetButtons();
+}
+
+void EqualiserSettingsWidget::updatePresetButtons()
+{
+    const QString name   = m_presetBox->currentText().trimmed();
+    const bool hasPreset = presetIndexByName(name) >= 0;
+
+    m_loadPresetButton->setEnabled(hasPreset);
+    m_deletePresetButton->setEnabled(hasPreset);
+    m_savePresetButton->setEnabled(!name.isEmpty());
+}
+
+void EqualiserSettingsWidget::loadPreset()
+{
+    const int presetIndex = presetIndexByName(m_presetBox->currentText());
+    if(presetIndex < 0) {
+        return;
+    }
+
+    EqualiserDsp dsp;
+    if(!dsp.loadSettings(m_presets.at(static_cast<size_t>(presetIndex)).settings)) {
+        QMessageBox::warning(this, tr("Presets"), tr("Unable to load the selected preset."));
+        return;
+    }
+
+    m_preampSlider->setValue(gainDbToSliderValue(dsp.preampDb()));
+    for(size_t i{0}; i < m_bandSliders.size(); ++i) {
+        m_bandSliders[i]->setValue(gainDbToSliderValue(dsp.bandDb(static_cast<int>(i))));
+    }
+
+    refreshTooltips();
+    m_previewTimer.start(PreviewDebounceMs, this);
+}
+
+void EqualiserSettingsWidget::savePreset()
+{
+    const QString name = m_presetBox->currentText().trimmed();
+    if(name.isEmpty()) {
+        return;
+    }
+
+    const int existingIndex = presetIndexByName(name);
+    if(existingIndex >= 0) {
+        QMessageBox msg{QMessageBox::Question, tr("Preset already exists"),
+                        tr("Preset \"%1\" already exists. Overwrite?").arg(name), QMessageBox::Yes | QMessageBox::No};
+        if(msg.exec() != QMessageBox::Yes) {
+            return;
+        }
+
+        m_presets[static_cast<size_t>(existingIndex)].settings = saveSettings();
+    }
+    else {
+        PresetItem preset;
+        preset.name     = name;
+        preset.settings = saveSettings();
+        m_presets.push_back(std::move(preset));
+    }
+
+    saveStoredPresets();
+    refreshPresets();
+    m_presetBox->setCurrentText(name);
+}
+
+void EqualiserSettingsWidget::deletePreset()
+{
+    const int presetIndex = presetIndexByName(m_presetBox->currentText());
+    if(presetIndex < 0) {
+        return;
+    }
+
+    m_presets.erase(m_presets.begin() + presetIndex);
+    saveStoredPresets();
+    refreshPresets();
+}
+
+void EqualiserSettingsWidget::importPreset()
+{
+    QSettings settings;
+    const QString initialPath = settings.value(QLatin1String(LastPresetPathKey), QDir::homePath()).toString();
+
+    const QString filePath = QFileDialog::getOpenFileName(this, tr("Import Equaliser Preset"), initialPath,
+                                                          tr("Equaliser Preset (*.feq)"));
+    if(filePath.isEmpty()) {
+        return;
+    }
+
+    QFile file(filePath);
+    if(!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("Import Equaliser Preset"),
+                             tr("Unable to open \"%1\" for reading.").arg(filePath));
+        return;
+    }
+
+    std::array<int, EqualiserDsp::BandCount> gains{};
+    int parsedBands{0};
+    int lineNumber{0};
+
+    QTextStream stream(&file);
+    while(!stream.atEnd() && parsedBands < EqualiserDsp::BandCount) {
+        const QString line = stream.readLine();
+        ++lineNumber;
+
+        const QString trimmed = line.trimmed();
+        if(trimmed.isEmpty()) {
+            continue;
+        }
+
+        bool ok{false};
+        const int value = trimmed.toInt(&ok);
+        if(!ok) {
+            QMessageBox::warning(this, tr("Import Equaliser Preset"),
+                                 tr("Invalid value on line %1. The first %2 non-empty lines must be integers.")
+                                     .arg(lineNumber)
+                                     .arg(EqualiserDsp::BandCount));
+            return;
+        }
+
+        gains[static_cast<size_t>(parsedBands)] = value;
+        ++parsedBands;
+    }
+
+    if(parsedBands < EqualiserDsp::BandCount) {
+        QMessageBox::warning(this, tr("Import Equaliser Preset"),
+                             tr("Preset file has %1 band values. %2 values are required.")
+                                 .arg(parsedBands)
+                                 .arg(EqualiserDsp::BandCount));
+        return;
+    }
+
+    for(size_t i{0}; i < m_bandSliders.size(); ++i) {
+        m_bandSliders[i]->setValue(gainDbToSliderValue(static_cast<double>(gains[i])));
+    }
+
+    settings.setValue(QLatin1String(LastPresetPathKey), QFileInfo(filePath).absolutePath());
+
+    refreshTooltips();
+    m_previewTimer.start(PreviewDebounceMs, this);
+}
+
+void EqualiserSettingsWidget::exportPreset()
+{
+    FySettings settings;
+    const QString initialPath = settings.value(QLatin1String(LastPresetPathKey), QDir::homePath()).toString();
+
+    QString filePath = QFileDialog::getSaveFileName(this, tr("Export Equaliser Preset"), initialPath,
+                                                    tr("Equaliser Preset (*.feq)"));
+    if(filePath.isEmpty()) {
+        return;
+    }
+
+    if(!filePath.endsWith(QStringLiteral(".feq"), Qt::CaseInsensitive)) {
+        filePath += QStringLiteral(".feq");
+    }
+
+    QFile file(filePath);
+    if(!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
+        QMessageBox::warning(this, tr("Export Equaliser Preset"),
+                             tr("Unable to open \"%1\" for writing.").arg(filePath));
+        return;
+    }
+
+    QTextStream stream(&file);
+    for(auto* slider : m_bandSliders) {
+        const int value = static_cast<int>(std::lround(sliderValueToGainDb(slider->value())));
+        stream << value << '\n';
+    }
+
+    if(stream.status() != QTextStream::Ok) {
+        QMessageBox::warning(this, tr("Export Equaliser Preset"),
+                             tr("An error occurred while writing \"%1\".").arg(filePath));
+        return;
+    }
+
+    settings.setValue(QLatin1String(LastPresetPathKey), QFileInfo(filePath).absolutePath());
+}
+
+void EqualiserSettingsWidget::zeroAll()
+{
+    m_preampSlider->setValue(0);
+
+    for(auto* slider : m_bandSliders) {
+        slider->setValue(0);
+    }
+
+    refreshTooltips();
+}
+
+void EqualiserSettingsWidget::autoLevel()
+{
+    double maxBandDb{0.0};
+
+    for(auto* slider : m_bandSliders) {
+        maxBandDb = std::max(maxBandDb, sliderValueToGainDb(slider->value()));
+    }
+
+    if(maxBandDb <= 0.0) {
+        refreshTooltips();
+        return;
+    }
+
+    for(auto* slider : m_bandSliders) {
+        const double band = sliderValueToGainDb(slider->value());
+        slider->setValue(gainDbToSliderValue(band - maxBandDb));
+    }
+
+    refreshTooltips();
+}
+
+int EqualiserSettingsWidget::gainDbToSliderValue(const double gainDb)
+{
+    const double clamped = std::clamp(gainDb, -20.0, 20.0);
+    return static_cast<int>(std::lround(clamped * static_cast<double>(SliderScale)));
+}
+
+double EqualiserSettingsWidget::sliderValueToGainDb(const int sliderValue)
+{
+    return std::clamp(static_cast<double>(sliderValue) / static_cast<double>(SliderScale), -20.0, 20.0);
+}
+
+QString EqualiserSettingsWidget::gainTooltip(const double gainDb)
+{
+    const QString prefix = gainDb >= 0.0 ? QStringLiteral("+") : QString{};
+    return prefix + QString::number(gainDb, 'f', 1) + tr(" dB");
+}
+
+void EqualiserSettingsWidget::refreshTooltips()
+{
+    m_preampSlider->setToolTip(gainTooltip(sliderValueToGainDb(m_preampSlider->value())));
+
+    for(auto* slider : m_bandSliders) {
+        slider->setToolTip(gainTooltip(sliderValueToGainDb(slider->value())));
+    }
+}
+
+void EqualiserSettingsWidget::updateSliderToolTip(QSlider* slider)
+{
+    if(!slider) {
+        return;
+    }
+
+    if(!m_sliderToolTip) {
+        m_sliderToolTip = new ToolTip(this);
+        m_sliderToolTip->show();
+    }
+
+    m_sliderToolTip->setText(gainTooltip(sliderValueToGainDb(slider->value())));
+    const QPoint cursorPos = slider->mapFromGlobal(QCursor::pos());
+    const int handleY      = std::clamp(cursorPos.y(), slider->rect().top(), slider->rect().bottom());
+    const QPoint handlePos = slider->mapTo(this, QPoint(slider->rect().center().x(), handleY));
+
+    const int tipHeight = m_sliderToolTip->height();
+    const int tipWidth  = m_sliderToolTip->width();
+    const int anchorY   = std::clamp(handlePos.y() + (tipHeight / 2), tipHeight, height());
+
+    const QPoint rightAnchor = slider->mapTo(this, QPoint(slider->rect().right() + 6, anchorY));
+    const QPoint leftAnchor  = slider->mapTo(this, QPoint(slider->rect().left() - 6, anchorY));
+
+    if(rightAnchor.x() + tipWidth <= width()) {
+        m_sliderToolTip->setPosition(rightAnchor, Qt::AlignLeft);
+    }
+    else {
+        m_sliderToolTip->setPosition(leftAnchor, Qt::AlignRight);
+    }
+}
+
+void EqualiserSettingsWidget::hideSliderToolTip()
+{
+    if(m_sliderToolTip) {
+        m_sliderToolTip->hide();
+    }
+}
+
+void EqualiserSettingsWidget::refreshSelectedBandEditor()
+{
+    const int bandIndex  = m_selectedBandCombo->currentIndex();
+    const bool validBand = (bandIndex >= 0 && std::cmp_less(bandIndex, m_bandSliders.size()));
+
+    m_selectedBandSpin->setEnabled(validBand);
+    if(!validBand) {
+        return;
+    }
+
+    const int sliderValue = m_bandSliders[static_cast<size_t>(bandIndex)]->value();
+    const QSignalBlocker blockSpin(m_selectedBandSpin);
+    m_selectedBandSpin->setValue(sliderValueToGainDb(sliderValue));
+}
+
+void EqualiserSettingsWidget::timerEvent(QTimerEvent* event)
+{
+    if(event->timerId() == m_previewTimer.timerId()) {
+        m_previewTimer.stop();
+        publishPreviewSettings();
+        return;
+    }
+
+    DspSettingsDialog::timerEvent(event);
+}
+
+QString EqualiserSettingsProvider::id() const
+{
+    return QStringLiteral("fooyin.dsp.equaliser");
+}
+
+DspSettingsDialog* EqualiserSettingsProvider::createSettingsWidget(QWidget* parent)
+{
+    return new EqualiserSettingsWidget(parent);
+}
+} // namespace Fooyin::Equaliser

--- a/src/plugins/equaliser/equalisersettingswidget.h
+++ b/src/plugins/equaliser/equalisersettingswidget.h
@@ -1,0 +1,110 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gui/dsp/dspsettingsprovider.h>
+
+#include <QBasicTimer>
+#include <QPointer>
+
+#include <array>
+#include <vector>
+
+class QComboBox;
+class QDoubleSpinBox;
+class QPushButton;
+class QSlider;
+class QTimerEvent;
+
+namespace Fooyin {
+class ToolTip;
+
+namespace Equaliser {
+class EqualiserSettingsWidget : public DspSettingsDialog
+{
+public:
+    explicit EqualiserSettingsWidget(QWidget* parent = nullptr);
+
+    void loadSettings(const QByteArray& settings) override;
+    [[nodiscard]] QByteArray saveSettings() const override;
+
+protected:
+    void restoreDefaults() override;
+    void timerEvent(QTimerEvent* event) override;
+
+private:
+    static constexpr int PreviewDebounceMs = 16;
+
+    struct PresetItem
+    {
+        QString name;
+        QByteArray settings;
+    };
+
+    static int gainDbToSliderValue(double gainDb);
+    static double sliderValueToGainDb(int sliderValue);
+    static QString gainTooltip(double gainDb);
+
+    void loadStoredPresets();
+    void saveStoredPresets() const;
+    [[nodiscard]] int presetIndexByName(const QString& name) const;
+    void refreshPresets();
+    void updatePresetButtons();
+    void loadPreset();
+    void savePreset();
+    void deletePreset();
+    void importPreset();
+    void exportPreset();
+
+    void refreshTooltips();
+    void zeroAll();
+    void autoLevel();
+    void updateSliderToolTip(QSlider* slider);
+    void hideSliderToolTip();
+
+    QComboBox* m_presetBox;
+
+    QPushButton* m_loadPresetButton;
+    QPushButton* m_savePresetButton;
+    QPushButton* m_deletePresetButton;
+    QPushButton* m_importPresetButton;
+    QPushButton* m_exportPresetButton;
+
+    QComboBox* m_selectedBandCombo;
+    QDoubleSpinBox* m_selectedBandSpin;
+
+    QSlider* m_preampSlider;
+    std::array<QSlider*, 18> m_bandSliders;
+    QPointer<ToolTip> m_sliderToolTip;
+
+    QBasicTimer m_previewTimer;
+    std::vector<PresetItem> m_presets;
+
+    void refreshSelectedBandEditor();
+};
+
+class EqualiserSettingsProvider : public DspSettingsProvider
+{
+public:
+    [[nodiscard]] QString id() const override;
+    DspSettingsDialog* createSettingsWidget(QWidget* parent) override;
+};
+} // namespace Equaliser
+} // namespace Fooyin

--- a/src/plugins/equaliser/supereq/LGPL.txt
+++ b/src/plugins/equaliser/supereq/LGPL.txt
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/src/plugins/equaliser/supereq/fft.h
+++ b/src/plugins/equaliser/supereq/fft.h
@@ -1,0 +1,2564 @@
+/******************************************************
+SuperEQ written by Naoki Shibata  shibatch@users.sourceforge.net
+
+Shibatch Super Equalizer is a graphic and parametric equalizer plugin
+for winamp. This plugin uses 16383th order FIR filter with FFT algorithm.
+It's equalization is very precise. Equalization setting can be done
+for each channel separately.
+
+
+Homepage : http://shibatch.sourceforge.net/
+e-mail   : shibatch@users.sourceforge.net
+
+Some changes are from foobar2000 (www.foobar2000.org):
+
+Copyright (c) 2001-2003, Peter Pawlowski
+All rights reserved.
+
+Other changes are:
+
+Copyright © 2026, Luke Taylor <luket@pm.me>
+*******************************************************/
+
+#ifndef _DSP_MATH_SHARED_H_
+#define _DSP_MATH_SHARED_H_
+
+#include <cmath>
+
+#define PI 3.1415926535897932384626433832795
+
+template <class REAL>
+class fft
+{
+public:
+    /*
+    Fast Fourier/Cosine/Sine Transform
+        dimension   :one
+        data length :power of 2
+        decimation  :frequency
+        radix       :split-radix
+        data        :inplace
+        table       :use
+    functions
+        cdft: Complex Discrete Fourier Transform
+        rdft: Real Discrete Fourier Transform
+        ddct: Discrete Cosine Transform
+        ddst: Discrete Sine Transform
+        dfct: Cosine Transform of RDFT (Real Symmetric DFT)
+        dfst: Sine Transform of RDFT (Real Anti-symmetric DFT)
+    function prototypes
+        void cdft(int, int, REAL *, int *, REAL *);
+        void rdft(int, int, REAL *, int *, REAL *);
+        void ddct(int, int, REAL *, int *, REAL *);
+        void ddst(int, int, REAL *, int *, REAL *);
+        void dfct(int, REAL *, REAL *, int *, REAL *);
+        void dfst(int, REAL *, REAL *, int *, REAL *);
+
+
+    -------- Complex DFT (Discrete Fourier Transform) --------
+        [definition]
+            <case1>
+                X[k] = sum_j=0^n-1 x[j]*exp(2*pi*i*j*k/n), 0<=k<n
+            <case2>
+                X[k] = sum_j=0^n-1 x[j]*exp(-2*pi*i*j*k/n), 0<=k<n
+            (notes: sum_j=0^n-1 is a summation from j=0 to n-1)
+        [usage]
+            <case1>
+                ip[0] = 0; // first time only
+                cdft(2*n, 1, a, ip, w);
+            <case2>
+                ip[0] = 0; // first time only
+                cdft(2*n, -1, a, ip, w);
+        [parameters]
+            2*n            :data length (int)
+                            n >= 1, n = power of 2
+            a[0...2*n-1]   :input/output data (REAL *)
+                            input data
+                                a[2*j] = Re(x[j]),
+                                a[2*j+1] = Im(x[j]), 0<=j<n
+                            output data
+                                a[2*k] = Re(X[k]),
+                                a[2*k+1] = Im(X[k]), 0<=k<n
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n/2-1]   :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                cdft(2*n, -1, a, ip, w);
+            is
+                cdft(2*n, 1, a, ip, w);
+                for (j = 0; j <= 2 * n - 1; j++) {
+                    a[j] *= 1.0 / n;
+                }
+            .
+
+
+    -------- Real DFT / Inverse of Real DFT --------
+        [definition]
+            <case1> RDFT
+                R[k] = sum_j=0^n-1 a[j]*cos(2*pi*j*k/n), 0<=k<=n/2
+                I[k] = sum_j=0^n-1 a[j]*sin(2*pi*j*k/n), 0<k<n/2
+            <case2> IRDFT (excluding scale)
+                a[k] = (R[0] + R[n/2]*cos(pi*k))/2 +
+                       sum_j=1^n/2-1 R[j]*cos(2*pi*j*k/n) +
+                       sum_j=1^n/2-1 I[j]*sin(2*pi*j*k/n), 0<=k<n
+        [usage]
+            <case1>
+                ip[0] = 0; // first time only
+                rdft(n, 1, a, ip, w);
+            <case2>
+                ip[0] = 0; // first time only
+                rdft(n, -1, a, ip, w);
+        [parameters]
+            n              :data length (int)
+                            n >= 2, n = power of 2
+            a[0...n-1]     :input/output data (REAL *)
+                            <case1>
+                                output data
+                                    a[2*k] = R[k], 0<=k<n/2
+                                    a[2*k+1] = I[k], 0<k<n/2
+                                    a[1] = R[n/2]
+                            <case2>
+                                input data
+                                    a[2*j] = R[j], 0<=j<n/2
+                                    a[2*j+1] = I[j], 0<j<n/2
+                                    a[1] = R[n/2]
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n/2)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n/2+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n/2-1]   :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                rdft(n, 1, a, ip, w);
+            is
+                rdft(n, -1, a, ip, w);
+                for (j = 0; j <= n - 1; j++) {
+                    a[j] *= 2.0 / n;
+                }
+            .
+
+
+    -------- DCT (Discrete Cosine Transform) / Inverse of DCT --------
+        [definition]
+            <case1> IDCT (excluding scale)
+                C[k] = sum_j=0^n-1 a[j]*cos(pi*j*(k+1/2)/n), 0<=k<n
+            <case2> DCT
+                C[k] = sum_j=0^n-1 a[j]*cos(pi*(j+1/2)*k/n), 0<=k<n
+        [usage]
+            <case1>
+                ip[0] = 0; // first time only
+                ddct(n, 1, a, ip, w);
+            <case2>
+                ip[0] = 0; // first time only
+                ddct(n, -1, a, ip, w);
+        [parameters]
+            n              :data length (int)
+                            n >= 2, n = power of 2
+            a[0...n-1]     :input/output data (REAL *)
+                            output data
+                                a[k] = C[k], 0<=k<n
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n/2)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n/2+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n*5/4-1] :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                ddct(n, -1, a, ip, w);
+            is
+                a[0] *= 0.5;
+                ddct(n, 1, a, ip, w);
+                for (j = 0; j <= n - 1; j++) {
+                    a[j] *= 2.0 / n;
+                }
+            .
+
+
+    -------- DST (Discrete Sine Transform) / Inverse of DST --------
+        [definition]
+            <case1> IDST (excluding scale)
+                S[k] = sum_j=1^n A[j]*sin(pi*j*(k+1/2)/n), 0<=k<n
+            <case2> DST
+                S[k] = sum_j=0^n-1 a[j]*sin(pi*(j+1/2)*k/n), 0<k<=n
+        [usage]
+            <case1>
+                ip[0] = 0; // first time only
+                ddst(n, 1, a, ip, w);
+            <case2>
+                ip[0] = 0; // first time only
+                ddst(n, -1, a, ip, w);
+        [parameters]
+            n              :data length (int)
+                            n >= 2, n = power of 2
+            a[0...n-1]     :input/output data (REAL *)
+                            <case1>
+                                input data
+                                    a[j] = A[j], 0<j<n
+                                    a[0] = A[n]
+                                output data
+                                    a[k] = S[k], 0<=k<n
+                            <case2>
+                                output data
+                                    a[k] = S[k], 0<k<n
+                                    a[0] = S[n]
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n/2)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n/2+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n*5/4-1] :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                ddst(n, -1, a, ip, w);
+            is
+                a[0] *= 0.5;
+                ddst(n, 1, a, ip, w);
+                for (j = 0; j <= n - 1; j++) {
+                    a[j] *= 2.0 / n;
+                }
+            .
+
+
+    -------- Cosine Transform of RDFT (Real Symmetric DFT) --------
+        [definition]
+            C[k] = sum_j=0^n a[j]*cos(pi*j*k/n), 0<=k<=n
+        [usage]
+            ip[0] = 0; // first time only
+            dfct(n, a, t, ip, w);
+        [parameters]
+            n              :data length - 1 (int)
+                            n >= 2, n = power of 2
+            a[0...n]       :input/output data (REAL *)
+                            output data
+                                a[k] = C[k], 0<=k<=n
+            t[0...n/2]     :work area (REAL *)
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n/4)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n/4+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n*5/8-1] :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                a[0] *= 0.5;
+                a[n] *= 0.5;
+                dfct(n, a, t, ip, w);
+            is
+                a[0] *= 0.5;
+                a[n] *= 0.5;
+                dfct(n, a, t, ip, w);
+                for (j = 0; j <= n; j++) {
+                    a[j] *= 2.0 / n;
+                }
+            .
+
+
+    -------- Sine Transform of RDFT (Real Anti-symmetric DFT) --------
+        [definition]
+            S[k] = sum_j=1^n-1 a[j]*sin(pi*j*k/n), 0<k<n
+        [usage]
+            ip[0] = 0; // first time only
+            dfst(n, a, t, ip, w);
+        [parameters]
+            n              :data length + 1 (int)
+                            n >= 2, n = power of 2
+            a[0...n-1]     :input/output data (REAL *)
+                            output data
+                                a[k] = S[k], 0<k<n
+                            (a[0] is used for work area)
+            t[0...n/2-1]   :work area (REAL *)
+            ip[0...*]      :work area for bit reversal (int *)
+                            length of ip >= 2+sqrt(n/4)
+                            strictly,
+                            length of ip >=
+                                2+(1<<(int)(log(n/4+0.5)/log(2))/2).
+                            ip[0],ip[1] are pointers of the cos/sin table.
+            w[0...n*5/8-1] :cos/sin table (REAL *)
+                            w[],ip[] are initialized if ip[0] == 0.
+        [remark]
+            Inverse of
+                dfst(n, a, t, ip, w);
+            is
+                dfst(n, a, t, ip, w);
+                for (j = 1; j <= n - 1; j++) {
+                    a[j] *= 2.0 / n;
+                }
+            .
+
+
+    Appendix :
+        The cos/sin table is recalculated when the larger table required.
+        w[] and ip[] are compatible with all routines.
+    */
+
+    static void cdft(int n, int isgn, REAL* a, int* ip, REAL* w)
+    {
+        int nw;
+
+        nw = ip[0];
+        if(n > (nw << 2)) {
+            nw = n >> 2;
+            makewt(nw, ip, w);
+        }
+        if(isgn >= 0) {
+            cftfsub(n, a, ip + 2, nw, w);
+        }
+        else {
+            cftbsub(n, a, ip + 2, nw, w);
+        }
+    }
+
+    static void rdft(int n, int isgn, REAL* a, int* ip, REAL* w)
+    {
+        int nw, nc;
+        REAL xi;
+
+        nw = ip[0];
+        if(n > (nw << 2)) {
+            nw = n >> 2;
+            makewt(nw, ip, w);
+        }
+        nc = ip[1];
+        if(n > (nc << 2)) {
+            nc = n >> 2;
+            makect(nc, ip, w + nw);
+        }
+        if(isgn >= 0) {
+            if(n > 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+                rftfsub(n, a, nc, w + nw);
+            }
+            else if(n == 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+            }
+            xi = a[0] - a[1];
+            a[0] += a[1];
+            a[1] = xi;
+        }
+        else {
+            a[1] = 0.5 * (a[0] - a[1]);
+            a[0] -= a[1];
+            if(n > 4) {
+                rftbsub(n, a, nc, w + nw);
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+            else if(n == 4) {
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+        }
+    }
+
+    static void ddct(int n, int isgn, REAL* a, int* ip, REAL* w)
+    {
+        int j, nw, nc;
+        REAL xr;
+
+        nw = ip[0];
+        if(n > (nw << 2)) {
+            nw = n >> 2;
+            makewt(nw, ip, w);
+        }
+        nc = ip[1];
+        if(n > nc) {
+            nc = n;
+            makect(nc, ip, w + nw);
+        }
+        if(isgn < 0) {
+            xr = a[n - 1];
+            for(j = n - 2; j >= 2; j -= 2) {
+                a[j + 1] = a[j] - a[j - 1];
+                a[j] += a[j - 1];
+            }
+            a[1] = a[0] - xr;
+            a[0] += xr;
+            if(n > 4) {
+                rftbsub(n, a, nc, w + nw);
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+            else if(n == 4) {
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+        }
+        dctsub(n, a, nc, w + nw);
+        if(isgn >= 0) {
+            if(n > 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+                rftfsub(n, a, nc, w + nw);
+            }
+            else if(n == 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+            }
+            xr = a[0] - a[1];
+            a[0] += a[1];
+            for(j = 2; j < n; j += 2) {
+                a[j - 1] = a[j] - a[j + 1];
+                a[j] += a[j + 1];
+            }
+            a[n - 1] = xr;
+        }
+    }
+
+    static void ddst(int n, int isgn, REAL* a, int* ip, REAL* w)
+    {
+        int j, nw, nc;
+        REAL xr;
+
+        nw = ip[0];
+        if(n > (nw << 2)) {
+            nw = n >> 2;
+            makewt(nw, ip, w);
+        }
+        nc = ip[1];
+        if(n > nc) {
+            nc = n;
+            makect(nc, ip, w + nw);
+        }
+        if(isgn < 0) {
+            xr = a[n - 1];
+            for(j = n - 2; j >= 2; j -= 2) {
+                a[j + 1] = -a[j] - a[j - 1];
+                a[j] -= a[j - 1];
+            }
+            a[1] = a[0] + xr;
+            a[0] -= xr;
+            if(n > 4) {
+                rftbsub(n, a, nc, w + nw);
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+            else if(n == 4) {
+                cftbsub(n, a, ip + 2, nw, w);
+            }
+        }
+        dstsub(n, a, nc, w + nw);
+        if(isgn >= 0) {
+            if(n > 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+                rftfsub(n, a, nc, w + nw);
+            }
+            else if(n == 4) {
+                cftfsub(n, a, ip + 2, nw, w);
+            }
+            xr = a[0] - a[1];
+            a[0] += a[1];
+            for(j = 2; j < n; j += 2) {
+                a[j - 1] = -a[j] - a[j + 1];
+                a[j] -= a[j + 1];
+            }
+            a[n - 1] = -xr;
+        }
+    }
+
+    static void dfct(int n, REAL* a, REAL* t, int* ip, REAL* w)
+    {
+        int j, k, l, m, mh, nw, nc;
+        REAL xr, xi, yr, yi;
+
+        nw = ip[0];
+        if(n > (nw << 3)) {
+            nw = n >> 3;
+            makewt(nw, ip, w);
+        }
+        nc = ip[1];
+        if(n > (nc << 1)) {
+            nc = n >> 1;
+            makect(nc, ip, w + nw);
+        }
+        m  = n >> 1;
+        yi = a[m];
+        xi = a[0] + a[n];
+        a[0] -= a[n];
+        t[0] = xi - yi;
+        t[m] = xi + yi;
+        if(n > 2) {
+            mh = m >> 1;
+            for(j = 1; j < mh; j++) {
+                k    = m - j;
+                xr   = a[j] - a[n - j];
+                xi   = a[j] + a[n - j];
+                yr   = a[k] - a[n - k];
+                yi   = a[k] + a[n - k];
+                a[j] = xr;
+                a[k] = yr;
+                t[j] = xi - yi;
+                t[k] = xi + yi;
+            }
+            t[mh] = a[mh] + a[n - mh];
+            a[mh] -= a[n - mh];
+            dctsub(m, a, nc, w + nw);
+            if(m > 4) {
+                cftfsub(m, a, ip + 2, nw, w);
+                rftfsub(m, a, nc, w + nw);
+            }
+            else if(m == 4) {
+                cftfsub(m, a, ip + 2, nw, w);
+            }
+            a[n - 1] = a[0] - a[1];
+            a[1]     = a[0] + a[1];
+            for(j = m - 2; j >= 2; j -= 2) {
+                a[2 * j + 1] = a[j] + a[j + 1];
+                a[2 * j - 1] = a[j] - a[j + 1];
+            }
+            l = 2;
+            m = mh;
+            while(m >= 2) {
+                dctsub(m, t, nc, w + nw);
+                if(m > 4) {
+                    cftfsub(m, t, ip + 2, nw, w);
+                    rftfsub(m, t, nc, w + nw);
+                }
+                else if(m == 4) {
+                    cftfsub(m, t, ip + 2, nw, w);
+                }
+                a[n - l] = t[0] - t[1];
+                a[l]     = t[0] + t[1];
+                k        = 0;
+                for(j = 2; j < m; j += 2) {
+                    k += l << 2;
+                    a[k - l] = t[j] - t[j + 1];
+                    a[k + l] = t[j] + t[j + 1];
+                }
+                l <<= 1;
+                mh = m >> 1;
+                for(j = 0; j < mh; j++) {
+                    k    = m - j;
+                    t[j] = t[m + k] - t[m + j];
+                    t[k] = t[m + k] + t[m + j];
+                }
+                t[mh] = t[m + mh];
+                m     = mh;
+            }
+            a[l] = t[0];
+            a[n] = t[2] - t[1];
+            a[0] = t[2] + t[1];
+        }
+        else {
+            a[1] = a[0];
+            a[2] = t[0];
+            a[0] = t[1];
+        }
+    }
+
+    static void dfst(int n, REAL* a, REAL* t, int* ip, REAL* w)
+    {
+        int j, k, l, m, mh, nw, nc;
+        REAL xr, xi, yr, yi;
+
+        nw = ip[0];
+        if(n > (nw << 3)) {
+            nw = n >> 3;
+            makewt(nw, ip, w);
+        }
+        nc = ip[1];
+        if(n > (nc << 1)) {
+            nc = n >> 1;
+            makect(nc, ip, w + nw);
+        }
+        if(n > 2) {
+            m  = n >> 1;
+            mh = m >> 1;
+            for(j = 1; j < mh; j++) {
+                k    = m - j;
+                xr   = a[j] + a[n - j];
+                xi   = a[j] - a[n - j];
+                yr   = a[k] + a[n - k];
+                yi   = a[k] - a[n - k];
+                a[j] = xr;
+                a[k] = yr;
+                t[j] = xi + yi;
+                t[k] = xi - yi;
+            }
+            t[0] = a[mh] - a[n - mh];
+            a[mh] += a[n - mh];
+            a[0] = a[m];
+            dstsub(m, a, nc, w + nw);
+            if(m > 4) {
+                cftfsub(m, a, ip + 2, nw, w);
+                rftfsub(m, a, nc, w + nw);
+            }
+            else if(m == 4) {
+                cftfsub(m, a, ip + 2, nw, w);
+            }
+            a[n - 1] = a[1] - a[0];
+            a[1]     = a[0] + a[1];
+            for(j = m - 2; j >= 2; j -= 2) {
+                a[2 * j + 1] = a[j] - a[j + 1];
+                a[2 * j - 1] = -a[j] - a[j + 1];
+            }
+            l = 2;
+            m = mh;
+            while(m >= 2) {
+                dstsub(m, t, nc, w + nw);
+                if(m > 4) {
+                    cftfsub(m, t, ip + 2, nw, w);
+                    rftfsub(m, t, nc, w + nw);
+                }
+                else if(m == 4) {
+                    cftfsub(m, t, ip + 2, nw, w);
+                }
+                a[n - l] = t[1] - t[0];
+                a[l]     = t[0] + t[1];
+                k        = 0;
+                for(j = 2; j < m; j += 2) {
+                    k += l << 2;
+                    a[k - l] = -t[j] - t[j + 1];
+                    a[k + l] = t[j] - t[j + 1];
+                }
+                l <<= 1;
+                mh = m >> 1;
+                for(j = 1; j < mh; j++) {
+                    k    = m - j;
+                    t[j] = t[m + k] + t[m + j];
+                    t[k] = t[m + k] - t[m + j];
+                }
+                t[0] = t[m + mh];
+                m    = mh;
+            }
+            a[l] = t[0];
+        }
+        a[0] = 0;
+    }
+
+    static void makewt(int nw, int* ip, REAL* w)
+    {
+        int j, nwh, nw0, nw1;
+        REAL delta, wn4r, wk1r, wk1i, wk3r, wk3i;
+
+        ip[0] = nw;
+        ip[1] = 1;
+        if(nw > 2) {
+            nwh   = nw >> 1;
+            delta = atan(1.0) / nwh;
+            wn4r  = cos(delta * nwh);
+            w[0]  = 1;
+            w[1]  = wn4r;
+            if(nwh >= 4) {
+                w[2] = 0.5 / cos(delta * 2);
+                w[3] = 0.5 / cos(delta * 6);
+            }
+            for(j = 4; j < nwh; j += 4) {
+                w[j]     = cos(delta * j);
+                w[j + 1] = sin(delta * j);
+                w[j + 2] = cos(3 * delta * j);
+                w[j + 3] = sin(3 * delta * j);
+            }
+            nw0 = 0;
+            while(nwh > 2) {
+                nw1 = nw0 + nwh;
+                nwh >>= 1;
+                w[nw1]     = 1;
+                w[nw1 + 1] = wn4r;
+                if(nwh >= 4) {
+                    wk1r       = w[nw0 + 4];
+                    wk3r       = w[nw0 + 6];
+                    w[nw1 + 2] = 0.5 / wk1r;
+                    w[nw1 + 3] = 0.5 / wk3r;
+                }
+                for(j = 4; j < nwh; j += 4) {
+                    wk1r           = w[nw0 + 2 * j];
+                    wk1i           = w[nw0 + 2 * j + 1];
+                    wk3r           = w[nw0 + 2 * j + 2];
+                    wk3i           = w[nw0 + 2 * j + 3];
+                    w[nw1 + j]     = wk1r;
+                    w[nw1 + j + 1] = wk1i;
+                    w[nw1 + j + 2] = wk3r;
+                    w[nw1 + j + 3] = wk3i;
+                }
+                nw0 = nw1;
+            }
+        }
+    }
+
+    static void makect(int nc, int* ip, REAL* c)
+    {
+        int j, nch;
+        REAL delta;
+
+        ip[1] = nc;
+        if(nc > 1) {
+            nch    = nc >> 1;
+            delta  = atan(1.0) / nch;
+            c[0]   = cos(delta * nch);
+            c[nch] = 0.5 * c[0];
+            for(j = 1; j < nch; j++) {
+                c[j]      = 0.5 * cos(delta * j);
+                c[nc - j] = 0.5 * sin(delta * j);
+            }
+        }
+    }
+
+    /* -------- child routines -------- */
+
+#ifndef CDFT_RECURSIVE_N     /* length of the recursive FFT mode */
+#define CDFT_RECURSIVE_N 512 /* <= (L1 cache size) / 16 */
+#endif
+
+    static void cftfsub(int n, REAL* a, int* ip, int nw, REAL* w)
+    {
+        int m;
+
+        if(n > 32) {
+            m = n >> 2;
+            cftf1st(n, a, &w[nw - m]);
+            if(n > CDFT_RECURSIVE_N) {
+                cftrec1(m, a, nw, w);
+                cftrec2(m, &a[m], nw, w);
+                cftrec1(m, &a[2 * m], nw, w);
+                cftrec1(m, &a[3 * m], nw, w);
+            }
+            else if(m > 32) {
+                cftexp1(n, a, nw, w);
+            }
+            else {
+                cftfx41(n, a, nw, w);
+            }
+            bitrv2(n, ip, a);
+        }
+        else if(n > 8) {
+            if(n == 32) {
+                cftf161(a, &w[nw - 8]);
+                bitrv216(a);
+            }
+            else {
+                cftf081(a, w);
+                bitrv208(a);
+            }
+        }
+        else if(n == 8) {
+            cftf040(a);
+        }
+        else if(n == 4) {
+            cftx020(a);
+        }
+    }
+
+    static void cftbsub(int n, REAL* a, int* ip, int nw, REAL* w)
+    {
+        int m;
+
+        if(n > 32) {
+            m = n >> 2;
+            cftb1st(n, a, &w[nw - m]);
+            if(n > CDFT_RECURSIVE_N) {
+                cftrec1(m, a, nw, w);
+                cftrec2(m, &a[m], nw, w);
+                cftrec1(m, &a[2 * m], nw, w);
+                cftrec1(m, &a[3 * m], nw, w);
+            }
+            else if(m > 32) {
+                cftexp1(n, a, nw, w);
+            }
+            else {
+                cftfx41(n, a, nw, w);
+            }
+            bitrv2conj(n, ip, a);
+        }
+        else if(n > 8) {
+            if(n == 32) {
+                cftf161(a, &w[nw - 8]);
+                bitrv216neg(a);
+            }
+            else {
+                cftf081(a, w);
+                bitrv208neg(a);
+            }
+        }
+        else if(n == 8) {
+            cftb040(a);
+        }
+        else if(n == 4) {
+            cftx020(a);
+        }
+    }
+
+    static void bitrv2(int n, int* ip, REAL* a)
+    {
+        int j, j1, k, k1, l, m, m2;
+        REAL xr, xi, yr, yi;
+
+        ip[0] = 0;
+        l     = n;
+        m     = 1;
+        while((m << 3) < l) {
+            l >>= 1;
+            for(j = 0; j < m; j++) {
+                ip[m + j] = ip[j] + l;
+            }
+            m <<= 1;
+        }
+        m2 = 2 * m;
+        if((m << 3) == l) {
+            for(k = 0; k < m; k++) {
+                for(j = 0; j < k; j++) {
+                    j1        = 2 * j + ip[k];
+                    k1        = 2 * k + ip[j];
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += 2 * m2;
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 -= m2;
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += 2 * m2;
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                }
+                j1        = 2 * k + m2 + ip[k];
+                k1        = j1 + m2;
+                xr        = a[j1];
+                xi        = a[j1 + 1];
+                yr        = a[k1];
+                yi        = a[k1 + 1];
+                a[j1]     = yr;
+                a[j1 + 1] = yi;
+                a[k1]     = xr;
+                a[k1 + 1] = xi;
+            }
+        }
+        else {
+            for(k = 1; k < m; k++) {
+                for(j = 0; j < k; j++) {
+                    j1        = 2 * j + ip[k];
+                    k1        = 2 * k + ip[j];
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += m2;
+                    xr        = a[j1];
+                    xi        = a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                }
+            }
+        }
+    }
+
+    static void bitrv2conj(int n, int* ip, REAL* a)
+    {
+        int j, j1, k, k1, l, m, m2;
+        REAL xr, xi, yr, yi;
+
+        ip[0] = 0;
+        l     = n;
+        m     = 1;
+        while((m << 3) < l) {
+            l >>= 1;
+            for(j = 0; j < m; j++) {
+                ip[m + j] = ip[j] + l;
+            }
+            m <<= 1;
+        }
+        m2 = 2 * m;
+        if((m << 3) == l) {
+            for(k = 0; k < m; k++) {
+                for(j = 0; j < k; j++) {
+                    j1        = 2 * j + ip[k];
+                    k1        = 2 * k + ip[j];
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += 2 * m2;
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 -= m2;
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += 2 * m2;
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                }
+                k1        = 2 * k + ip[k];
+                a[k1 + 1] = -a[k1 + 1];
+                j1        = k1 + m2;
+                k1        = j1 + m2;
+                xr        = a[j1];
+                xi        = -a[j1 + 1];
+                yr        = a[k1];
+                yi        = -a[k1 + 1];
+                a[j1]     = yr;
+                a[j1 + 1] = yi;
+                a[k1]     = xr;
+                a[k1 + 1] = xi;
+                k1 += m2;
+                a[k1 + 1] = -a[k1 + 1];
+            }
+        }
+        else {
+            a[1]      = -a[1];
+            a[m2 + 1] = -a[m2 + 1];
+            for(k = 1; k < m; k++) {
+                for(j = 0; j < k; j++) {
+                    j1        = 2 * j + ip[k];
+                    k1        = 2 * k + ip[j];
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                    j1 += m2;
+                    k1 += m2;
+                    xr        = a[j1];
+                    xi        = -a[j1 + 1];
+                    yr        = a[k1];
+                    yi        = -a[k1 + 1];
+                    a[j1]     = yr;
+                    a[j1 + 1] = yi;
+                    a[k1]     = xr;
+                    a[k1 + 1] = xi;
+                }
+                k1             = 2 * k + ip[k];
+                a[k1 + 1]      = -a[k1 + 1];
+                a[k1 + m2 + 1] = -a[k1 + m2 + 1];
+            }
+        }
+    }
+
+    static void bitrv216(REAL* a)
+    {
+        REAL x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x7r, x7i, x8r, x8i, x10r, x10i, x11r, x11i, x12r, x12i,
+            x13r, x13i, x14r, x14i;
+
+        x1r   = a[2];
+        x1i   = a[3];
+        x2r   = a[4];
+        x2i   = a[5];
+        x3r   = a[6];
+        x3i   = a[7];
+        x4r   = a[8];
+        x4i   = a[9];
+        x5r   = a[10];
+        x5i   = a[11];
+        x7r   = a[14];
+        x7i   = a[15];
+        x8r   = a[16];
+        x8i   = a[17];
+        x10r  = a[20];
+        x10i  = a[21];
+        x11r  = a[22];
+        x11i  = a[23];
+        x12r  = a[24];
+        x12i  = a[25];
+        x13r  = a[26];
+        x13i  = a[27];
+        x14r  = a[28];
+        x14i  = a[29];
+        a[2]  = x8r;
+        a[3]  = x8i;
+        a[4]  = x4r;
+        a[5]  = x4i;
+        a[6]  = x12r;
+        a[7]  = x12i;
+        a[8]  = x2r;
+        a[9]  = x2i;
+        a[10] = x10r;
+        a[11] = x10i;
+        a[14] = x14r;
+        a[15] = x14i;
+        a[16] = x1r;
+        a[17] = x1i;
+        a[20] = x5r;
+        a[21] = x5i;
+        a[22] = x13r;
+        a[23] = x13i;
+        a[24] = x3r;
+        a[25] = x3i;
+        a[26] = x11r;
+        a[27] = x11i;
+        a[28] = x7r;
+        a[29] = x7i;
+    }
+
+    static void bitrv216neg(REAL* a)
+    {
+        REAL x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x6r, x6i, x7r, x7i, x8r, x8i, x9r, x9i, x10r, x10i, x11r,
+            x11i, x12r, x12i, x13r, x13i, x14r, x14i, x15r, x15i;
+
+        x1r   = a[2];
+        x1i   = a[3];
+        x2r   = a[4];
+        x2i   = a[5];
+        x3r   = a[6];
+        x3i   = a[7];
+        x4r   = a[8];
+        x4i   = a[9];
+        x5r   = a[10];
+        x5i   = a[11];
+        x6r   = a[12];
+        x6i   = a[13];
+        x7r   = a[14];
+        x7i   = a[15];
+        x8r   = a[16];
+        x8i   = a[17];
+        x9r   = a[18];
+        x9i   = a[19];
+        x10r  = a[20];
+        x10i  = a[21];
+        x11r  = a[22];
+        x11i  = a[23];
+        x12r  = a[24];
+        x12i  = a[25];
+        x13r  = a[26];
+        x13i  = a[27];
+        x14r  = a[28];
+        x14i  = a[29];
+        x15r  = a[30];
+        x15i  = a[31];
+        a[2]  = x15r;
+        a[3]  = x15i;
+        a[4]  = x7r;
+        a[5]  = x7i;
+        a[6]  = x11r;
+        a[7]  = x11i;
+        a[8]  = x3r;
+        a[9]  = x3i;
+        a[10] = x13r;
+        a[11] = x13i;
+        a[12] = x5r;
+        a[13] = x5i;
+        a[14] = x9r;
+        a[15] = x9i;
+        a[16] = x1r;
+        a[17] = x1i;
+        a[18] = x14r;
+        a[19] = x14i;
+        a[20] = x6r;
+        a[21] = x6i;
+        a[22] = x10r;
+        a[23] = x10i;
+        a[24] = x2r;
+        a[25] = x2i;
+        a[26] = x12r;
+        a[27] = x12i;
+        a[28] = x4r;
+        a[29] = x4i;
+        a[30] = x8r;
+        a[31] = x8i;
+    }
+
+    static void bitrv208(REAL* a)
+    {
+        REAL x1r, x1i, x3r, x3i, x4r, x4i, x6r, x6i;
+
+        x1r   = a[2];
+        x1i   = a[3];
+        x3r   = a[6];
+        x3i   = a[7];
+        x4r   = a[8];
+        x4i   = a[9];
+        x6r   = a[12];
+        x6i   = a[13];
+        a[2]  = x4r;
+        a[3]  = x4i;
+        a[6]  = x6r;
+        a[7]  = x6i;
+        a[8]  = x1r;
+        a[9]  = x1i;
+        a[12] = x3r;
+        a[13] = x3i;
+    }
+
+    static void bitrv208neg(REAL* a)
+    {
+        REAL x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x6r, x6i, x7r, x7i;
+
+        x1r   = a[2];
+        x1i   = a[3];
+        x2r   = a[4];
+        x2i   = a[5];
+        x3r   = a[6];
+        x3i   = a[7];
+        x4r   = a[8];
+        x4i   = a[9];
+        x5r   = a[10];
+        x5i   = a[11];
+        x6r   = a[12];
+        x6i   = a[13];
+        x7r   = a[14];
+        x7i   = a[15];
+        a[2]  = x7r;
+        a[3]  = x7i;
+        a[4]  = x3r;
+        a[5]  = x3i;
+        a[6]  = x5r;
+        a[7]  = x5i;
+        a[8]  = x1r;
+        a[9]  = x1i;
+        a[10] = x6r;
+        a[11] = x6i;
+        a[12] = x2r;
+        a[13] = x2i;
+        a[14] = x4r;
+        a[15] = x4i;
+    }
+
+    static void cftf1st(int n, REAL* a, REAL* w)
+    {
+        int j, j0, j1, j2, j3, k, m, mh;
+        REAL wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i;
+
+        mh        = n >> 3;
+        m         = 2 * mh;
+        j1        = m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[0] + a[j2];
+        x0i       = a[1] + a[j2 + 1];
+        x1r       = a[0] - a[j2];
+        x1i       = a[1] - a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[0]      = x0r + x2r;
+        a[1]      = x0i + x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i - x2i;
+        a[j2]     = x1r - x3i;
+        a[j2 + 1] = x1i + x3r;
+        a[j3]     = x1r + x3i;
+        a[j3 + 1] = x1i - x3r;
+        wn4r      = w[1];
+        csc1      = w[2];
+        csc3      = w[3];
+        wd1r      = 1;
+        wd1i      = 0;
+        wd3r      = 1;
+        wd3i      = 0;
+        k         = 0;
+        for(j = 2; j < mh - 2; j += 4) {
+            k += 4;
+            wk1r      = csc1 * (wd1r + w[k]);
+            wk1i      = csc1 * (wd1i + w[k + 1]);
+            wk3r      = csc3 * (wd3r + w[k + 2]);
+            wk3i      = csc3 * (wd3i - w[k + 3]);
+            wd1r      = w[k];
+            wd1i      = w[k + 1];
+            wd3r      = w[k + 2];
+            wd3i      = -w[k + 3];
+            j1        = j + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j] + a[j2];
+            x0i       = a[j + 1] + a[j2 + 1];
+            x1r       = a[j] - a[j2];
+            x1i       = a[j + 1] - a[j2 + 1];
+            y0r       = a[j + 2] + a[j2 + 2];
+            y0i       = a[j + 3] + a[j2 + 3];
+            y1r       = a[j + 2] - a[j2 + 2];
+            y1i       = a[j + 3] - a[j2 + 3];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            y2r       = a[j1 + 2] + a[j3 + 2];
+            y2i       = a[j1 + 3] + a[j3 + 3];
+            y3r       = a[j1 + 2] - a[j3 + 2];
+            y3i       = a[j1 + 3] - a[j3 + 3];
+            a[j]      = x0r + x2r;
+            a[j + 1]  = x0i + x2i;
+            a[j + 2]  = y0r + y2r;
+            a[j + 3]  = y0i + y2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i - x2i;
+            a[j1 + 2] = y0r - y2r;
+            a[j1 + 3] = y0i - y2i;
+            x0r       = x1r - x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1r * x0r - wk1i * x0i;
+            a[j2 + 1] = wk1r * x0i + wk1i * x0r;
+            x0r       = y1r - y3i;
+            x0i       = y1i + y3r;
+            a[j2 + 2] = wd1r * x0r - wd1i * x0i;
+            a[j2 + 3] = wd1r * x0i + wd1i * x0r;
+            x0r       = x1r + x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3r * x0r + wk3i * x0i;
+            a[j3 + 1] = wk3r * x0i - wk3i * x0r;
+            x0r       = y1r + y3i;
+            x0i       = y1i - y3r;
+            a[j3 + 2] = wd3r * x0r + wd3i * x0i;
+            a[j3 + 3] = wd3r * x0i - wd3i * x0r;
+            j0        = m - j;
+            j1        = j0 + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j0] + a[j2];
+            x0i       = a[j0 + 1] + a[j2 + 1];
+            x1r       = a[j0] - a[j2];
+            x1i       = a[j0 + 1] - a[j2 + 1];
+            y0r       = a[j0 - 2] + a[j2 - 2];
+            y0i       = a[j0 - 1] + a[j2 - 1];
+            y1r       = a[j0 - 2] - a[j2 - 2];
+            y1i       = a[j0 - 1] - a[j2 - 1];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            y2r       = a[j1 - 2] + a[j3 - 2];
+            y2i       = a[j1 - 1] + a[j3 - 1];
+            y3r       = a[j1 - 2] - a[j3 - 2];
+            y3i       = a[j1 - 1] - a[j3 - 1];
+            a[j0]     = x0r + x2r;
+            a[j0 + 1] = x0i + x2i;
+            a[j0 - 2] = y0r + y2r;
+            a[j0 - 1] = y0i + y2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i - x2i;
+            a[j1 - 2] = y0r - y2r;
+            a[j1 - 1] = y0i - y2i;
+            x0r       = x1r - x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1i * x0r - wk1r * x0i;
+            a[j2 + 1] = wk1i * x0i + wk1r * x0r;
+            x0r       = y1r - y3i;
+            x0i       = y1i + y3r;
+            a[j2 - 2] = wd1i * x0r - wd1r * x0i;
+            a[j2 - 1] = wd1i * x0i + wd1r * x0r;
+            x0r       = x1r + x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3i * x0r + wk3r * x0i;
+            a[j3 + 1] = wk3i * x0i - wk3r * x0r;
+            x0r       = y1r + y3i;
+            x0i       = y1i - y3r;
+            a[j3 - 2] = wd3i * x0r + wd3r * x0i;
+            a[j3 - 1] = wd3i * x0i - wd3r * x0r;
+        }
+        wk1r      = csc1 * (wd1r + wn4r);
+        wk1i      = csc1 * (wd1i + wn4r);
+        wk3r      = csc3 * (wd3r - wn4r);
+        wk3i      = csc3 * (wd3i - wn4r);
+        j0        = mh;
+        j1        = j0 + m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[j0 - 2] + a[j2 - 2];
+        x0i       = a[j0 - 1] + a[j2 - 1];
+        x1r       = a[j0 - 2] - a[j2 - 2];
+        x1i       = a[j0 - 1] - a[j2 - 1];
+        x2r       = a[j1 - 2] + a[j3 - 2];
+        x2i       = a[j1 - 1] + a[j3 - 1];
+        x3r       = a[j1 - 2] - a[j3 - 2];
+        x3i       = a[j1 - 1] - a[j3 - 1];
+        a[j0 - 2] = x0r + x2r;
+        a[j0 - 1] = x0i + x2i;
+        a[j1 - 2] = x0r - x2r;
+        a[j1 - 1] = x0i - x2i;
+        x0r       = x1r - x3i;
+        x0i       = x1i + x3r;
+        a[j2 - 2] = wk1r * x0r - wk1i * x0i;
+        a[j2 - 1] = wk1r * x0i + wk1i * x0r;
+        x0r       = x1r + x3i;
+        x0i       = x1i - x3r;
+        a[j3 - 2] = wk3r * x0r + wk3i * x0i;
+        a[j3 - 1] = wk3r * x0i - wk3i * x0r;
+        x0r       = a[j0] + a[j2];
+        x0i       = a[j0 + 1] + a[j2 + 1];
+        x1r       = a[j0] - a[j2];
+        x1i       = a[j0 + 1] - a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[j0]     = x0r + x2r;
+        a[j0 + 1] = x0i + x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i - x2i;
+        x0r       = x1r - x3i;
+        x0i       = x1i + x3r;
+        a[j2]     = wn4r * (x0r - x0i);
+        a[j2 + 1] = wn4r * (x0i + x0r);
+        x0r       = x1r + x3i;
+        x0i       = x1i - x3r;
+        a[j3]     = -wn4r * (x0r + x0i);
+        a[j3 + 1] = -wn4r * (x0i - x0r);
+        x0r       = a[j0 + 2] + a[j2 + 2];
+        x0i       = a[j0 + 3] + a[j2 + 3];
+        x1r       = a[j0 + 2] - a[j2 + 2];
+        x1i       = a[j0 + 3] - a[j2 + 3];
+        x2r       = a[j1 + 2] + a[j3 + 2];
+        x2i       = a[j1 + 3] + a[j3 + 3];
+        x3r       = a[j1 + 2] - a[j3 + 2];
+        x3i       = a[j1 + 3] - a[j3 + 3];
+        a[j0 + 2] = x0r + x2r;
+        a[j0 + 3] = x0i + x2i;
+        a[j1 + 2] = x0r - x2r;
+        a[j1 + 3] = x0i - x2i;
+        x0r       = x1r - x3i;
+        x0i       = x1i + x3r;
+        a[j2 + 2] = wk1i * x0r - wk1r * x0i;
+        a[j2 + 3] = wk1i * x0i + wk1r * x0r;
+        x0r       = x1r + x3i;
+        x0i       = x1i - x3r;
+        a[j3 + 2] = wk3i * x0r + wk3r * x0i;
+        a[j3 + 3] = wk3i * x0i - wk3r * x0r;
+    }
+
+    static void cftb1st(int n, REAL* a, REAL* w)
+    {
+        int j, j0, j1, j2, j3, k, m, mh;
+        REAL wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i;
+
+        mh        = n >> 3;
+        m         = 2 * mh;
+        j1        = m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[0] + a[j2];
+        x0i       = -a[1] - a[j2 + 1];
+        x1r       = a[0] - a[j2];
+        x1i       = -a[1] + a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[0]      = x0r + x2r;
+        a[1]      = x0i - x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i + x2i;
+        a[j2]     = x1r + x3i;
+        a[j2 + 1] = x1i + x3r;
+        a[j3]     = x1r - x3i;
+        a[j3 + 1] = x1i - x3r;
+        wn4r      = w[1];
+        csc1      = w[2];
+        csc3      = w[3];
+        wd1r      = 1;
+        wd1i      = 0;
+        wd3r      = 1;
+        wd3i      = 0;
+        k         = 0;
+        for(j = 2; j < mh - 2; j += 4) {
+            k += 4;
+            wk1r      = csc1 * (wd1r + w[k]);
+            wk1i      = csc1 * (wd1i + w[k + 1]);
+            wk3r      = csc3 * (wd3r + w[k + 2]);
+            wk3i      = csc3 * (wd3i - w[k + 3]);
+            wd1r      = w[k];
+            wd1i      = w[k + 1];
+            wd3r      = w[k + 2];
+            wd3i      = -w[k + 3];
+            j1        = j + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j] + a[j2];
+            x0i       = -a[j + 1] - a[j2 + 1];
+            x1r       = a[j] - a[j2];
+            x1i       = -a[j + 1] + a[j2 + 1];
+            y0r       = a[j + 2] + a[j2 + 2];
+            y0i       = -a[j + 3] - a[j2 + 3];
+            y1r       = a[j + 2] - a[j2 + 2];
+            y1i       = -a[j + 3] + a[j2 + 3];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            y2r       = a[j1 + 2] + a[j3 + 2];
+            y2i       = a[j1 + 3] + a[j3 + 3];
+            y3r       = a[j1 + 2] - a[j3 + 2];
+            y3i       = a[j1 + 3] - a[j3 + 3];
+            a[j]      = x0r + x2r;
+            a[j + 1]  = x0i - x2i;
+            a[j + 2]  = y0r + y2r;
+            a[j + 3]  = y0i - y2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i + x2i;
+            a[j1 + 2] = y0r - y2r;
+            a[j1 + 3] = y0i + y2i;
+            x0r       = x1r + x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1r * x0r - wk1i * x0i;
+            a[j2 + 1] = wk1r * x0i + wk1i * x0r;
+            x0r       = y1r + y3i;
+            x0i       = y1i + y3r;
+            a[j2 + 2] = wd1r * x0r - wd1i * x0i;
+            a[j2 + 3] = wd1r * x0i + wd1i * x0r;
+            x0r       = x1r - x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3r * x0r + wk3i * x0i;
+            a[j3 + 1] = wk3r * x0i - wk3i * x0r;
+            x0r       = y1r - y3i;
+            x0i       = y1i - y3r;
+            a[j3 + 2] = wd3r * x0r + wd3i * x0i;
+            a[j3 + 3] = wd3r * x0i - wd3i * x0r;
+            j0        = m - j;
+            j1        = j0 + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j0] + a[j2];
+            x0i       = -a[j0 + 1] - a[j2 + 1];
+            x1r       = a[j0] - a[j2];
+            x1i       = -a[j0 + 1] + a[j2 + 1];
+            y0r       = a[j0 - 2] + a[j2 - 2];
+            y0i       = -a[j0 - 1] - a[j2 - 1];
+            y1r       = a[j0 - 2] - a[j2 - 2];
+            y1i       = -a[j0 - 1] + a[j2 - 1];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            y2r       = a[j1 - 2] + a[j3 - 2];
+            y2i       = a[j1 - 1] + a[j3 - 1];
+            y3r       = a[j1 - 2] - a[j3 - 2];
+            y3i       = a[j1 - 1] - a[j3 - 1];
+            a[j0]     = x0r + x2r;
+            a[j0 + 1] = x0i - x2i;
+            a[j0 - 2] = y0r + y2r;
+            a[j0 - 1] = y0i - y2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i + x2i;
+            a[j1 - 2] = y0r - y2r;
+            a[j1 - 1] = y0i + y2i;
+            x0r       = x1r + x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1i * x0r - wk1r * x0i;
+            a[j2 + 1] = wk1i * x0i + wk1r * x0r;
+            x0r       = y1r + y3i;
+            x0i       = y1i + y3r;
+            a[j2 - 2] = wd1i * x0r - wd1r * x0i;
+            a[j2 - 1] = wd1i * x0i + wd1r * x0r;
+            x0r       = x1r - x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3i * x0r + wk3r * x0i;
+            a[j3 + 1] = wk3i * x0i - wk3r * x0r;
+            x0r       = y1r - y3i;
+            x0i       = y1i - y3r;
+            a[j3 - 2] = wd3i * x0r + wd3r * x0i;
+            a[j3 - 1] = wd3i * x0i - wd3r * x0r;
+        }
+        wk1r      = csc1 * (wd1r + wn4r);
+        wk1i      = csc1 * (wd1i + wn4r);
+        wk3r      = csc3 * (wd3r - wn4r);
+        wk3i      = csc3 * (wd3i - wn4r);
+        j0        = mh;
+        j1        = j0 + m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[j0 - 2] + a[j2 - 2];
+        x0i       = -a[j0 - 1] - a[j2 - 1];
+        x1r       = a[j0 - 2] - a[j2 - 2];
+        x1i       = -a[j0 - 1] + a[j2 - 1];
+        x2r       = a[j1 - 2] + a[j3 - 2];
+        x2i       = a[j1 - 1] + a[j3 - 1];
+        x3r       = a[j1 - 2] - a[j3 - 2];
+        x3i       = a[j1 - 1] - a[j3 - 1];
+        a[j0 - 2] = x0r + x2r;
+        a[j0 - 1] = x0i - x2i;
+        a[j1 - 2] = x0r - x2r;
+        a[j1 - 1] = x0i + x2i;
+        x0r       = x1r + x3i;
+        x0i       = x1i + x3r;
+        a[j2 - 2] = wk1r * x0r - wk1i * x0i;
+        a[j2 - 1] = wk1r * x0i + wk1i * x0r;
+        x0r       = x1r - x3i;
+        x0i       = x1i - x3r;
+        a[j3 - 2] = wk3r * x0r + wk3i * x0i;
+        a[j3 - 1] = wk3r * x0i - wk3i * x0r;
+        x0r       = a[j0] + a[j2];
+        x0i       = -a[j0 + 1] - a[j2 + 1];
+        x1r       = a[j0] - a[j2];
+        x1i       = -a[j0 + 1] + a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[j0]     = x0r + x2r;
+        a[j0 + 1] = x0i - x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i + x2i;
+        x0r       = x1r + x3i;
+        x0i       = x1i + x3r;
+        a[j2]     = wn4r * (x0r - x0i);
+        a[j2 + 1] = wn4r * (x0i + x0r);
+        x0r       = x1r - x3i;
+        x0i       = x1i - x3r;
+        a[j3]     = -wn4r * (x0r + x0i);
+        a[j3 + 1] = -wn4r * (x0i - x0r);
+        x0r       = a[j0 + 2] + a[j2 + 2];
+        x0i       = -a[j0 + 3] - a[j2 + 3];
+        x1r       = a[j0 + 2] - a[j2 + 2];
+        x1i       = -a[j0 + 3] + a[j2 + 3];
+        x2r       = a[j1 + 2] + a[j3 + 2];
+        x2i       = a[j1 + 3] + a[j3 + 3];
+        x3r       = a[j1 + 2] - a[j3 + 2];
+        x3i       = a[j1 + 3] - a[j3 + 3];
+        a[j0 + 2] = x0r + x2r;
+        a[j0 + 3] = x0i - x2i;
+        a[j1 + 2] = x0r - x2r;
+        a[j1 + 3] = x0i + x2i;
+        x0r       = x1r + x3i;
+        x0i       = x1i + x3r;
+        a[j2 + 2] = wk1i * x0r - wk1r * x0i;
+        a[j2 + 3] = wk1i * x0i + wk1r * x0r;
+        x0r       = x1r - x3i;
+        x0i       = x1i - x3r;
+        a[j3 + 2] = wk3i * x0r + wk3r * x0i;
+        a[j3 + 3] = wk3i * x0i - wk3r * x0r;
+    }
+
+    static void cftrec1(int n, REAL* a, int nw, REAL* w)
+    {
+        int m;
+
+        m = n >> 2;
+        cftmdl1(n, a, &w[nw - 2 * m]);
+        if(n > CDFT_RECURSIVE_N) {
+            cftrec1(m, a, nw, w);
+            cftrec2(m, &a[m], nw, w);
+            cftrec1(m, &a[2 * m], nw, w);
+            cftrec1(m, &a[3 * m], nw, w);
+        }
+        else {
+            cftexp1(n, a, nw, w);
+        }
+    }
+
+    static void cftrec2(int n, REAL* a, int nw, REAL* w)
+    {
+        int m;
+
+        m = n >> 2;
+        cftmdl2(n, a, &w[nw - n]);
+        if(n > CDFT_RECURSIVE_N) {
+            cftrec1(m, a, nw, w);
+            cftrec2(m, &a[m], nw, w);
+            cftrec1(m, &a[2 * m], nw, w);
+            cftrec2(m, &a[3 * m], nw, w);
+        }
+        else {
+            cftexp2(n, a, nw, w);
+        }
+    }
+
+    static void cftexp1(int n, REAL* a, int nw, REAL* w)
+    {
+        int j, k, l;
+
+        l = n >> 2;
+        while(l > 128) {
+            for(k = l; k < n; k <<= 2) {
+                for(j = k - l; j < n; j += 4 * k) {
+                    cftmdl1(l, &a[j], &w[nw - (l >> 1)]);
+                    cftmdl2(l, &a[k + j], &w[nw - l]);
+                    cftmdl1(l, &a[2 * k + j], &w[nw - (l >> 1)]);
+                }
+            }
+            cftmdl1(l, &a[n - l], &w[nw - (l >> 1)]);
+            l >>= 2;
+        }
+        for(k = l; k < n; k <<= 2) {
+            for(j = k - l; j < n; j += 4 * k) {
+                cftmdl1(l, &a[j], &w[nw - (l >> 1)]);
+                cftfx41(l, &a[j], nw, w);
+                cftmdl2(l, &a[k + j], &w[nw - l]);
+                cftfx42(l, &a[k + j], nw, w);
+                cftmdl1(l, &a[2 * k + j], &w[nw - (l >> 1)]);
+                cftfx41(l, &a[2 * k + j], nw, w);
+            }
+        }
+        cftmdl1(l, &a[n - l], &w[nw - (l >> 1)]);
+        cftfx41(l, &a[n - l], nw, w);
+    }
+
+    static void cftexp2(int n, REAL* a, int nw, REAL* w)
+    {
+        int j, k, l, m;
+
+        m = n >> 1;
+        l = n >> 2;
+        while(l > 128) {
+            for(k = l; k < m; k <<= 2) {
+                for(j = k - l; j < m; j += 2 * k) {
+                    cftmdl1(l, &a[j], &w[nw - (l >> 1)]);
+                    cftmdl1(l, &a[m + j], &w[nw - (l >> 1)]);
+                }
+                for(j = 2 * k - l; j < m; j += 4 * k) {
+                    cftmdl2(l, &a[j], &w[nw - l]);
+                    cftmdl2(l, &a[m + j], &w[nw - l]);
+                }
+            }
+            l >>= 2;
+        }
+        for(k = l; k < m; k <<= 2) {
+            for(j = k - l; j < m; j += 2 * k) {
+                cftmdl1(l, &a[j], &w[nw - (l >> 1)]);
+                cftfx41(l, &a[j], nw, w);
+                cftmdl1(l, &a[m + j], &w[nw - (l >> 1)]);
+                cftfx41(l, &a[m + j], nw, w);
+            }
+            for(j = 2 * k - l; j < m; j += 4 * k) {
+                cftmdl2(l, &a[j], &w[nw - l]);
+                cftfx42(l, &a[j], nw, w);
+                cftmdl2(l, &a[m + j], &w[nw - l]);
+                cftfx42(l, &a[m + j], nw, w);
+            }
+        }
+    }
+
+    static void cftmdl1(int n, REAL* a, REAL* w)
+    {
+        int j, j0, j1, j2, j3, k, m, mh;
+        REAL wn4r, wk1r, wk1i, wk3r, wk3i;
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i;
+
+        mh        = n >> 3;
+        m         = 2 * mh;
+        j1        = m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[0] + a[j2];
+        x0i       = a[1] + a[j2 + 1];
+        x1r       = a[0] - a[j2];
+        x1i       = a[1] - a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[0]      = x0r + x2r;
+        a[1]      = x0i + x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i - x2i;
+        a[j2]     = x1r - x3i;
+        a[j2 + 1] = x1i + x3r;
+        a[j3]     = x1r + x3i;
+        a[j3 + 1] = x1i - x3r;
+        wn4r      = w[1];
+        k         = 0;
+        for(j = 2; j < mh; j += 2) {
+            k += 4;
+            wk1r      = w[k];
+            wk1i      = w[k + 1];
+            wk3r      = w[k + 2];
+            wk3i      = -w[k + 3];
+            j1        = j + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j] + a[j2];
+            x0i       = a[j + 1] + a[j2 + 1];
+            x1r       = a[j] - a[j2];
+            x1i       = a[j + 1] - a[j2 + 1];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            a[j]      = x0r + x2r;
+            a[j + 1]  = x0i + x2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i - x2i;
+            x0r       = x1r - x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1r * x0r - wk1i * x0i;
+            a[j2 + 1] = wk1r * x0i + wk1i * x0r;
+            x0r       = x1r + x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3r * x0r + wk3i * x0i;
+            a[j3 + 1] = wk3r * x0i - wk3i * x0r;
+            j0        = m - j;
+            j1        = j0 + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j0] + a[j2];
+            x0i       = a[j0 + 1] + a[j2 + 1];
+            x1r       = a[j0] - a[j2];
+            x1i       = a[j0 + 1] - a[j2 + 1];
+            x2r       = a[j1] + a[j3];
+            x2i       = a[j1 + 1] + a[j3 + 1];
+            x3r       = a[j1] - a[j3];
+            x3i       = a[j1 + 1] - a[j3 + 1];
+            a[j0]     = x0r + x2r;
+            a[j0 + 1] = x0i + x2i;
+            a[j1]     = x0r - x2r;
+            a[j1 + 1] = x0i - x2i;
+            x0r       = x1r - x3i;
+            x0i       = x1i + x3r;
+            a[j2]     = wk1i * x0r - wk1r * x0i;
+            a[j2 + 1] = wk1i * x0i + wk1r * x0r;
+            x0r       = x1r + x3i;
+            x0i       = x1i - x3r;
+            a[j3]     = wk3i * x0r + wk3r * x0i;
+            a[j3 + 1] = wk3i * x0i - wk3r * x0r;
+        }
+        j0        = mh;
+        j1        = j0 + m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[j0] + a[j2];
+        x0i       = a[j0 + 1] + a[j2 + 1];
+        x1r       = a[j0] - a[j2];
+        x1i       = a[j0 + 1] - a[j2 + 1];
+        x2r       = a[j1] + a[j3];
+        x2i       = a[j1 + 1] + a[j3 + 1];
+        x3r       = a[j1] - a[j3];
+        x3i       = a[j1 + 1] - a[j3 + 1];
+        a[j0]     = x0r + x2r;
+        a[j0 + 1] = x0i + x2i;
+        a[j1]     = x0r - x2r;
+        a[j1 + 1] = x0i - x2i;
+        x0r       = x1r - x3i;
+        x0i       = x1i + x3r;
+        a[j2]     = wn4r * (x0r - x0i);
+        a[j2 + 1] = wn4r * (x0i + x0r);
+        x0r       = x1r + x3i;
+        x0i       = x1i - x3r;
+        a[j3]     = -wn4r * (x0r + x0i);
+        a[j3 + 1] = -wn4r * (x0i - x0r);
+    }
+
+    static void cftmdl2(int n, REAL* a, REAL* w)
+    {
+        int j, j0, j1, j2, j3, k, kr, m, mh;
+        REAL wn4r, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y2r, y2i;
+
+        mh        = n >> 3;
+        m         = 2 * mh;
+        wn4r      = w[1];
+        j1        = m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[0] - a[j2 + 1];
+        x0i       = a[1] + a[j2];
+        x1r       = a[0] + a[j2 + 1];
+        x1i       = a[1] - a[j2];
+        x2r       = a[j1] - a[j3 + 1];
+        x2i       = a[j1 + 1] + a[j3];
+        x3r       = a[j1] + a[j3 + 1];
+        x3i       = a[j1 + 1] - a[j3];
+        y0r       = wn4r * (x2r - x2i);
+        y0i       = wn4r * (x2i + x2r);
+        a[0]      = x0r + y0r;
+        a[1]      = x0i + y0i;
+        a[j1]     = x0r - y0r;
+        a[j1 + 1] = x0i - y0i;
+        y0r       = wn4r * (x3r - x3i);
+        y0i       = wn4r * (x3i + x3r);
+        a[j2]     = x1r - y0i;
+        a[j2 + 1] = x1i + y0r;
+        a[j3]     = x1r + y0i;
+        a[j3 + 1] = x1i - y0r;
+        k         = 0;
+        kr        = 2 * m;
+        for(j = 2; j < mh; j += 2) {
+            k += 4;
+            wk1r = w[k];
+            wk1i = w[k + 1];
+            wk3r = w[k + 2];
+            wk3i = -w[k + 3];
+            kr -= 4;
+            wd1i      = w[kr];
+            wd1r      = w[kr + 1];
+            wd3i      = w[kr + 2];
+            wd3r      = -w[kr + 3];
+            j1        = j + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j] - a[j2 + 1];
+            x0i       = a[j + 1] + a[j2];
+            x1r       = a[j] + a[j2 + 1];
+            x1i       = a[j + 1] - a[j2];
+            x2r       = a[j1] - a[j3 + 1];
+            x2i       = a[j1 + 1] + a[j3];
+            x3r       = a[j1] + a[j3 + 1];
+            x3i       = a[j1 + 1] - a[j3];
+            y0r       = wk1r * x0r - wk1i * x0i;
+            y0i       = wk1r * x0i + wk1i * x0r;
+            y2r       = wd1r * x2r - wd1i * x2i;
+            y2i       = wd1r * x2i + wd1i * x2r;
+            a[j]      = y0r + y2r;
+            a[j + 1]  = y0i + y2i;
+            a[j1]     = y0r - y2r;
+            a[j1 + 1] = y0i - y2i;
+            y0r       = wk3r * x1r + wk3i * x1i;
+            y0i       = wk3r * x1i - wk3i * x1r;
+            y2r       = wd3r * x3r + wd3i * x3i;
+            y2i       = wd3r * x3i - wd3i * x3r;
+            a[j2]     = y0r + y2r;
+            a[j2 + 1] = y0i + y2i;
+            a[j3]     = y0r - y2r;
+            a[j3 + 1] = y0i - y2i;
+            j0        = m - j;
+            j1        = j0 + m;
+            j2        = j1 + m;
+            j3        = j2 + m;
+            x0r       = a[j0] - a[j2 + 1];
+            x0i       = a[j0 + 1] + a[j2];
+            x1r       = a[j0] + a[j2 + 1];
+            x1i       = a[j0 + 1] - a[j2];
+            x2r       = a[j1] - a[j3 + 1];
+            x2i       = a[j1 + 1] + a[j3];
+            x3r       = a[j1] + a[j3 + 1];
+            x3i       = a[j1 + 1] - a[j3];
+            y0r       = wd1i * x0r - wd1r * x0i;
+            y0i       = wd1i * x0i + wd1r * x0r;
+            y2r       = wk1i * x2r - wk1r * x2i;
+            y2i       = wk1i * x2i + wk1r * x2r;
+            a[j0]     = y0r + y2r;
+            a[j0 + 1] = y0i + y2i;
+            a[j1]     = y0r - y2r;
+            a[j1 + 1] = y0i - y2i;
+            y0r       = wd3i * x1r + wd3r * x1i;
+            y0i       = wd3i * x1i - wd3r * x1r;
+            y2r       = wk3i * x3r + wk3r * x3i;
+            y2i       = wk3i * x3i - wk3r * x3r;
+            a[j2]     = y0r + y2r;
+            a[j2 + 1] = y0i + y2i;
+            a[j3]     = y0r - y2r;
+            a[j3 + 1] = y0i - y2i;
+        }
+        wk1r      = w[m];
+        wk1i      = w[m + 1];
+        j0        = mh;
+        j1        = j0 + m;
+        j2        = j1 + m;
+        j3        = j2 + m;
+        x0r       = a[j0] - a[j2 + 1];
+        x0i       = a[j0 + 1] + a[j2];
+        x1r       = a[j0] + a[j2 + 1];
+        x1i       = a[j0 + 1] - a[j2];
+        x2r       = a[j1] - a[j3 + 1];
+        x2i       = a[j1 + 1] + a[j3];
+        x3r       = a[j1] + a[j3 + 1];
+        x3i       = a[j1 + 1] - a[j3];
+        y0r       = wk1r * x0r - wk1i * x0i;
+        y0i       = wk1r * x0i + wk1i * x0r;
+        y2r       = wk1i * x2r - wk1r * x2i;
+        y2i       = wk1i * x2i + wk1r * x2r;
+        a[j0]     = y0r + y2r;
+        a[j0 + 1] = y0i + y2i;
+        a[j1]     = y0r - y2r;
+        a[j1 + 1] = y0i - y2i;
+        y0r       = wk1i * x1r - wk1r * x1i;
+        y0i       = wk1i * x1i + wk1r * x1r;
+        y2r       = wk1r * x3r - wk1i * x3i;
+        y2i       = wk1r * x3i + wk1i * x3r;
+        a[j2]     = y0r - y2r;
+        a[j2 + 1] = y0i - y2i;
+        a[j3]     = y0r + y2r;
+        a[j3 + 1] = y0i + y2i;
+    }
+
+    static void cftfx41(int n, REAL* a, int nw, REAL* w)
+    {
+        if(n == 128) {
+            cftf161(a, &w[nw - 8]);
+            cftf162(&a[32], &w[nw - 32]);
+            cftf161(&a[64], &w[nw - 8]);
+            cftf161(&a[96], &w[nw - 8]);
+        }
+        else {
+            cftf081(a, &w[nw - 16]);
+            cftf082(&a[16], &w[nw - 16]);
+            cftf081(&a[32], &w[nw - 16]);
+            cftf081(&a[48], &w[nw - 16]);
+        }
+    }
+
+    static void cftfx42(int n, REAL* a, int nw, REAL* w)
+    {
+        if(n == 128) {
+            cftf161(a, &w[nw - 8]);
+            cftf162(&a[32], &w[nw - 32]);
+            cftf161(&a[64], &w[nw - 8]);
+            cftf162(&a[96], &w[nw - 32]);
+        }
+        else {
+            cftf081(a, &w[nw - 16]);
+            cftf082(&a[16], &w[nw - 16]);
+            cftf081(&a[32], &w[nw - 16]);
+            cftf082(&a[48], &w[nw - 16]);
+        }
+    }
+
+    static void cftf161(REAL* a, REAL* w)
+    {
+        REAL wn4r, wk1r, wk1i, x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i, y4r, y4i,
+            y5r, y5i, y6r, y6i, y7r, y7i, y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i, y12r, y12i, y13r, y13i, y14r,
+            y14i, y15r, y15i;
+
+        wn4r  = w[1];
+        wk1i  = wn4r * w[2];
+        wk1r  = wk1i + w[2];
+        x0r   = a[0] + a[16];
+        x0i   = a[1] + a[17];
+        x1r   = a[0] - a[16];
+        x1i   = a[1] - a[17];
+        x2r   = a[8] + a[24];
+        x2i   = a[9] + a[25];
+        x3r   = a[8] - a[24];
+        x3i   = a[9] - a[25];
+        y0r   = x0r + x2r;
+        y0i   = x0i + x2i;
+        y4r   = x0r - x2r;
+        y4i   = x0i - x2i;
+        y8r   = x1r - x3i;
+        y8i   = x1i + x3r;
+        y12r  = x1r + x3i;
+        y12i  = x1i - x3r;
+        x0r   = a[2] + a[18];
+        x0i   = a[3] + a[19];
+        x1r   = a[2] - a[18];
+        x1i   = a[3] - a[19];
+        x2r   = a[10] + a[26];
+        x2i   = a[11] + a[27];
+        x3r   = a[10] - a[26];
+        x3i   = a[11] - a[27];
+        y1r   = x0r + x2r;
+        y1i   = x0i + x2i;
+        y5r   = x0r - x2r;
+        y5i   = x0i - x2i;
+        x0r   = x1r - x3i;
+        x0i   = x1i + x3r;
+        y9r   = wk1r * x0r - wk1i * x0i;
+        y9i   = wk1r * x0i + wk1i * x0r;
+        x0r   = x1r + x3i;
+        x0i   = x1i - x3r;
+        y13r  = wk1i * x0r - wk1r * x0i;
+        y13i  = wk1i * x0i + wk1r * x0r;
+        x0r   = a[4] + a[20];
+        x0i   = a[5] + a[21];
+        x1r   = a[4] - a[20];
+        x1i   = a[5] - a[21];
+        x2r   = a[12] + a[28];
+        x2i   = a[13] + a[29];
+        x3r   = a[12] - a[28];
+        x3i   = a[13] - a[29];
+        y2r   = x0r + x2r;
+        y2i   = x0i + x2i;
+        y6r   = x0r - x2r;
+        y6i   = x0i - x2i;
+        x0r   = x1r - x3i;
+        x0i   = x1i + x3r;
+        y10r  = wn4r * (x0r - x0i);
+        y10i  = wn4r * (x0i + x0r);
+        x0r   = x1r + x3i;
+        x0i   = x1i - x3r;
+        y14r  = wn4r * (x0r + x0i);
+        y14i  = wn4r * (x0i - x0r);
+        x0r   = a[6] + a[22];
+        x0i   = a[7] + a[23];
+        x1r   = a[6] - a[22];
+        x1i   = a[7] - a[23];
+        x2r   = a[14] + a[30];
+        x2i   = a[15] + a[31];
+        x3r   = a[14] - a[30];
+        x3i   = a[15] - a[31];
+        y3r   = x0r + x2r;
+        y3i   = x0i + x2i;
+        y7r   = x0r - x2r;
+        y7i   = x0i - x2i;
+        x0r   = x1r - x3i;
+        x0i   = x1i + x3r;
+        y11r  = wk1i * x0r - wk1r * x0i;
+        y11i  = wk1i * x0i + wk1r * x0r;
+        x0r   = x1r + x3i;
+        x0i   = x1i - x3r;
+        y15r  = wk1r * x0r - wk1i * x0i;
+        y15i  = wk1r * x0i + wk1i * x0r;
+        x0r   = y12r - y14r;
+        x0i   = y12i - y14i;
+        x1r   = y12r + y14r;
+        x1i   = y12i + y14i;
+        x2r   = y13r - y15r;
+        x2i   = y13i - y15i;
+        x3r   = y13r + y15r;
+        x3i   = y13i + y15i;
+        a[24] = x0r + x2r;
+        a[25] = x0i + x2i;
+        a[26] = x0r - x2r;
+        a[27] = x0i - x2i;
+        a[28] = x1r - x3i;
+        a[29] = x1i + x3r;
+        a[30] = x1r + x3i;
+        a[31] = x1i - x3r;
+        x0r   = y8r + y10r;
+        x0i   = y8i + y10i;
+        x1r   = y8r - y10r;
+        x1i   = y8i - y10i;
+        x2r   = y9r + y11r;
+        x2i   = y9i + y11i;
+        x3r   = y9r - y11r;
+        x3i   = y9i - y11i;
+        a[16] = x0r + x2r;
+        a[17] = x0i + x2i;
+        a[18] = x0r - x2r;
+        a[19] = x0i - x2i;
+        a[20] = x1r - x3i;
+        a[21] = x1i + x3r;
+        a[22] = x1r + x3i;
+        a[23] = x1i - x3r;
+        x0r   = y5r - y7i;
+        x0i   = y5i + y7r;
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        x0r   = y5r + y7i;
+        x0i   = y5i - y7r;
+        x3r   = wn4r * (x0r - x0i);
+        x3i   = wn4r * (x0i + x0r);
+        x0r   = y4r - y6i;
+        x0i   = y4i + y6r;
+        x1r   = y4r + y6i;
+        x1i   = y4i - y6r;
+        a[8]  = x0r + x2r;
+        a[9]  = x0i + x2i;
+        a[10] = x0r - x2r;
+        a[11] = x0i - x2i;
+        a[12] = x1r - x3i;
+        a[13] = x1i + x3r;
+        a[14] = x1r + x3i;
+        a[15] = x1i - x3r;
+        x0r   = y0r + y2r;
+        x0i   = y0i + y2i;
+        x1r   = y0r - y2r;
+        x1i   = y0i - y2i;
+        x2r   = y1r + y3r;
+        x2i   = y1i + y3i;
+        x3r   = y1r - y3r;
+        x3i   = y1i - y3i;
+        a[0]  = x0r + x2r;
+        a[1]  = x0i + x2i;
+        a[2]  = x0r - x2r;
+        a[3]  = x0i - x2i;
+        a[4]  = x1r - x3i;
+        a[5]  = x1i + x3r;
+        a[6]  = x1r + x3i;
+        a[7]  = x1i - x3r;
+    }
+
+    static void cftf162(REAL* a, REAL* w)
+    {
+        REAL wn4r, wk1r, wk1i, wk2r, wk2i, wk3r, wk3i, x0r, x0i, x1r, x1i, x2r, x2i, y0r, y0i, y1r, y1i, y2r, y2i, y3r,
+            y3i, y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i, y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i, y12r, y12i, y13r,
+            y13i, y14r, y14i, y15r, y15i;
+
+        wn4r  = w[1];
+        wk1r  = w[4];
+        wk1i  = w[5];
+        wk3r  = w[6];
+        wk3i  = w[7];
+        wk2r  = w[8];
+        wk2i  = w[9];
+        x1r   = a[0] - a[17];
+        x1i   = a[1] + a[16];
+        x0r   = a[8] - a[25];
+        x0i   = a[9] + a[24];
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        y0r   = x1r + x2r;
+        y0i   = x1i + x2i;
+        y4r   = x1r - x2r;
+        y4i   = x1i - x2i;
+        x1r   = a[0] + a[17];
+        x1i   = a[1] - a[16];
+        x0r   = a[8] + a[25];
+        x0i   = a[9] - a[24];
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        y8r   = x1r - x2i;
+        y8i   = x1i + x2r;
+        y12r  = x1r + x2i;
+        y12i  = x1i - x2r;
+        x0r   = a[2] - a[19];
+        x0i   = a[3] + a[18];
+        x1r   = wk1r * x0r - wk1i * x0i;
+        x1i   = wk1r * x0i + wk1i * x0r;
+        x0r   = a[10] - a[27];
+        x0i   = a[11] + a[26];
+        x2r   = wk3i * x0r - wk3r * x0i;
+        x2i   = wk3i * x0i + wk3r * x0r;
+        y1r   = x1r + x2r;
+        y1i   = x1i + x2i;
+        y5r   = x1r - x2r;
+        y5i   = x1i - x2i;
+        x0r   = a[2] + a[19];
+        x0i   = a[3] - a[18];
+        x1r   = wk3r * x0r - wk3i * x0i;
+        x1i   = wk3r * x0i + wk3i * x0r;
+        x0r   = a[10] + a[27];
+        x0i   = a[11] - a[26];
+        x2r   = wk1r * x0r + wk1i * x0i;
+        x2i   = wk1r * x0i - wk1i * x0r;
+        y9r   = x1r - x2r;
+        y9i   = x1i - x2i;
+        y13r  = x1r + x2r;
+        y13i  = x1i + x2i;
+        x0r   = a[4] - a[21];
+        x0i   = a[5] + a[20];
+        x1r   = wk2r * x0r - wk2i * x0i;
+        x1i   = wk2r * x0i + wk2i * x0r;
+        x0r   = a[12] - a[29];
+        x0i   = a[13] + a[28];
+        x2r   = wk2i * x0r - wk2r * x0i;
+        x2i   = wk2i * x0i + wk2r * x0r;
+        y2r   = x1r + x2r;
+        y2i   = x1i + x2i;
+        y6r   = x1r - x2r;
+        y6i   = x1i - x2i;
+        x0r   = a[4] + a[21];
+        x0i   = a[5] - a[20];
+        x1r   = wk2i * x0r - wk2r * x0i;
+        x1i   = wk2i * x0i + wk2r * x0r;
+        x0r   = a[12] + a[29];
+        x0i   = a[13] - a[28];
+        x2r   = wk2r * x0r - wk2i * x0i;
+        x2i   = wk2r * x0i + wk2i * x0r;
+        y10r  = x1r - x2r;
+        y10i  = x1i - x2i;
+        y14r  = x1r + x2r;
+        y14i  = x1i + x2i;
+        x0r   = a[6] - a[23];
+        x0i   = a[7] + a[22];
+        x1r   = wk3r * x0r - wk3i * x0i;
+        x1i   = wk3r * x0i + wk3i * x0r;
+        x0r   = a[14] - a[31];
+        x0i   = a[15] + a[30];
+        x2r   = wk1i * x0r - wk1r * x0i;
+        x2i   = wk1i * x0i + wk1r * x0r;
+        y3r   = x1r + x2r;
+        y3i   = x1i + x2i;
+        y7r   = x1r - x2r;
+        y7i   = x1i - x2i;
+        x0r   = a[6] + a[23];
+        x0i   = a[7] - a[22];
+        x1r   = wk1i * x0r + wk1r * x0i;
+        x1i   = wk1i * x0i - wk1r * x0r;
+        x0r   = a[14] + a[31];
+        x0i   = a[15] - a[30];
+        x2r   = wk3i * x0r - wk3r * x0i;
+        x2i   = wk3i * x0i + wk3r * x0r;
+        y11r  = x1r + x2r;
+        y11i  = x1i + x2i;
+        y15r  = x1r - x2r;
+        y15i  = x1i - x2i;
+        x1r   = y0r + y2r;
+        x1i   = y0i + y2i;
+        x2r   = y1r + y3r;
+        x2i   = y1i + y3i;
+        a[0]  = x1r + x2r;
+        a[1]  = x1i + x2i;
+        a[2]  = x1r - x2r;
+        a[3]  = x1i - x2i;
+        x1r   = y0r - y2r;
+        x1i   = y0i - y2i;
+        x2r   = y1r - y3r;
+        x2i   = y1i - y3i;
+        a[4]  = x1r - x2i;
+        a[5]  = x1i + x2r;
+        a[6]  = x1r + x2i;
+        a[7]  = x1i - x2r;
+        x1r   = y4r - y6i;
+        x1i   = y4i + y6r;
+        x0r   = y5r - y7i;
+        x0i   = y5i + y7r;
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        a[8]  = x1r + x2r;
+        a[9]  = x1i + x2i;
+        a[10] = x1r - x2r;
+        a[11] = x1i - x2i;
+        x1r   = y4r + y6i;
+        x1i   = y4i - y6r;
+        x0r   = y5r + y7i;
+        x0i   = y5i - y7r;
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        a[12] = x1r - x2i;
+        a[13] = x1i + x2r;
+        a[14] = x1r + x2i;
+        a[15] = x1i - x2r;
+        x1r   = y8r + y10r;
+        x1i   = y8i + y10i;
+        x2r   = y9r - y11r;
+        x2i   = y9i - y11i;
+        a[16] = x1r + x2r;
+        a[17] = x1i + x2i;
+        a[18] = x1r - x2r;
+        a[19] = x1i - x2i;
+        x1r   = y8r - y10r;
+        x1i   = y8i - y10i;
+        x2r   = y9r + y11r;
+        x2i   = y9i + y11i;
+        a[20] = x1r - x2i;
+        a[21] = x1i + x2r;
+        a[22] = x1r + x2i;
+        a[23] = x1i - x2r;
+        x1r   = y12r - y14i;
+        x1i   = y12i + y14r;
+        x0r   = y13r + y15i;
+        x0i   = y13i - y15r;
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        a[24] = x1r + x2r;
+        a[25] = x1i + x2i;
+        a[26] = x1r - x2r;
+        a[27] = x1i - x2i;
+        x1r   = y12r + y14i;
+        x1i   = y12i - y14r;
+        x0r   = y13r - y15i;
+        x0i   = y13i + y15r;
+        x2r   = wn4r * (x0r - x0i);
+        x2i   = wn4r * (x0i + x0r);
+        a[28] = x1r - x2i;
+        a[29] = x1i + x2r;
+        a[30] = x1r + x2i;
+        a[31] = x1i - x2r;
+    }
+
+    static void cftf081(REAL* a, REAL* w)
+    {
+        REAL wn4r, x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i, y4r, y4i, y5r, y5i,
+            y6r, y6i, y7r, y7i;
+
+        wn4r  = w[1];
+        x0r   = a[0] + a[8];
+        x0i   = a[1] + a[9];
+        x1r   = a[0] - a[8];
+        x1i   = a[1] - a[9];
+        x2r   = a[4] + a[12];
+        x2i   = a[5] + a[13];
+        x3r   = a[4] - a[12];
+        x3i   = a[5] - a[13];
+        y0r   = x0r + x2r;
+        y0i   = x0i + x2i;
+        y2r   = x0r - x2r;
+        y2i   = x0i - x2i;
+        y1r   = x1r - x3i;
+        y1i   = x1i + x3r;
+        y3r   = x1r + x3i;
+        y3i   = x1i - x3r;
+        x0r   = a[2] + a[10];
+        x0i   = a[3] + a[11];
+        x1r   = a[2] - a[10];
+        x1i   = a[3] - a[11];
+        x2r   = a[6] + a[14];
+        x2i   = a[7] + a[15];
+        x3r   = a[6] - a[14];
+        x3i   = a[7] - a[15];
+        y4r   = x0r + x2r;
+        y4i   = x0i + x2i;
+        y6r   = x0r - x2r;
+        y6i   = x0i - x2i;
+        x0r   = x1r - x3i;
+        x0i   = x1i + x3r;
+        x2r   = x1r + x3i;
+        x2i   = x1i - x3r;
+        y5r   = wn4r * (x0r - x0i);
+        y5i   = wn4r * (x0r + x0i);
+        y7r   = wn4r * (x2r - x2i);
+        y7i   = wn4r * (x2r + x2i);
+        a[8]  = y1r + y5r;
+        a[9]  = y1i + y5i;
+        a[10] = y1r - y5r;
+        a[11] = y1i - y5i;
+        a[12] = y3r - y7i;
+        a[13] = y3i + y7r;
+        a[14] = y3r + y7i;
+        a[15] = y3i - y7r;
+        a[0]  = y0r + y4r;
+        a[1]  = y0i + y4i;
+        a[2]  = y0r - y4r;
+        a[3]  = y0i - y4i;
+        a[4]  = y2r - y6i;
+        a[5]  = y2i + y6r;
+        a[6]  = y2r + y6i;
+        a[7]  = y2i - y6r;
+    }
+
+    static void cftf082(REAL* a, REAL* w)
+    {
+        REAL wn4r, wk1r, wk1i, x0r, x0i, x1r, x1i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i, y4r, y4i, y5r, y5i, y6r, y6i,
+            y7r, y7i;
+
+        wn4r  = w[1];
+        wk1r  = w[4];
+        wk1i  = w[5];
+        y0r   = a[0] - a[9];
+        y0i   = a[1] + a[8];
+        y1r   = a[0] + a[9];
+        y1i   = a[1] - a[8];
+        x0r   = a[4] - a[13];
+        x0i   = a[5] + a[12];
+        y2r   = wn4r * (x0r - x0i);
+        y2i   = wn4r * (x0i + x0r);
+        x0r   = a[4] + a[13];
+        x0i   = a[5] - a[12];
+        y3r   = wn4r * (x0r - x0i);
+        y3i   = wn4r * (x0i + x0r);
+        x0r   = a[2] - a[11];
+        x0i   = a[3] + a[10];
+        y4r   = wk1r * x0r - wk1i * x0i;
+        y4i   = wk1r * x0i + wk1i * x0r;
+        x0r   = a[2] + a[11];
+        x0i   = a[3] - a[10];
+        y5r   = wk1i * x0r - wk1r * x0i;
+        y5i   = wk1i * x0i + wk1r * x0r;
+        x0r   = a[6] - a[15];
+        x0i   = a[7] + a[14];
+        y6r   = wk1i * x0r - wk1r * x0i;
+        y6i   = wk1i * x0i + wk1r * x0r;
+        x0r   = a[6] + a[15];
+        x0i   = a[7] - a[14];
+        y7r   = wk1r * x0r - wk1i * x0i;
+        y7i   = wk1r * x0i + wk1i * x0r;
+        x0r   = y0r + y2r;
+        x0i   = y0i + y2i;
+        x1r   = y4r + y6r;
+        x1i   = y4i + y6i;
+        a[0]  = x0r + x1r;
+        a[1]  = x0i + x1i;
+        a[2]  = x0r - x1r;
+        a[3]  = x0i - x1i;
+        x0r   = y0r - y2r;
+        x0i   = y0i - y2i;
+        x1r   = y4r - y6r;
+        x1i   = y4i - y6i;
+        a[4]  = x0r - x1i;
+        a[5]  = x0i + x1r;
+        a[6]  = x0r + x1i;
+        a[7]  = x0i - x1r;
+        x0r   = y1r - y3i;
+        x0i   = y1i + y3r;
+        x1r   = y5r - y7r;
+        x1i   = y5i - y7i;
+        a[8]  = x0r + x1r;
+        a[9]  = x0i + x1i;
+        a[10] = x0r - x1r;
+        a[11] = x0i - x1i;
+        x0r   = y1r + y3i;
+        x0i   = y1i - y3r;
+        x1r   = y5r + y7r;
+        x1i   = y5i + y7i;
+        a[12] = x0r - x1i;
+        a[13] = x0i + x1r;
+        a[14] = x0r + x1i;
+        a[15] = x0i - x1r;
+    }
+
+    static void cftf040(REAL* a)
+    {
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i;
+
+        x0r  = a[0] + a[4];
+        x0i  = a[1] + a[5];
+        x1r  = a[0] - a[4];
+        x1i  = a[1] - a[5];
+        x2r  = a[2] + a[6];
+        x2i  = a[3] + a[7];
+        x3r  = a[2] - a[6];
+        x3i  = a[3] - a[7];
+        a[0] = x0r + x2r;
+        a[1] = x0i + x2i;
+        a[4] = x0r - x2r;
+        a[5] = x0i - x2i;
+        a[2] = x1r - x3i;
+        a[3] = x1i + x3r;
+        a[6] = x1r + x3i;
+        a[7] = x1i - x3r;
+    }
+
+    static void cftb040(REAL* a)
+    {
+        REAL x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i;
+
+        x0r  = a[0] + a[4];
+        x0i  = a[1] + a[5];
+        x1r  = a[0] - a[4];
+        x1i  = a[1] - a[5];
+        x2r  = a[2] + a[6];
+        x2i  = a[3] + a[7];
+        x3r  = a[2] - a[6];
+        x3i  = a[3] - a[7];
+        a[0] = x0r + x2r;
+        a[1] = x0i + x2i;
+        a[4] = x0r - x2r;
+        a[5] = x0i - x2i;
+        a[2] = x1r + x3i;
+        a[3] = x1i - x3r;
+        a[6] = x1r - x3i;
+        a[7] = x1i + x3r;
+    }
+
+    static void cftx020(REAL* a)
+    {
+        REAL x0r, x0i;
+
+        x0r = a[0] - a[2];
+        x0i = a[1] - a[3];
+        a[0] += a[2];
+        a[1] += a[3];
+        a[2] = x0r;
+        a[3] = x0i;
+    }
+
+    static void rftfsub(int n, REAL* a, int nc, REAL* c)
+    {
+        int j, k, kk, ks, m;
+        REAL wkr, wki, xr, xi, yr, yi;
+
+        m  = n >> 1;
+        ks = 2 * nc / m;
+        kk = 0;
+        for(j = 2; j < m; j += 2) {
+            k = n - j;
+            kk += ks;
+            wkr = 0.5 - c[nc - kk];
+            wki = c[kk];
+            xr  = a[j] - a[k];
+            xi  = a[j + 1] + a[k + 1];
+            yr  = wkr * xr - wki * xi;
+            yi  = wkr * xi + wki * xr;
+            a[j] -= yr;
+            a[j + 1] -= yi;
+            a[k] += yr;
+            a[k + 1] -= yi;
+        }
+    }
+
+    static void rftbsub(int n, REAL* a, int nc, REAL* c)
+    {
+        int j, k, kk, ks, m;
+        REAL wkr, wki, xr, xi, yr, yi;
+
+        m  = n >> 1;
+        ks = 2 * nc / m;
+        kk = 0;
+        for(j = 2; j < m; j += 2) {
+            k = n - j;
+            kk += ks;
+            wkr = 0.5 - c[nc - kk];
+            wki = c[kk];
+            xr  = a[j] - a[k];
+            xi  = a[j + 1] + a[k + 1];
+            yr  = wkr * xr + wki * xi;
+            yi  = wkr * xi - wki * xr;
+            a[j] -= yr;
+            a[j + 1] -= yi;
+            a[k] += yr;
+            a[k + 1] -= yi;
+        }
+    }
+
+    static void dctsub(int n, REAL* a, int nc, REAL* c)
+    {
+        int j, k, kk, ks, m;
+        REAL wkr, wki, xr;
+
+        m  = n >> 1;
+        ks = nc / n;
+        kk = 0;
+        for(j = 1; j < m; j++) {
+            k = n - j;
+            kk += ks;
+            wkr  = c[kk] - c[nc - kk];
+            wki  = c[kk] + c[nc - kk];
+            xr   = wki * a[j] - wkr * a[k];
+            a[j] = wkr * a[j] + wki * a[k];
+            a[k] = xr;
+        }
+        a[m] *= c[0];
+    }
+
+    static void dstsub(int n, REAL* a, int nc, REAL* c)
+    {
+        int j, k, kk, ks, m;
+        REAL wkr, wki, xr;
+
+        m  = n >> 1;
+        ks = nc / n;
+        kk = 0;
+        for(j = 1; j < m; j++) {
+            k = n - j;
+            kk += ks;
+            wkr  = c[kk] - c[nc - kk];
+            wki  = c[kk] + c[nc - kk];
+            xr   = wki * a[k] - wkr * a[j];
+            a[k] = wkr * a[k] + wki * a[j];
+            a[j] = xr;
+        }
+        a[m] *= c[0];
+    }
+};
+
+#endif //_DSP_MATH_SHARED_H_

--- a/src/plugins/equaliser/supereq/paramlist.h
+++ b/src/plugins/equaliser/supereq/paramlist.h
@@ -1,0 +1,167 @@
+/******************************************************
+SuperEQ written by Naoki Shibata  shibatch@users.sourceforge.net
+
+Shibatch Super Equalizer is a graphic and parametric equalizer plugin
+for winamp. This plugin uses 16383th order FIR filter with FFT algorithm.
+It's equalization is very precise. Equalization setting can be done
+for each channel separately.
+
+
+Homepage : http://shibatch.sourceforge.net/
+e-mail   : shibatch@users.sourceforge.net
+
+Some changes are from foobar2000 (www.foobar2000.org):
+
+Copyright (c) 2001-2003, Peter Pawlowski
+All rights reserved.
+
+Other changes are:
+
+Copyright © 2026, Luke Taylor <luket@pm.me>
+*******************************************************/
+
+#ifndef __PARAMLIST_H__
+#define __PARAMLIST_H__
+
+class paramlistelm
+{
+public:
+    paramlistelm* next{nullptr};
+
+    char left;
+    char right;
+    float lower;
+    float upper;
+    float gain;
+    float gain2{0};
+    int sortindex{0};
+
+    paramlistelm()
+    {
+        left = right = 1;
+        lower = upper = gain = 0;
+    };
+
+    ~paramlistelm()
+    {
+        delete next;
+        next = nullptr;
+    };
+
+    /*	char *getString(void) {
+            static char str[64];
+            sprintf(str,"%gHz to %gHz, %gdB %c%c",
+                (double)lower,(double)upper,(double)gain,left?'L':' ',right?'R':' ');
+            return str;
+        }*/
+};
+
+class paramlist
+{
+public:
+    paramlistelm* elm{nullptr};
+
+    ~paramlist()
+    {
+        delete elm;
+        elm = nullptr;
+    }
+
+    void copy(paramlist& src)
+    {
+        delete elm;
+        elm = nullptr;
+
+        paramlistelm** p;
+        paramlistelm* q;
+
+        for(p = &elm, q = src.elm; q != nullptr; q = q->next, p = &(*p)->next) {
+            *p          = new paramlistelm;
+            (*p)->left  = q->left;
+            (*p)->right = q->right;
+            (*p)->lower = q->lower;
+            (*p)->upper = q->upper;
+            (*p)->gain  = q->gain;
+        }
+    }
+
+    paramlistelm* newelm()
+    {
+        paramlistelm** e;
+        for(e = &elm; *e != nullptr; e = &(*e)->next) {
+            ;
+        }
+
+        *e = new paramlistelm;
+
+        return *e;
+    }
+
+    int getnelm()
+    {
+        int i;
+        paramlistelm* e;
+
+        for(e = elm, i = 0; e != nullptr; e = e->next, i++) {
+            ;
+        }
+
+        return i;
+    }
+
+    void delelm(paramlistelm* p)
+    {
+        paramlistelm** e;
+
+        for(e = &elm; *e != nullptr && p != *e; e = &(*e)->next) {
+            ;
+        }
+
+        if(*e == nullptr) {
+            return;
+        }
+
+        *e      = (*e)->next;
+        p->next = nullptr;
+        delete p;
+    }
+
+    void sortelm()
+    {
+        int i{0};
+
+        if(elm == nullptr) {
+            return;
+        }
+
+        for(paramlistelm* r = elm; r != nullptr; r = r->next) {
+            r->sortindex = i++;
+        }
+
+        paramlistelm** p;
+        paramlistelm** q;
+
+        for(p = &elm->next; *p != nullptr;) {
+            for(q = &elm; *q != *p; q = &(*q)->next) {
+                if((*p)->lower < (*q)->lower || ((*p)->lower == (*q)->lower && (*p)->sortindex < (*q)->sortindex)) {
+                    break;
+                }
+            }
+
+            if(p == q) {
+                p = &(*p)->next;
+                continue;
+            }
+
+            paramlistelm** pn = p;
+            paramlistelm* pp  = *p;
+            *p                = (*p)->next;
+            pp->next          = *q;
+            *q                = pp;
+
+            p = pn;
+        }
+    }
+};
+
+#endif // __PARAMLIST_H__

--- a/src/plugins/equaliser/supereq/supereq.h
+++ b/src/plugins/equaliser/supereq/supereq.h
@@ -1,0 +1,470 @@
+/******************************************************
+SuperEQ written by Naoki Shibata  shibatch@users.sourceforge.net
+
+Shibatch Super Equalizer is a graphic and parametric equalizer plugin
+for winamp. This plugin uses 16383th order FIR filter with FFT algorithm.
+It's equalization is very precise. Equalization setting can be done
+for each channel separately.
+
+Homepage : http://shibatch.sourceforge.net/
+e-mail   : shibatch@users.sourceforge.net
+
+Some changes are from foobar2000 (www.foobar2000.org):
+
+Copyright (c) 2001-2003, Peter Pawlowski
+All rights reserved.
+
+Other changes are:
+
+Copyright © 2026, Luke Taylor <luket@pm.me>
+*******************************************************/
+
+#ifndef _SUPEREQ_H_
+#define _SUPEREQ_H_
+
+#include "fft.h"
+#include "paramlist.h"
+#include "supereq_compat.h"
+
+#include <cmath>
+#include <cstring>
+
+#ifndef NOVTABLE
+#if defined(_MSC_VER)
+#define NOVTABLE __declspec(novtable)
+#else
+#define NOVTABLE
+#endif
+#endif
+
+class NOVTABLE supereq_base
+{
+public:
+    virtual void equ_makeTable(double* bc, class paramlist* param, double fs) = 0;
+    virtual void equ_clearbuf()                                               = 0;
+
+    virtual void write_samples(audio_sample* buf, int nsamples) = 0;
+    virtual audio_sample* get_output(int* nsamples)             = 0;
+    virtual int samples_buffered()                              = 0;
+    virtual ~supereq_base()                                     = default;
+};
+
+template <class REAL>
+class supereq : public supereq_base
+{
+public:
+    enum
+    {
+        NBANDS = 17
+    };
+
+private:
+    enum
+    {
+        M = 15
+    };
+
+    pfc::array_t<int> m_rfft_ip;
+    pfc::array_t<REAL> m_rfft_w;
+
+    REAL fact[M + 1];
+    REAL aa{96};
+    REAL iza{0};
+
+    pfc::array_t<REAL> lires;
+    pfc::array_t<REAL> lires1;
+    pfc::array_t<REAL> lires2;
+    pfc::array_t<REAL> irest;
+    pfc::array_t<REAL> fsamples;
+
+    volatile int chg_ires{0};
+    volatile int cur_ires{0};
+    int winlen{0};
+    int winlenbit{0};
+    int tabsize{0};
+    int nbufsamples{0};
+    int firstframe{1};
+
+    pfc::array_t<REAL> inbuf, outbuf;
+    pfc::array_t<audio_sample> done;
+    int samples_done{0};
+
+    void rfft(int n, int isign, REAL x[])
+    {
+        if(n == 0) {
+            m_rfft_ip.set_size(0);
+            m_rfft_ip.set_size(0);
+            return;
+        }
+
+        const t_size newipsize = 2 + std::sqrt(static_cast<float>(n / 2));
+        if(newipsize > m_rfft_ip.get_size()) {
+            m_rfft_ip.set_size(newipsize);
+            m_rfft_ip[0] = 0;
+        }
+
+        t_size newwsize = n / 2;
+        if(newwsize > m_rfft_ip.get_size()) {
+            m_rfft_w.set_size(newwsize);
+        }
+
+        fft<REAL>::rdft(n, isign, x, m_rfft_ip.get_ptr(), m_rfft_w.get_ptr());
+    }
+
+    REAL izero(REAL x)
+    {
+        REAL ret{1};
+
+        for(int m{1}; m <= M; ++m) {
+            REAL t;
+            t = pow(x / 2, m) / fact[m];
+            ret += t * t;
+        }
+
+        return ret;
+    }
+
+    REAL win(REAL n, int N)
+    {
+        return izero(alpha(aa) * sqrt(1 - (4 * n * n / ((N - 1) * (N - 1))))) / iza;
+    }
+
+    void equ_init(int wb)
+    {
+        lires1.set_size(0);
+        lires2.set_size(0);
+        irest.set_size(0);
+        fsamples.set_size(0);
+
+        winlen    = (1 << (wb - 1)) - 1;
+        winlenbit = wb;
+        tabsize   = 1 << wb;
+
+        lires1.set_size(tabsize);
+        lires1.fill_null();
+        lires2.set_size(tabsize);
+        lires2.fill_null();
+        irest.set_size(tabsize);
+        irest.fill_null();
+        fsamples.set_size(tabsize);
+        fsamples.fill_null();
+        inbuf.set_size(winlen);
+        inbuf.fill_null();
+        outbuf.set_size(tabsize);
+        outbuf.fill_null();
+
+        lires    = lires1;
+        cur_ires = 1;
+        chg_ires = 1;
+
+        for(int i = 0; i <= M; ++i) {
+            fact[i] = 1;
+            for(int j = 1; j <= i; ++j) {
+                fact[i] *= j;
+            }
+        }
+
+        iza = izero(alpha(aa));
+    }
+
+    static REAL alpha(REAL a)
+    {
+        if(a <= 21) {
+            return 0;
+        }
+        if(a <= 50) {
+            return (0.5842 * pow((a - 21.), 0.4)) + (0.07886 * (a - 21));
+        }
+        return 0.1102 * (a - 8.7);
+    }
+
+    static REAL sinc(REAL x)
+    {
+        return x == 0 ? 1 : sin(x) / x;
+    }
+
+    static REAL hn_lpf(int n, REAL f, REAL fs)
+    {
+        static constexpr auto Pi = static_cast<REAL>(3.14159265358979323846264338327950288L);
+        REAL t                   = 1 / fs;
+        REAL omega               = 2 * Pi * f;
+        return 2 * f * t * sinc(n * omega * t);
+    }
+
+    static REAL hn_imp(int n)
+    {
+        return n == 0 ? 1.0 : 0.0;
+    }
+
+    static REAL hn(int n, const paramlist& param2, REAL fs)
+    {
+        paramlistelm* e;
+        REAL ret;
+        REAL lhn;
+
+        lhn = hn_lpf(n, param2.elm->upper, fs);
+        ret = param2.elm->gain * lhn;
+
+        for(e = param2.elm->next; e->next != nullptr && e->upper < fs / 2; e = e->next) {
+            REAL lhn2 = hn_lpf(n, e->upper, fs);
+            ret += e->gain * (lhn2 - lhn);
+            lhn = lhn2;
+        }
+
+        ret += e->gain * (hn_imp(n) - lhn);
+
+        return ret;
+    }
+
+    static void process_param(const double* bc, paramlist* param, paramlist& param2, double fs, int ch)
+    {
+        static constexpr double bands[]
+            = {65.406392, 92.498606, 130.81278, 184.99721, 261.62557, 369.99442, 523.25113, 739.9884, 1046.5023,
+               1479.9768, 2093.0045, 2959.9536, 4186.0091, 5919.9072, 8372.0181, 11839.814, 16744.036};
+
+        paramlistelm** pp;
+        paramlistelm* p;
+        paramlistelm* e2;
+
+        int i;
+
+        delete param2.elm;
+        param2.elm = nullptr;
+
+        for(i = 0, pp = &param2.elm; i <= NBANDS; ++i, pp = &(*pp)->next) {
+            (*pp)        = new paramlistelm;
+            (*pp)->lower = i == 0 ? 0 : bands[i - 1];
+            (*pp)->upper = i == NBANDS ? fs : bands[i];
+            (*pp)->gain  = bc[i];
+        }
+
+        for(paramlistelm* e = param->elm; e != nullptr; e = e->next) {
+            if((ch == 0 && !e->left) || (ch == 1 && !e->right)) {
+                continue;
+            }
+            if(e->lower >= e->upper) {
+                continue;
+            }
+
+            for(p = param2.elm; p != nullptr; p = p->next) {
+                if(p->upper > e->lower) {
+                    break;
+                }
+            }
+
+            while(p != nullptr && p->lower < e->upper) {
+                if(e->lower <= p->lower && p->upper <= e->upper) {
+                    p->gain *= pow(10.0, e->gain / 20.0);
+                    p = p->next;
+                    continue;
+                }
+                if(p->lower < e->lower && e->upper < p->upper) {
+                    e2        = new paramlistelm;
+                    e2->lower = e->upper;
+                    e2->upper = p->upper;
+                    e2->gain  = p->gain;
+                    e2->next  = p->next;
+                    p->next   = e2;
+
+                    e2        = new paramlistelm;
+                    e2->lower = e->lower;
+                    e2->upper = e->upper;
+                    e2->gain  = p->gain * pow(10., e->gain / 20.0);
+                    e2->next  = p->next;
+                    p->next   = e2;
+
+                    p->upper = e->lower;
+
+                    p = p->next->next->next;
+                    continue;
+                }
+                if(p->lower < e->lower) {
+                    e2        = new paramlistelm;
+                    e2->lower = e->lower;
+                    e2->upper = p->upper;
+                    e2->gain  = p->gain * pow(10.0, e->gain / 20.0);
+                    e2->next  = p->next;
+                    p->next   = e2;
+
+                    p->upper = e->lower;
+                    p        = p->next->next;
+                    continue;
+                }
+                if(e->upper < p->upper) {
+                    e2        = new paramlistelm;
+                    e2->lower = e->upper;
+                    e2->upper = p->upper;
+                    e2->gain  = p->gain;
+                    e2->next  = p->next;
+                    p->next   = e2;
+
+                    p->upper = e->upper;
+                    p->gain  = p->gain * pow(10.0, e->gain / 20.0);
+                    p        = p->next->next;
+                    continue;
+                }
+                abort();
+            }
+        }
+    }
+
+public:
+    explicit supereq(int wb = 14)
+    {
+        memset(fact, 0, sizeof(fact));
+
+        equ_init(wb);
+    }
+
+    void equ_makeTable(double* bc, class paramlist* param, double fs) override
+    {
+        int i;
+        int cires = cur_ires;
+
+        if(fs <= 0) {
+            return;
+        }
+
+        paramlist param2;
+
+        // L
+
+        process_param(bc, param, param2, fs, 0);
+
+        for(i = 0; i < winlen; i++) {
+            irest[i] = hn(i - (winlen / 2), param2, fs) * win(i - (winlen / 2), winlen);
+        }
+
+        for(; i < tabsize; i++) {
+            irest[i] = 0;
+        }
+
+        rfft(tabsize, 1, irest.get_ptr());
+
+        REAL* nires = cires == 1 ? lires2.get_ptr() : lires1.get_ptr();
+
+        for(i = 0; i < tabsize; i++) {
+            nires[i] = irest[i];
+        }
+
+        chg_ires = cires == 1 ? 2 : 1;
+    }
+
+    void equ_clearbuf() override
+    {
+        firstframe   = 1;
+        samples_done = 0;
+        nbufsamples  = 0;
+    }
+
+    void write_samples(audio_sample* buf, int nsamples) override
+    {
+        int i;
+
+        if(chg_ires) {
+            cur_ires = chg_ires;
+            lires    = cur_ires == 1 ? lires1 : lires2;
+            chg_ires = 0;
+        }
+
+        int p = 0;
+
+        int flush_length = 0;
+
+        if(!buf) // flush
+        {
+            if(nbufsamples == 0) {
+                return;
+            }
+            flush_length = nbufsamples;
+            nsamples     = winlen - nbufsamples;
+        }
+
+        while(nbufsamples + nsamples >= winlen) {
+            if(buf) {
+                for(i = 0; i < winlen - nbufsamples; ++i) {
+                    inbuf[nbufsamples + i] = static_cast<REAL>(buf[i + p]);
+                }
+            }
+            else {
+                for(i = 0; i < winlen - nbufsamples; ++i) {
+                    inbuf[nbufsamples + i] = 0;
+                }
+            }
+
+            for(i = winlen; i < tabsize; ++i) {
+                outbuf[i - winlen] = outbuf[i];
+            }
+
+            p += winlen - nbufsamples;
+            nsamples -= winlen - nbufsamples;
+            nbufsamples = 0;
+
+            REAL* ires = lires.get_ptr();
+            for(i = 0; i < winlen; ++i) {
+                fsamples[i] = inbuf[i];
+            }
+
+            for(i = winlen; i < tabsize; ++i) {
+                fsamples[i] = 0;
+            }
+
+            rfft(tabsize, 1, fsamples.get_ptr());
+
+            fsamples[0] = ires[0] * fsamples[0];
+            fsamples[1] = ires[1] * fsamples[1];
+
+            for(i = 1; i < tabsize / 2; ++i) {
+                REAL re;
+                REAL im;
+                re = (ires[i * 2] * fsamples[i * 2]) - (ires[(i * 2) + 1] * fsamples[(i * 2) + 1]);
+                im = (ires[(i * 2) + 1] * fsamples[i * 2]) + (ires[i * 2] * fsamples[(i * 2) + 1]);
+
+                fsamples[i * 2]       = re;
+                fsamples[(i * 2) + 1] = im;
+            }
+            rfft(tabsize, -1, fsamples.get_ptr());
+
+            for(i = 0; i < winlen; ++i) {
+                outbuf[i] += fsamples[i] / tabsize * 2;
+            }
+
+            for(i = winlen; i < tabsize; ++i) {
+                outbuf[i] = fsamples[i] / tabsize * 2;
+            }
+
+            int out_length = flush_length > 0 ? flush_length + (winlen / 2) : winlen;
+
+            done.grow_size(samples_done + out_length);
+
+            for(i = firstframe ? winlen / 2 : 0; i < out_length; i++) {
+                done[samples_done++] = outbuf[i];
+            }
+            firstframe = 0;
+        }
+
+        if(buf) {
+            for(i = 0; i < nsamples; ++i) {
+                inbuf[nbufsamples + i] = static_cast<REAL>(buf[i + p]);
+            }
+            p += nsamples;
+        }
+        nbufsamples += nsamples;
+    }
+
+    audio_sample* get_output(int* nsamples) override
+    {
+        *nsamples    = samples_done;
+        samples_done = 0;
+        return done.get_ptr();
+    }
+
+    int samples_buffered() override
+    {
+        return nbufsamples;
+    }
+
+    ~supereq() override = default;
+};
+
+#endif

--- a/src/plugins/equaliser/supereq/supereq_compat.h
+++ b/src/plugins/equaliser/supereq/supereq_compat.h
@@ -1,0 +1,86 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#ifndef NOVTABLE
+#if defined(_MSC_VER)
+#define NOVTABLE __declspec(novtable)
+#else
+#define NOVTABLE
+#endif
+#endif
+
+using t_size       = size_t;
+using audio_sample = double;
+
+namespace pfc {
+template <typename T>
+class array_t
+{
+public:
+    void set_size(const t_size size)
+    {
+        m_data.resize(size);
+    }
+
+    void grow_size(const t_size size)
+    {
+        if(m_data.size() < size) {
+            m_data.resize(size);
+        }
+    }
+
+    void fill_null()
+    {
+        std::fill(m_data.begin(), m_data.end(), T{});
+    }
+
+    [[nodiscard]] t_size get_size() const
+    {
+        return m_data.size();
+    }
+
+    T* get_ptr()
+    {
+        return m_data.empty() ? nullptr : m_data.data();
+    }
+
+    [[nodiscard]] const T* get_ptr() const
+    {
+        return m_data.empty() ? nullptr : m_data.data();
+    }
+
+    T& operator[](const t_size index)
+    {
+        return m_data[index];
+    }
+
+    const T& operator[](const t_size index) const
+    {
+        return m_data[index];
+    }
+
+private:
+    std::vector<T> m_data;
+};
+} // namespace pfc

--- a/src/plugins/equaliser/supereqadapter.cpp
+++ b/src/plugins/equaliser/supereqadapter.cpp
@@ -1,0 +1,310 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "supereqadapter.h"
+
+#include "supereq/paramlist.h"
+#include "supereq/supereq.h"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <limits>
+
+namespace {
+int clampWindowBits(int bits)
+{
+    return std::clamp(bits, 8, 18);
+}
+
+int windowLengthForBits(int bits)
+{
+    const int safeBits = clampWindowBits(bits);
+    return (1 << (safeBits - 1)) - 1;
+}
+
+int windowBitsForSampleRate(int sampleRate, int defaultBits = Fooyin::Equaliser::SuperEq::Processor::DefaultWindowBits,
+                            int referenceRate = 96000, int minBits = 8, int maxBits = 16)
+{
+    if(sampleRate <= 0 || referenceRate <= 0) {
+        return std::clamp(defaultBits, minBits, maxBits);
+    }
+
+    const int refLen = windowLengthForBits(defaultBits); // samples
+    if(refLen <= 0) {
+        return std::clamp(defaultBits, minBits, maxBits);
+    }
+
+    const auto num        = static_cast<int64_t>(refLen) * static_cast<int64_t>(sampleRate);
+    const auto den        = static_cast<int64_t>(referenceRate);
+    const auto desiredLen = std::max<int64_t>(1, (num + den / 2) / den);
+
+    const int bits = 1 + std::bit_width(static_cast<uint64_t>(desiredLen));
+    return std::clamp(bits, minBits, maxBits);
+}
+
+double dbToAmp(const double valueDb)
+{
+    static constexpr double Ln10 = 2.30258509299404568402;
+    return std::exp((Ln10 * valueDb) / 20.0);
+}
+} // namespace
+
+namespace Fooyin::Equaliser::SuperEq {
+class Processor::ChannelProcessor
+{
+public:
+    explicit ChannelProcessor(const int windowBits)
+        : m_eq{windowBits}
+    { }
+
+    void setTable(const std::array<double, BandCount>& linearBands, const double sampleRate)
+    {
+        std::array<double, BandCount> bands = linearBands;
+        m_eq.equ_makeTable(bands.data(), &m_paramRoot, sampleRate);
+    }
+
+    void reset()
+    {
+        m_eq.equ_clearbuf();
+    }
+
+    void writeSamples(double* samples, const int count)
+    {
+        m_eq.write_samples(samples, count);
+    }
+
+    void flush()
+    {
+        m_eq.write_samples(nullptr, 0);
+    }
+
+    const double* getOutput(int& samples)
+    {
+        return m_eq.get_output(&samples);
+    }
+
+    [[nodiscard]] int pendingInputSamples()
+    {
+        return m_eq.samples_buffered();
+    }
+
+private:
+    supereq<double> m_eq;
+    paramlist m_paramRoot;
+};
+
+Processor::Processor()
+    : Processor{DefaultWindowBits}
+{ }
+
+Processor::Processor(const int windowBits)
+    : m_windowBits{clampWindowBits(windowBits)}
+    , m_channelCount{0}
+    , m_sampleRate{44100.0}
+    , m_tableDirty{true}
+    , m_preampDb{0.0}
+    , m_bandDb{}
+{
+    m_bandDb.fill(0.0);
+}
+
+Processor::~Processor() = default;
+
+void Processor::prepare(const int channelCount, const double sampleRate)
+{
+    const int safeChannels      = std::max(1, channelCount);
+    const double safeRate       = sampleRate > 0.0 ? sampleRate : 44100.0;
+    const int adaptedWindowBits = windowBitsForSampleRate(static_cast<int>(std::lround(safeRate)), DefaultWindowBits);
+
+    m_channelCount = safeChannels;
+    m_sampleRate   = safeRate;
+    m_windowBits   = adaptedWindowBits;
+
+    m_channels.clear();
+    m_channels.reserve(static_cast<size_t>(safeChannels));
+    for(int i{0}; i < safeChannels; ++i) {
+        m_channels.push_back(std::make_unique<ChannelProcessor>(m_windowBits));
+    }
+
+    m_outputPointers.resize(static_cast<size_t>(safeChannels), nullptr);
+    m_outputSamples.resize(static_cast<size_t>(safeChannels), 0);
+
+    m_tableDirty = true;
+}
+
+void Processor::setGainDb(const double preampDb, const std::array<double, BandCount>& bandDb)
+{
+    m_preampDb   = preampDb;
+    m_bandDb     = bandDb;
+    m_tableDirty = true;
+}
+
+void Processor::reset()
+{
+    for(auto& channel : m_channels) {
+        if(channel) {
+            (*channel).reset();
+        }
+    }
+}
+
+void Processor::rebuildTablesIfNeeded()
+{
+    if(!m_tableDirty) {
+        return;
+    }
+
+    std::array<double, BandCount> linearBands{};
+    for(size_t i{0}; i < linearBands.size(); ++i) {
+        linearBands[i] = dbToAmp(m_preampDb + m_bandDb[i]);
+    }
+
+    for(auto& channel : m_channels) {
+        if(channel) {
+            channel->setTable(linearBands, m_sampleRate);
+        }
+    }
+
+    m_tableDirty = false;
+}
+
+int Processor::processInterleaved(std::span<const double> inputInterleaved, std::vector<double>& outputInterleaved)
+{
+    outputInterleaved.clear();
+
+    if(m_channelCount <= 0 || m_channels.empty() || inputInterleaved.empty()) {
+        return 0;
+    }
+
+    const auto channels = static_cast<size_t>(m_channelCount);
+    const size_t frames = inputInterleaved.size() / channels;
+    if(frames == 0) {
+        return 0;
+    }
+
+    rebuildTablesIfNeeded();
+
+    m_channelInputScratch.resize(frames * channels);
+
+    for(size_t frame{0}; frame < frames; ++frame) {
+        const size_t srcBase = frame * channels;
+
+        for(size_t channel{0}; channel < channels; ++channel) {
+            m_channelInputScratch[(channel * frames) + frame] = inputInterleaved[srcBase + channel];
+        }
+    }
+
+    int outputFrames = std::numeric_limits<int>::max();
+
+    for(size_t channel{0}; channel < channels; ++channel) {
+        auto& processor = m_channels[channel];
+        processor->writeSamples(&m_channelInputScratch[channel * frames], static_cast<int>(frames));
+
+        int sampleCount{0};
+        m_outputPointers[channel] = processor->getOutput(sampleCount);
+        m_outputSamples[channel]  = sampleCount;
+
+        outputFrames = std::min(outputFrames, sampleCount);
+    }
+
+    if(outputFrames <= 0) {
+        return 0;
+    }
+
+    outputInterleaved.resize(static_cast<size_t>(outputFrames) * channels);
+    for(int frame{0}; frame < outputFrames; ++frame) {
+        const size_t dstBase = static_cast<size_t>(frame) * channels;
+
+        for(size_t channel{0}; channel < channels; ++channel) {
+            outputInterleaved[dstBase + channel] = m_outputPointers[channel][frame];
+        }
+    }
+
+    return outputFrames;
+}
+
+int Processor::flushInterleaved(std::vector<double>& outputInterleaved)
+{
+    outputInterleaved.clear();
+
+    if(m_channelCount <= 0 || m_channels.empty()) {
+        return 0;
+    }
+
+    rebuildTablesIfNeeded();
+
+    const auto channels = static_cast<size_t>(m_channelCount);
+    int outputFrames    = std::numeric_limits<int>::max();
+
+    for(size_t channel{0}; channel < channels; ++channel) {
+        auto& processor = m_channels[channel];
+        processor->flush();
+
+        int sampleCount{0};
+        m_outputPointers[channel] = processor->getOutput(sampleCount);
+        m_outputSamples[channel]  = sampleCount;
+
+        outputFrames = std::min(outputFrames, sampleCount);
+    }
+
+    if(outputFrames <= 0) {
+        return 0;
+    }
+
+    outputInterleaved.resize(static_cast<size_t>(outputFrames) * channels);
+
+    for(int frame{0}; frame < outputFrames; ++frame) {
+        const size_t dstBase = static_cast<size_t>(frame) * channels;
+
+        for(size_t channel{0}; channel < channels; ++channel) {
+            outputInterleaved[dstBase + channel] = m_outputPointers[channel][frame];
+        }
+    }
+
+    return outputFrames;
+}
+
+int Processor::pendingInputFrames() const
+{
+    if(m_channels.empty()) {
+        return 0;
+    }
+
+    int pendingSamples{0};
+
+    for(const auto& channel : m_channels) {
+        if(channel) {
+            pendingSamples = std::max(pendingSamples, channel->pendingInputSamples());
+        }
+    }
+
+    return std::max(0, pendingSamples);
+}
+
+int Processor::channelCount() const
+{
+    return m_channelCount;
+}
+
+int Processor::windowLength() const
+{
+    return windowLengthForBits(m_windowBits);
+}
+} // namespace Fooyin::Equaliser::SuperEq

--- a/src/plugins/equaliser/supereqadapter.h
+++ b/src/plugins/equaliser/supereqadapter.h
@@ -1,0 +1,69 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace Fooyin::Equaliser::SuperEq {
+class Processor
+{
+public:
+    static constexpr auto BandCount         = 18;
+    static constexpr auto DefaultWindowBits = 14;
+
+    Processor();
+    explicit Processor(int windowBits);
+    ~Processor();
+
+    void prepare(int channelCount, double sampleRate);
+    void setGainDb(double preampDb, const std::array<double, BandCount>& bandDb);
+
+    void reset();
+
+    int processInterleaved(std::span<const double> inputInterleaved, std::vector<double>& outputInterleaved);
+    int flushInterleaved(std::vector<double>& outputInterleaved);
+
+    [[nodiscard]] int pendingInputFrames() const;
+    [[nodiscard]] int channelCount() const;
+    [[nodiscard]] int windowLength() const;
+
+private:
+    class ChannelProcessor;
+
+    void rebuildTablesIfNeeded();
+
+    int m_windowBits;
+    int m_channelCount;
+    double m_sampleRate;
+    bool m_tableDirty;
+
+    double m_preampDb;
+    std::array<double, BandCount> m_bandDb;
+
+    std::vector<std::unique_ptr<ChannelProcessor>> m_channels;
+
+    std::vector<double> m_channelInputScratch;
+    std::vector<const double*> m_outputPointers;
+    std::vector<int> m_outputSamples;
+};
+} // namespace Fooyin::Equaliser::SuperEq


### PR DESCRIPTION
This PR introduces a new SuperEQ-based DSP plugin that adds an 18-band equaliser.

 It includes support for importing/exporting via `.feq` files, which are compatible with foobar2000 presets.

<img width="991" height="383" alt="image" src="https://github.com/user-attachments/assets/63dcec22-f7be-4af9-9599-d59bf665c00b" />

Resolves #283 