### PR TITLE
[gme] Fix playback startup

### DIFF
--- a/src/plugins/gme/gmeinput.cpp
+++ b/src/plugins/gme/gmeinput.cpp
@@ -227,11 +227,6 @@ std::optional<AudioFormat> GmeDecoder::init(const AudioSource& source, const Tra
 
     gme_enable_accuracy(m_emu.get(), 1);
 
-    return m_format;
-}
-
-void GmeDecoder::start()
-{
     gme_start_track(m_emu.get(), m_subsong);
 
     if(m_loopLength != 0 && m_repeatTrack) {
@@ -246,11 +241,19 @@ void GmeDecoder::start()
         gme_set_fade(m_emu.get(), m_duration - 8000);
 #endif
     }
+
+    return m_format;
+}
+
+void GmeDecoder::start()
+{
+    m_isDecoding = true;
 }
 
 void GmeDecoder::stop()
 {
     m_emu.reset();
+    m_isDecoding = false;
 }
 
 void GmeDecoder::seek(uint64_t pos)
@@ -263,6 +266,10 @@ void GmeDecoder::seek(uint64_t pos)
 
 AudioBuffer GmeDecoder::readBuffer(size_t bytes)
 {
+    if(!m_isDecoding) {
+        return {};
+    }
+
     if(gme_track_ended(m_emu.get())) {
         return {};
     }

--- a/src/plugins/gme/gmeinput.h
+++ b/src/plugins/gme/gmeinput.h
@@ -52,6 +52,7 @@ public:
 
 private:
     bool m_repeatTrack;
+    bool m_isDecoding;
     FySettings m_settings;
     AudioFormat m_format;
     MusicEmuPtr m_emu;


### PR DESCRIPTION
Playback repeats itself within about 3 seconds of startup if start() is allowed to restart the track.