### PR TITLE
Ignore mouse events if not left right or middle button

### DIFF
--- a/include/gui/widgets/extendabletableview.h
+++ b/include/gui/widgets/extendabletableview.h
@@ -90,6 +90,7 @@ protected:
     virtual void setupContextActions(QMenu* menu, const QPoint& pos);
     void contextMenuEvent(QContextMenuEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
 private:
     std::unique_ptr<ExtendableTableViewPrivate> p;

--- a/src/gui/controls/seekbar.cpp
+++ b/src/gui/controls/seekbar.cpp
@@ -138,17 +138,20 @@ void TrackSlider::mousePressEvent(QMouseEvent* event)
     }
 
     Qt::MouseButton button = event->button();
-    if(button == Qt::LeftButton) {
-        const int absolute = style()->styleHint(QStyle::SH_Slider_AbsoluteSetButtons);
-        if(Qt::LeftButton & absolute) {
-            button = Qt::LeftButton;
-        }
-        else if(Qt::MiddleButton & absolute) {
-            button = Qt::MiddleButton;
-        }
-        else if(Qt::RightButton & absolute) {
-            button = Qt::RightButton;
-        }
+    if(button != Qt::LeftButton) {
+        event->ignore();
+        return;
+    }
+
+    const int absolute = style()->styleHint(QStyle::SH_Slider_AbsoluteSetButtons);
+    if(Qt::LeftButton & absolute) {
+        button = Qt::LeftButton;
+    }
+    else if(Qt::MiddleButton & absolute) {
+        button = Qt::MiddleButton;
+    }
+    else if(Qt::RightButton & absolute) {
+        button = Qt::RightButton;
     }
 
     QMouseEvent modifiedEvent{event->type(), event->position(), event->globalPosition(), button,

--- a/src/gui/librarytree/librarytreeview.cpp
+++ b/src/gui/librarytree/librarytreeview.cpp
@@ -52,7 +52,10 @@ void LibraryTreeView::setLoading(bool isLoading)
 
 void LibraryTreeView::mousePressEvent(QMouseEvent* event)
 {
-    QTreeView::mousePressEvent(event);
+    if(event->button() > Qt::MiddleButton) {
+        event->ignore();
+        return;
+    }
 
     const QModelIndex index = indexAt(event->position().toPoint());
 
@@ -62,12 +65,16 @@ void LibraryTreeView::mousePressEvent(QMouseEvent* event)
 
     if(event->button() == Qt::MiddleButton) {
         emit middleClicked(index);
+        return;
     }
+
+    QTreeView::mousePressEvent(event);
 }
 
 void LibraryTreeView::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if(event->button() == Qt::MiddleButton) {
+    if(event->button() != Qt::LeftButton) {
+        event->ignore();
         return;
     }
     QTreeView::mouseDoubleClickEvent(event);

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -109,6 +109,25 @@ void restoreExpandedState(QTreeView* view, QAbstractItemModel* model, QByteArray
         }
     }
 }
+
+class OrganiserTreeView : public QTreeView
+{
+public:
+    explicit OrganiserTreeView(QWidget* parent = nullptr)
+        : QTreeView(parent)
+    { }
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override
+    {
+        if(event->button() != Qt::LeftButton) {
+            event->ignore();
+            return;
+        }
+        QTreeView::mousePressEvent(event);
+    }
+};
+
 } // namespace
 
 namespace Fooyin {
@@ -119,7 +138,7 @@ PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistInter
     , m_settings{settings}
     , m_playlistInteractor{playlistInteractor}
     , m_playerController{playlistInteractor->playlistController()->playerController()}
-    , m_organiserTree{new QTreeView(this)}
+    , m_organiserTree{new OrganiserTreeView(this)}
     , m_model{new PlaylistOrganiserModel(playlistInteractor->handler(), m_playerController)}
     , m_context{new WidgetContext(this, Context{Id{"Context.PlaylistOrganiser."}.append(Utils::generateUniqueHash())},
                                   this)}

--- a/src/gui/widgets/autoheaderview.cpp
+++ b/src/gui/widgets/autoheaderview.cpp
@@ -671,6 +671,7 @@ void AutoHeaderView::restoreHeaderState(const QByteArray& state)
 void AutoHeaderView::mousePressEvent(QMouseEvent* event)
 {
     if(p->m_state != SectionState::None || event->button() != Qt::LeftButton) {
+        event->ignore();
         return;
     }
 
@@ -770,6 +771,11 @@ void AutoHeaderView::mouseReleaseEvent(QMouseEvent* event)
 
 void AutoHeaderView::mouseDoubleClickEvent(QMouseEvent* event)
 {
+    if(event->button() != Qt::LeftButton) {
+        event->ignore();
+        return;
+    }
+
     p->m_state = SectionState::Resizing;
 
     QHeaderView::mouseDoubleClickEvent(event);

--- a/src/gui/widgets/editabletabbar.cpp
+++ b/src/gui/widgets/editabletabbar.cpp
@@ -106,6 +106,11 @@ bool EditableTabBar::event(QEvent* event)
 
 void EditableTabBar::mouseDoubleClickEvent(QMouseEvent* event)
 {
+    if(event->button() > Qt::MiddleButton) {
+        event->ignore();
+        return;
+    }
+
     const QPoint pos = event->position().toPoint();
 
     if(event->button() & Qt::MiddleButton) {
@@ -121,6 +126,11 @@ void EditableTabBar::mouseDoubleClickEvent(QMouseEvent* event)
 
 void EditableTabBar::mousePressEvent(QMouseEvent* event)
 {
+    if(event->button() > Qt::MiddleButton) {
+        event->ignore();
+        return;
+    }
+
     const QPoint pos = event->position().toPoint();
 
     if(event->button() & Qt::MiddleButton) {

--- a/src/gui/widgets/expandedtreeview.cpp
+++ b/src/gui/widgets/expandedtreeview.cpp
@@ -3448,6 +3448,11 @@ void ExpandedTreeView::dragLeaveEvent(QDragLeaveEvent* /*event*/)
 
 void ExpandedTreeView::mousePressEvent(QMouseEvent* event)
 {
+    if(event->button() > Qt::MiddleButton) {
+        event->ignore();
+        return;
+    }
+
     const QPoint pos        = event->position().toPoint();
     const QModelIndex index = indexAt(pos);
 
@@ -3485,7 +3490,8 @@ void ExpandedTreeView::mousePressEvent(QMouseEvent* event)
 
 void ExpandedTreeView::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if(event->button() == Qt::MiddleButton) {
+    if(event->button() != Qt::LeftButton) {
+        event->ignore();
         return;
     }
     QAbstractItemView::mouseDoubleClickEvent(event);

--- a/src/gui/widgets/extendabletableview.cpp
+++ b/src/gui/widgets/extendabletableview.cpp
@@ -439,6 +439,15 @@ void ExtendableTableView::resizeEvent(QResizeEvent* event)
 
     p->updateToolArea();
 }
+
+void ExtendableTableView::mousePressEvent(QMouseEvent* event)
+{
+    if(event->button() > Qt::RightButton) {
+        event->ignore();
+        return;
+    }
+    QTableView::mousePressEvent(event);
+}
 } // namespace Fooyin
 
 #include "extendabletableview.moc"

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -33,17 +33,20 @@ Slider::Slider(Qt::Orientation type, QWidget* parent)
 void Slider::mousePressEvent(QMouseEvent* e)
 {
     Qt::MouseButton button = e->button();
-    if(button == Qt::LeftButton) {
-        const int absolute = style()->styleHint(QStyle::SH_Slider_AbsoluteSetButtons);
-        if(Qt::LeftButton & absolute) {
-            button = Qt::LeftButton;
-        }
-        else if(Qt::MiddleButton & absolute) {
-            button = Qt::MiddleButton;
-        }
-        else if(Qt::RightButton & absolute) {
-            button = Qt::RightButton;
-        }
+    if(button != Qt::LeftButton) {
+        e->ignore();
+        return;
+    }
+
+    const int absolute = style()->styleHint(QStyle::SH_Slider_AbsoluteSetButtons);
+    if(Qt::LeftButton & absolute) {
+        button = Qt::LeftButton;
+    }
+    else if(Qt::MiddleButton & absolute) {
+        button = Qt::MiddleButton;
+    }
+    else if(Qt::RightButton & absolute) {
+        button = Qt::RightButton;
     }
 
     QMouseEvent event(e->type(), e->position(), e->globalPosition(), button, button, e->modifiers());


### PR DESCRIPTION
In `mousePressEvent` handlers (and `mouseDoubleClickEvent` where relevant), explicitly `event->ignore()` if button is not left click (or middle click as appropriate). This fixes a good deal of weirdness where middle and forward/back mouse buttons would be able to interact with UI elements (e.g. forward/back button can move playlist tabs).

Components changed:
* Seekbar (middle click would visually shift the slider with no actual effect)
* Slider (middle click would be able to adjust volume)
* LibraryTreeView
* ExpandedTreeView (playlist and playback queue)
* AutoHeaderView (playlist column headers)
* EditableTabBar (playlist tabs)
* ExtendableTableView (tag editor and others)
* PlaylistOrganiser
  * Unfortunately it was necessary to implement a `QTreeView` subclass just to override `mousePressEvent`.

This is also a precursor to implementing track control with mouse forward and back buttons in a later PR (check out https://github.com/magusjanus/fooyin/commit/9c56395efc06ab587a4d5c52cd0b8e155296c6a8).