### PR TITLE
Adjust lyrics panel colors when theme changed

### DIFF
--- a/src/plugins/lyrics/lyricscolours.h
+++ b/src/plugins/lyrics/lyricscolours.h
@@ -38,26 +38,34 @@ struct Colours
         WordSynced,
         LineUnsynced
     };
-    
+
     QMap<Type, QColor> lyricsColours;
-    
-    [[nodiscard]] static QColor defaultColour(Type type)
+
+    [[nodiscard]] static QColor defaultColour(Type type, const QPalette& palette = QApplication::palette())
     {
         switch(type) {
-            case Type::Background:     return QApplication::palette().base().color();
-            case Type::LineUnplayed:   return QApplication::palette().placeholderText().color();
-            case Type::LinePlayed:     return QApplication::palette().placeholderText().color();
-            case Type::LineSynced:     return QApplication::palette().text().color();
-            case Type::WordLineSynced: return QApplication::palette().text().color();
-            case Type::WordSynced:     return QApplication::palette().highlight().color();
-            case Type::LineUnsynced:   return QApplication::palette().text().color();
-            default:                   return {};
+            case Type::Background:
+                return palette.base().color();
+            case Type::LineUnplayed:
+                return palette.placeholderText().color();
+            case Type::LinePlayed:
+                return palette.placeholderText().color();
+            case Type::LineSynced:
+                return palette.text().color();
+            case Type::WordLineSynced:
+                return palette.text().color();
+            case Type::WordSynced:
+                return palette.highlight().color();
+            case Type::LineUnsynced:
+                return palette.text().color();
+            default:
+                return {};
         }
     }
 
-    [[nodiscard]] QColor colour(Type type) const
+    [[nodiscard]] QColor colour(Type type, const QPalette& palette = QApplication::palette()) const
     {
-        return lyricsColours.value(type, defaultColour(type));
+        return lyricsColours.value(type, defaultColour(type, palette));
     }
 
     void setColour(Type type, const QColor& colour)


### PR DESCRIPTION
currently when changing theme (dark <-> light), the lyrics panel color (text, background, etc.) will not update.

- ive written some code that fixes this by not storing the colors as a static list. This doesn't break custom colors users may set.

- instead of using darken for out-of-focus text as the default (which only affect dark mode), I switch this to placeholder text (which achieves the same effect with colorscheme ambivalence).

I'm hoping to fix playlist tracks not updating color and icons as well, but maybe a later merge (they seem more complicated)