### PR TITLE
Add boundary fading

### DIFF
--- a/include/core/engine/fadingdefs.h
+++ b/include/core/engine/fadingdefs.h
@@ -76,16 +76,17 @@ struct FadeSpec
 //! Fading policy group used for transport operations.
 struct FadingValues
 {
-    FadeSpec pause;
-    FadeSpec stop;
+    FadeSpec pause{.in = 120, .out = 120, .curve = FadeCurve::Linear};
+    FadeSpec stop{.in = 120, .out = 300, .curve = FadeCurve::Linear};
+    FadeSpec boundary{.in = 700, .out = 700, .curve = FadeCurve::Linear, .enabled = false};
 };
 
 //! Crossfade policy for manual/automatic track changes and seek transitions.
 struct CrossfadingValues
 {
-    FadeSpec manualChange;
-    FadeSpec autoChange;
-    FadeSpec seek;
+    FadeSpec manualChange{.in = 300, .out = 300, .curve = FadeCurve::Linear};
+    FadeSpec autoChange{.in = 700, .out = 700, .curve = FadeCurve::Linear};
+    FadeSpec seek{.in = 120, .out = 120, .curve = FadeCurve::Linear};
 };
 
 FYCORE_EXPORT QDataStream& operator<<(QDataStream& stream, const FadeSpec& fading);
@@ -97,5 +98,6 @@ FYCORE_EXPORT QDataStream& operator>>(QDataStream& stream, CrossfadingValues& fa
 } // namespace Fooyin::Engine
 
 Q_DECLARE_METATYPE(Fooyin::Engine::FadeCurve)
+Q_DECLARE_METATYPE(Fooyin::Engine::FadeSpec)
 Q_DECLARE_METATYPE(Fooyin::Engine::FadingValues)
 Q_DECLARE_METATYPE(Fooyin::Engine::CrossfadingValues)

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -204,6 +204,8 @@ AudioEngine::AudioEngine(std::shared_ptr<AudioLoader> audioLoader, SettingsManag
     , m_autoCrossfadeTailFadeActive{false}
     , m_autoCrossfadeTailFadeStreamId{InvalidStreamId}
     , m_autoCrossfadeTailFadeGeneration{0}
+    , m_autoBoundaryFadeActive{false}
+    , m_autoBoundaryFadeGeneration{0}
 {
     setupSettings();
 
@@ -380,6 +382,7 @@ bool AudioEngine::startTrackCrossfade(const Track& track, bool isManualChange)
     const bool skipFadeOutStart = hasEarlyAutoTailFade && overlapDurationMs <= 0;
 
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
 
     setCurrentTrackContext(track);
     updateTrackStatus(Engine::TrackStatus::Loading);
@@ -465,6 +468,7 @@ void AudioEngine::performSeek(uint64_t positionMs, uint64_t requestId)
     m_positionCoordinator.clearGaplessHold();
 
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
 
     if(m_analysisBus) {
         m_analysisBus->flush();
@@ -768,6 +772,7 @@ void AudioEngine::reinitOutputForCurrentFormat()
     }
 
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState();
     m_transitions.cancelPendingSeek();
     m_transitions.setSeekInProgress(false);
     clearPendingAnalysisData();
@@ -959,11 +964,80 @@ void AudioEngine::maybeBeginAutoCrossfadeTailFadeOut(const AudioStreamPtr& strea
     m_autoCrossfadeTailFadeGeneration = m_trackGeneration;
 }
 
+void AudioEngine::maybeBeginAutoBoundaryFadeOut(uint64_t relativePosMs)
+{
+    if(!hasPlaybackState(Engine::PlaybackState::Playing)) {
+        return;
+    }
+
+    if(m_transitions.autoTransitionMode() != AutoTransitionMode::BoundaryFade) {
+        return;
+    }
+
+    const auto& boundarySpec = m_fadingValues.boundary;
+    if(!boundarySpec.enabled) {
+        return;
+    }
+
+    const int fadeOutMs = std::max(0, boundarySpec.effectiveOutMs());
+    if(fadeOutMs <= 0) {
+        return;
+    }
+
+    if(m_fadeController.hasPendingFade()) {
+        return;
+    }
+
+    if(m_autoBoundaryFadeActive && m_autoBoundaryFadeGeneration == m_trackGeneration) {
+        return;
+    }
+
+    if(m_currentTrack.duration() == 0 || relativePosMs >= m_currentTrack.duration()) {
+        return;
+    }
+
+    const uint64_t remainingTrackMs = m_currentTrack.duration() - relativePosMs;
+    const int remainingWindowMs
+        = static_cast<int>(std::min<uint64_t>(remainingTrackMs, std::numeric_limits<int>::max()));
+    const int tailFadeOutMs = std::min(fadeOutMs, remainingWindowMs);
+
+    if(tailFadeOutMs <= 0) {
+        return;
+    }
+
+    m_pipeline.setFaderCurve(boundarySpec.curve);
+    m_pipeline.faderFadeOut(tailFadeOutMs, m_volume, 0);
+    m_autoBoundaryFadeActive     = true;
+    m_autoBoundaryFadeGeneration = m_trackGeneration;
+}
+
+void AudioEngine::applyAutoBoundaryFadeIn(const bool allowFadeInOnly)
+{
+    if(!allowFadeInOnly && !m_autoBoundaryFadeActive) {
+        return;
+    }
+
+    const int fadeInMs = std::max(0, m_fadingValues.boundary.effectiveInMs());
+    m_pipeline.setFaderCurve(m_fadingValues.boundary.curve);
+    m_pipeline.faderFadeIn(fadeInMs, m_volume, 0);
+    clearAutoBoundaryFadeState();
+}
+
 void AudioEngine::clearAutoCrossfadeTailFadeState()
 {
     m_autoCrossfadeTailFadeActive     = false;
     m_autoCrossfadeTailFadeStreamId   = InvalidStreamId;
     m_autoCrossfadeTailFadeGeneration = 0;
+}
+
+void AudioEngine::clearAutoBoundaryFadeState(bool restoreOutput)
+{
+    if(restoreOutput && m_autoBoundaryFadeActive) {
+        m_pipeline.faderFadeIn(0, m_volume, 0);
+    }
+
+    m_autoBoundaryFadeActive     = false;
+    m_autoBoundaryFadeGeneration = 0;
 }
 
 void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_t trackEndingPosMs,
@@ -974,6 +1048,7 @@ void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_
 
     if(result.aboutToFinish) {
         maybeBeginAutoCrossfadeTailFadeOut(stream, trackEndingPosMs);
+        maybeBeginAutoBoundaryFadeOut(trackEndingPosMs);
         emit trackAboutToFinish(m_currentTrack, m_trackGeneration);
     }
     if(result.readyToSwitch && transitionMode == AutoTransitionMode::Crossfade) {
@@ -1452,6 +1527,8 @@ AudioEngine::TrackEndingResult AudioEngine::checkTrackEnding(const AudioStreamPt
     input.gaplessEnabled                 = m_gaplessEnabled;
     input.autoFadeOutMs                  = m_crossfadingValues.autoChange.effectiveOutMs();
     input.autoFadeInMs                   = m_crossfadingValues.autoChange.effectiveInMs();
+    input.boundaryFadeEnabled            = m_fadingValues.boundary.isConfigured();
+    input.boundaryFadeOutMs              = m_fadingValues.boundary.effectiveOutMs();
     input.autoPrepareLeadMs              = preferredPreparedPrefillMs();
     input.gaplessPrepareWindowMs         = GaplessPrepareLeadMs;
 
@@ -1499,9 +1576,13 @@ AudioEngine::evaluateAutoTransitionEligibility(const Track& track, bool isManual
     const int baseFadeOutMs    = transitionSpec.effectiveOutMs();
     const int baseFadeInMs     = transitionSpec.effectiveInMs();
 
-    const bool crossfadeMix   = m_crossfadeEnabled && (baseFadeInMs > 0 || baseFadeOutMs > 0);
-    const bool gaplessHandoff = !isManualChange && m_gaplessEnabled
-                             && (!m_crossfadeEnabled || !m_crossfadingValues.autoChange.isConfigured());
+    const bool crossfadeMix = m_crossfadeEnabled && (baseFadeInMs > 0 || baseFadeOutMs > 0);
+    const bool boundaryFadeEnabled
+        = !isManualChange && m_fadingEnabled && m_fadingValues.boundary.isConfigured() && !crossfadeMix;
+    const bool gaplessHandoff
+        = !isManualChange && !crossfadeMix
+       && (boundaryFadeEnabled
+           || (m_gaplessEnabled && (!m_crossfadeEnabled || !m_crossfadingValues.autoChange.isConfigured())));
 
     if(!crossfadeMix && !gaplessHandoff) {
         return {};
@@ -1515,7 +1596,10 @@ AudioEngine::evaluateAutoTransitionEligibility(const Track& track, bool isManual
         if(crossfadeMix && readyMode != AutoTransitionMode::Crossfade) {
             return {};
         }
-        if(!crossfadeMix && gaplessHandoff && readyMode != AutoTransitionMode::Gapless) {
+        if(!crossfadeMix && gaplessHandoff && boundaryFadeEnabled && readyMode != AutoTransitionMode::BoundaryFade) {
+            return {};
+        }
+        if(!crossfadeMix && gaplessHandoff && !boundaryFadeEnabled && readyMode != AutoTransitionMode::Gapless) {
             return {};
         }
     }
@@ -1772,6 +1856,7 @@ void AudioEngine::clearPreparedGaplessTransition()
     m_preparedGaplessTransition.targetTrack      = {};
     m_preparedGaplessTransition.sourceGeneration = 0;
     m_preparedGaplessTransition.streamId         = InvalidStreamId;
+    m_preparedGaplessTransition.boundaryFadeMode = false;
 }
 
 void AudioEngine::disarmStalePreparedTransitions(const Track& contextTrack, uint64_t contextGeneration)
@@ -1931,6 +2016,7 @@ TrackLoadContext AudioEngine::buildLoadContext(const Track& track, bool manualCh
 bool AudioEngine::executeSegmentSwitchLoad(const Track& track, bool preserveTransportFade)
 {
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
 
     uint64_t streamPosMs{0};
     if(const auto stream = m_decoder.activeStream()) {
@@ -2015,6 +2101,7 @@ void AudioEngine::executeFullReinitLoad(const Track& track, bool manualChange, b
     qCDebug(ENGINE) << "Loading track:" << track.filenameExt();
 
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
     clearPendingAnalysisData();
     m_decoder.stopDecoding();
     cleanupActiveStream();
@@ -2264,6 +2351,7 @@ bool AudioEngine::armPreparedCrossfadeTransition(const Track& track, uint64_t ge
         = (m_currentTrack.duration() > currentRelativePosMs) ? (m_currentTrack.duration() - currentRelativePosMs) : 0;
 
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
 
     AudioPipeline::TransitionRequest request;
     request.type             = AudioPipeline::TransitionType::Crossfade;
@@ -2344,6 +2432,7 @@ bool AudioEngine::commitPreparedCrossfadeTransition(const Track& track)
     m_format = m_decoder.format();
     m_decoder.startDecoding();
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState(true);
 
     setCurrentTrackContext(track);
     setStreamToTrackOriginForTrack(track);
@@ -2382,7 +2471,8 @@ bool AudioEngine::armPreparedGaplessTransition(const Track& track, uint64_t gene
         return false;
     }
 
-    if(m_transitions.autoTransitionMode() != AutoTransitionMode::Gapless
+    const auto transitionMode = m_transitions.autoTransitionMode();
+    if((transitionMode != AutoTransitionMode::Gapless && transitionMode != AutoTransitionMode::BoundaryFade)
        || isMultiTrackFileTransition(m_currentTrack, track)) {
         return false;
     }
@@ -2412,6 +2502,7 @@ bool AudioEngine::armPreparedGaplessTransition(const Track& track, uint64_t gene
     m_preparedGaplessTransition.targetTrack      = track;
     m_preparedGaplessTransition.sourceGeneration = generation;
     m_preparedGaplessTransition.streamId         = transitionResult.streamId;
+    m_preparedGaplessTransition.boundaryFadeMode = (transitionMode == AutoTransitionMode::BoundaryFade);
     clearPreparedCrossfadeTransition();
     return true;
 }
@@ -2420,14 +2511,22 @@ bool AudioEngine::commitPreparedGaplessTransition(const Track& track)
 {
     disarmStalePreparedTransitions(track, m_trackGeneration);
 
+    const bool boundaryFadeMode = m_preparedGaplessTransition.boundaryFadeMode;
+
     if(!track.isValid() || !m_preparedGaplessTransition.active
        || !sameTrackIdentity(track, m_preparedGaplessTransition.targetTrack)) {
+        if(boundaryFadeMode) {
+            clearAutoBoundaryFadeState(true);
+        }
         return false;
     }
 
     const StreamId preparedStreamId = m_preparedGaplessTransition.streamId;
 
     if(!initDecoder(track, true)) {
+        if(boundaryFadeMode) {
+            clearAutoBoundaryFadeState(true);
+        }
         clearPreparedGaplessTransition();
         return false;
     }
@@ -2437,6 +2536,9 @@ bool AudioEngine::commitPreparedGaplessTransition(const Track& track)
         qCWarning(ENGINE) << "Prepared gapless commit could not adopt armed stream:"
                           << "expectedStreamId=" << preparedStreamId
                           << "actualStreamId=" << (preparedStream ? preparedStream->id() : InvalidStreamId);
+        if(boundaryFadeMode) {
+            clearAutoBoundaryFadeState(true);
+        }
         clearPreparedGaplessTransition();
         return false;
     }
@@ -2444,6 +2546,9 @@ bool AudioEngine::commitPreparedGaplessTransition(const Track& track)
     m_format = m_decoder.format();
     m_decoder.startDecoding();
     clearAutoCrossfadeTailFadeState();
+    if(!boundaryFadeMode) {
+        clearAutoBoundaryFadeState();
+    }
 
     setCurrentTrackContext(track);
     setStreamToTrackOriginForTrack(track);
@@ -2451,6 +2556,10 @@ bool AudioEngine::commitPreparedGaplessTransition(const Track& track)
     m_transitions.clearTrackEnding();
 
     m_positionCoordinator.setGaplessHold(preparedStreamId);
+
+    if(boundaryFadeMode) {
+        applyAutoBoundaryFadeIn(true);
+    }
 
     updateTrackStatus(Engine::TrackStatus::Buffered);
     clearPreparedGaplessTransition();
@@ -2612,6 +2721,7 @@ void AudioEngine::stop()
 void AudioEngine::stopImmediate()
 {
     clearAutoCrossfadeTailFadeState();
+    clearAutoBoundaryFadeState();
     m_transitions.setSeekInProgress(false);
     m_transitions.clearForStop();
 

--- a/src/core/engine/audioengine.h
+++ b/src/core/engine/audioengine.h
@@ -201,7 +201,10 @@ private:
                          AudioClock::UpdateMode mode, bool emitNow = true);
     void updatePositionContext(uint64_t timelineEpoch);
     void maybeBeginAutoCrossfadeTailFadeOut(const AudioStreamPtr& stream, uint64_t relativePosMs);
+    void maybeBeginAutoBoundaryFadeOut(uint64_t relativePosMs);
+    void applyAutoBoundaryFadeIn(bool allowFadeInOnly = false);
     void clearAutoCrossfadeTailFadeState();
+    void clearAutoBoundaryFadeState(bool restoreOutput = false);
     void handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_t trackEndingPosMs, bool preparedCrossfadeArmed,
                                   bool boundaryFallbackReached);
     void updatePosition();
@@ -295,6 +298,7 @@ private:
         Track targetTrack;
         uint64_t sourceGeneration{0};
         StreamId streamId{InvalidStreamId};
+        bool boundaryFadeMode{false};
     };
     PreparedGaplessTransition m_preparedGaplessTransition;
 
@@ -332,5 +336,7 @@ private:
     bool m_autoCrossfadeTailFadeActive;
     StreamId m_autoCrossfadeTailFadeStreamId;
     uint64_t m_autoCrossfadeTailFadeGeneration;
+    bool m_autoBoundaryFadeActive;
+    uint64_t m_autoBoundaryFadeGeneration;
 };
 } // namespace Fooyin

--- a/src/core/engine/control/playbacktransitioncoordinator.cpp
+++ b/src/core/engine/control/playbacktransitioncoordinator.cpp
@@ -119,6 +119,16 @@ bool PlaybackTransitionCoordinator::shouldSignalTrackEnding(const TrackEndingInp
         crossfadeReady                  = readyByTimeline || readyByDrain;
     }
 
+    bool boundaryFadeReady = false;
+    if(input.boundaryFadeEnabled) {
+        const uint64_t fadeOutWindowMs  = static_cast<uint64_t>(std::max(0, input.boundaryFadeOutMs));
+        const uint64_t prepareWindowMs  = std::max(fadeOutWindowMs, input.gaplessPrepareWindowMs);
+        const uint64_t timelineWindowMs = saturatingAddWindow(prepareWindowMs, input.timelineDelayMs);
+        const bool readyByTimeline      = inTimelineWindow(input, timelineWindowMs);
+        const bool readyByDrain         = input.endOfInput && input.remainingOutputMs <= timelineWindowMs;
+        boundaryFadeReady               = readyByTimeline || readyByDrain;
+    }
+
     bool gaplessReady = false;
     if(input.gaplessEnabled) {
         const uint64_t timelineWindowMs = saturatingAddWindow(input.gaplessPrepareWindowMs, input.timelineDelayMs);
@@ -127,10 +137,20 @@ bool PlaybackTransitionCoordinator::shouldSignalTrackEnding(const TrackEndingInp
         gaplessReady                    = input.endOfInput || readyByTimeline || readyByDrain;
     }
 
-    if(crossfadeReady || gaplessReady) {
-        // When both are enabled, auto crossfade should own transition mode;
-        // gapless is only a readiness lead/fallback for non-crossfade paths
-        m_autoTransitionMode = input.autoCrossfadeEnabled ? AutoTransitionMode::Crossfade : AutoTransitionMode::Gapless;
+    const bool crossfadeConfigured = input.autoCrossfadeEnabled;
+    const bool boundaryConfigured  = input.boundaryFadeEnabled;
+
+    if(crossfadeReady || boundaryFadeReady || gaplessReady) {
+        // Keep configured transition ownership stable when gapless lead trips first.
+        if(crossfadeConfigured) {
+            m_autoTransitionMode = AutoTransitionMode::Crossfade;
+        }
+        else if(boundaryConfigured) {
+            m_autoTransitionMode = AutoTransitionMode::BoundaryFade;
+        }
+        else {
+            m_autoTransitionMode = AutoTransitionMode::Gapless;
+        }
         return true;
     }
 
@@ -143,7 +163,7 @@ bool PlaybackTransitionCoordinator::shouldSignalTrackEnding(const TrackEndingInp
     }
 
     clearAutoTransitionReadiness();
-    if(input.autoCrossfadeEnabled || input.gaplessEnabled) {
+    if(input.autoCrossfadeEnabled || input.boundaryFadeEnabled || input.gaplessEnabled) {
         return false;
     }
 
@@ -169,6 +189,8 @@ bool PlaybackTransitionCoordinator::shouldSignalReadyToSwitch(const TrackEndingI
             const bool readyByDrain         = input.endOfInput && input.remainingOutputMs <= timelineWindowMs;
             return readyByTimeline || readyByDrain;
         }
+        case AutoTransitionMode::BoundaryFade:
+            return false;
         case AutoTransitionMode::None:
             return false;
     }
@@ -233,7 +255,8 @@ bool PlaybackTransitionCoordinator::isReadyForAutoCrossfade() const
 
 bool PlaybackTransitionCoordinator::isReadyForGaplessHandoff() const
 {
-    return m_autoTransitionMode == AutoTransitionMode::Gapless;
+    return m_autoTransitionMode == AutoTransitionMode::Gapless
+        || m_autoTransitionMode == AutoTransitionMode::BoundaryFade;
 }
 
 void PlaybackTransitionCoordinator::clearForStop()

--- a/src/core/engine/control/playbacktransitioncoordinator.h
+++ b/src/core/engine/control/playbacktransitioncoordinator.h
@@ -37,7 +37,8 @@ public:
     {
         None = 0,
         Gapless,
-        Crossfade
+        Crossfade,
+        BoundaryFade
     };
 
     struct CrossfadeParams
@@ -72,10 +73,12 @@ public:
         bool endOfInput{false};
         bool bufferEmpty{false};
         bool autoCrossfadeEnabled{false};
+        bool boundaryFadeEnabled{false};
         bool gaplessEnabled{false};
         int autoFadeOutMs{0};
         int autoFadeInMs{0};
         uint64_t autoPrepareLeadMs{0};
+        int boundaryFadeOutMs{0};
         uint64_t gaplessPrepareWindowMs{0};
         uint64_t timelineDelayMs{0};
     };

--- a/src/core/engine/fadingdefs.cpp
+++ b/src/core/engine/fadingdefs.cpp
@@ -84,6 +84,7 @@ QDataStream& operator<<(QDataStream& stream, const FadingValues& fading)
 {
     stream << fading.pause;
     stream << fading.stop;
+    stream << fading.boundary;
 
     return stream;
 }
@@ -92,6 +93,14 @@ QDataStream& operator>>(QDataStream& stream, FadingValues& fading)
 {
     stream >> fading.pause;
     stream >> fading.stop;
+
+    FadeSpec boundary;
+
+    stream.startTransaction();
+    stream >> boundary;
+    if(stream.commitTransaction()) {
+        fading.boundary = boundary;
+    }
 
     return stream;
 }

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -36,32 +36,6 @@ using namespace Qt::StringLiterals;
 constexpr auto LogLevel = "LogLevel";
 
 namespace Fooyin {
-namespace {
-Engine::FadingValues defaultFadingValues()
-{
-    Engine::FadingValues values;
-    values.pause.in    = 120;
-    values.pause.out   = 120;
-    values.pause.curve = Engine::FadeCurve::Linear;
-    values.stop.in     = 120;
-    values.stop.out    = 300;
-    values.stop.curve  = Engine::FadeCurve::Linear;
-    return values;
-}
-
-Engine::CrossfadingValues defaultCrossfadingValues()
-{
-    Engine::CrossfadingValues values;
-    values.manualChange.in  = 300;
-    values.manualChange.out = 300;
-    values.autoChange.in    = 700;
-    values.autoChange.out   = 700;
-    values.seek.in          = 80;
-    values.seek.out         = 80;
-    return values;
-}
-} // namespace
-
 FySettings::FySettings(QObject* parent)
     : QSettings{Core::settingsPath(), QSettings::IniFormat, parent}
 { }
@@ -77,6 +51,7 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
 
     qRegisterMetaType<Engine::FadingValues>("FadingValues");
     qRegisterMetaType<Engine::CrossfadingValues>("CrossfadingValues");
+    qRegisterMetaType<Engine::FadeSpec>("FadeSpec");
 
     m_settings->createTempSetting<FirstRun>(true);
     m_settings->createTempSetting<Version>(QString::fromLatin1(VERSION));
@@ -122,10 +97,10 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
     m_settings->createTempSetting<Internal::MuteVolume>(m_settings->value<OutputVolume>());
     m_settings->createSetting<Internal::DisabledPlugins>(QStringList{}, u"Plugins/Disabled"_s);
     m_settings->createSetting<Internal::EngineFading>(false, u"Engine/Fading"_s);
-    m_settings->createSetting<Internal::FadingValues>(QVariant::fromValue(defaultFadingValues()),
+    m_settings->createSetting<Internal::FadingValues>(QVariant::fromValue(Engine::FadingValues{}),
                                                       u"Engine/FadingValues"_s);
     m_settings->createSetting<Internal::EngineCrossfading>(false, u"Engine/Crossfading"_s);
-    m_settings->createSetting<Internal::CrossfadingValues>(QVariant::fromValue(defaultCrossfadingValues()),
+    m_settings->createSetting<Internal::CrossfadingValues>(QVariant::fromValue(Engine::CrossfadingValues{}),
                                                            u"Engine/CrossfadingValues"_s);
     m_settings->createSetting<Internal::VBRUpdateInterval>(1000, u"Engine/VBRUpdateInterval"_s);
     m_settings->createSetting<Internal::ProxyMode>(static_cast<int>(NetworkAccessManager::Mode::None),

--- a/src/gui/settings/playback/outputpage.cpp
+++ b/src/gui/settings/playback/outputpage.cpp
@@ -78,8 +78,12 @@ private:
     QSpinBox* m_fadingPauseOut;
     QSpinBox* m_fadingStopIn;
     QSpinBox* m_fadingStopOut;
+    QCheckBox* m_fadingBoundaryEnabled;
+    QSpinBox* m_fadingBoundaryIn;
+    QSpinBox* m_fadingBoundaryOut;
     QComboBox* m_pauseFadeCurve;
     QComboBox* m_stopFadeCurve;
+    QComboBox* m_boundaryFadeCurve;
 
     QGroupBox* m_crossfadeBox;
     QCheckBox* m_crossfadeSeekEnabled;
@@ -89,6 +93,7 @@ private:
     QSpinBox* m_crossfadeManualOut;
     QSpinBox* m_crossfadeAutoIn;
     QSpinBox* m_crossfadeAutoOut;
+    QLabel* m_crossfadeAutoSwitchPolicyLabel;
     QComboBox* m_crossfadeAutoSwitchPolicy;
     QSpinBox* m_crossfadeSeekIn;
     QSpinBox* m_crossfadeSeekOut;
@@ -112,8 +117,12 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     , m_fadingPauseOut{new QSpinBox(this)}
     , m_fadingStopIn{new QSpinBox(this)}
     , m_fadingStopOut{new QSpinBox(this)}
+    , m_fadingBoundaryEnabled{new QCheckBox(tr("Boundary"), this)}
+    , m_fadingBoundaryIn{new QSpinBox(this)}
+    , m_fadingBoundaryOut{new QSpinBox(this)}
     , m_pauseFadeCurve{new QComboBox(this)}
     , m_stopFadeCurve{new QComboBox(this)}
+    , m_boundaryFadeCurve{new QComboBox(this)}
     , m_crossfadeBox{new QGroupBox(tr("Crossfading"), this)}
     , m_crossfadeSeekEnabled{new QCheckBox(tr("Seek"), this)}
     , m_crossfadeManualEnabled{new QCheckBox(tr("Manual track change"), this)}
@@ -122,6 +131,7 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     , m_crossfadeManualOut{new QSpinBox(this)}
     , m_crossfadeAutoIn{new QSpinBox(this)}
     , m_crossfadeAutoOut{new QSpinBox(this)}
+    , m_crossfadeAutoSwitchPolicyLabel{new QLabel(tr("Auto switch policy") + u":"_s, this)}
     , m_crossfadeAutoSwitchPolicy{new QComboBox(this)}
     , m_crossfadeSeekIn{new QSpinBox(this)}
     , m_crossfadeSeekOut{new QSpinBox(this)}
@@ -188,6 +198,9 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     bufferLayout->addWidget(m_decodeWatermarkHint, 2, 1, 1, 2);
     bufferLayout->setColumnStretch(2, 1);
 
+    m_fadingBoundaryEnabled->setToolTip(tr("Cannot be enabled together with auto track change crossfade"));
+    m_crossfadeAutoEnabled->setToolTip(tr("Cannot be enabled together with track boundary fades"));
+
     auto* fadingLayout = new QGridLayout(m_fadingBox);
 
     m_fadingBox->setCheckable(true);
@@ -196,6 +209,8 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     m_fadingPauseOut->setSuffix(u"ms"_s);
     m_fadingStopIn->setSuffix(u"ms"_s);
     m_fadingStopOut->setSuffix(u"ms"_s);
+    m_fadingBoundaryIn->setSuffix(u"ms"_s);
+    m_fadingBoundaryOut->setSuffix(u"ms"_s);
     m_crossfadeManualIn->setSuffix(u"ms"_s);
     m_crossfadeManualOut->setSuffix(u"ms"_s);
     m_crossfadeAutoIn->setSuffix(u"ms"_s);
@@ -207,11 +222,15 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     m_fadingPauseOut->setMaximum(10000);
     m_fadingStopIn->setMaximum(10000);
     m_fadingStopOut->setMaximum(10000);
+    m_fadingBoundaryIn->setMaximum(10000);
+    m_fadingBoundaryOut->setMaximum(10000);
 
     m_fadingPauseIn->setSingleStep(100);
     m_fadingPauseOut->setSingleStep(100);
     m_fadingStopIn->setSingleStep(100);
     m_fadingStopOut->setSingleStep(100);
+    m_fadingBoundaryIn->setSingleStep(100);
+    m_fadingBoundaryOut->setSingleStep(100);
 
     const auto addFadeCurveItems = [](QComboBox* combo) {
         combo->addItem(tr("Linear"), static_cast<int>(Engine::FadeCurve::Linear));
@@ -224,6 +243,7 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
 
     addFadeCurveItems(m_pauseFadeCurve);
     addFadeCurveItems(m_stopFadeCurve);
+    addFadeCurveItems(m_boundaryFadeCurve);
 
     int row{0};
     fadingLayout->addWidget(new QLabel(tr("Fade In"), this), row, 1);
@@ -240,6 +260,10 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     fadingLayout->addWidget(m_fadingStopOut, row, 2);
     fadingLayout->addWidget(m_stopFadeCurve, row++, 3);
 
+    fadingLayout->addWidget(m_fadingBoundaryEnabled, row, 0);
+    fadingLayout->addWidget(m_fadingBoundaryIn, row, 1);
+    fadingLayout->addWidget(m_fadingBoundaryOut, row, 2);
+    fadingLayout->addWidget(m_boundaryFadeCurve, row++, 3);
     fadingLayout->setColumnStretch(4, 1);
 
     auto* crossmixLayout = new QGridLayout(m_crossfadeBox);
@@ -253,8 +277,8 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
 
     m_crossfadeManualIn->setMaximum(30000);
     m_crossfadeManualOut->setMaximum(30000);
-    m_crossfadeAutoIn->setMaximum(30000);
-    m_crossfadeAutoOut->setMaximum(30000);
+    m_crossfadeAutoIn->setRange(100, 30000);
+    m_crossfadeAutoOut->setRange(100, 30000);
     m_crossfadeSeekIn->setMaximum(10000);
     m_crossfadeSeekOut->setMaximum(10000);
 
@@ -286,7 +310,7 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     crossmixLayout->addWidget(m_crossfadeAutoEnabled, row, 0);
     crossmixLayout->addWidget(m_crossfadeAutoIn, row, 1);
     crossmixLayout->addWidget(m_crossfadeAutoOut, row++, 2);
-    crossmixLayout->addWidget(new QLabel(tr("Auto switch policy"), this), row, 0);
+    crossmixLayout->addWidget(m_crossfadeAutoSwitchPolicyLabel, row, 0);
     crossmixLayout->addWidget(m_crossfadeAutoSwitchPolicy, row++, 1, 1, 2);
     crossmixLayout->setColumnStretch(3, 1);
 
@@ -305,7 +329,7 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     mainLayout->setColumnStretch(1, 1);
     mainLayout->setRowStretch(mainLayout->rowCount(), 1);
 
-    auto syncBufferBounds = [this]() {
+    const auto syncBufferBounds = [this]() {
         const bool fading    = m_fadingBox->isChecked();
         const bool crossfade = m_crossfadeBox->isChecked();
 
@@ -313,12 +337,14 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
             return (groupOn && enabled->isChecked()) ? spin->value() : 0;
         };
 
-        const std::array<int, 11> values{
+        const std::array<int, 13> values{
             MinBufferSize,
             enabledValue(fading, m_fadingPauseEnabled, m_fadingPauseIn),
             enabledValue(fading, m_fadingPauseEnabled, m_fadingPauseOut),
             enabledValue(fading, m_fadingStopEnabled, m_fadingStopIn),
             enabledValue(fading, m_fadingStopEnabled, m_fadingStopOut),
+            enabledValue(fading, m_fadingBoundaryEnabled, m_fadingBoundaryIn),
+            enabledValue(fading, m_fadingBoundaryEnabled, m_fadingBoundaryOut),
             enabledValue(crossfade, m_crossfadeManualEnabled, m_crossfadeManualIn),
             enabledValue(crossfade, m_crossfadeManualEnabled, m_crossfadeManualOut),
             enabledValue(crossfade, m_crossfadeAutoEnabled, m_crossfadeAutoIn),
@@ -335,21 +361,43 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
         }
     };
 
-    auto updateRowStates = [this]() {
-        m_fadingPauseIn->setEnabled(m_fadingPauseEnabled->isChecked());
-        m_fadingPauseOut->setEnabled(m_fadingPauseEnabled->isChecked());
-        m_pauseFadeCurve->setEnabled(m_fadingPauseEnabled->isChecked());
-        m_fadingStopIn->setEnabled(m_fadingStopEnabled->isChecked());
-        m_fadingStopOut->setEnabled(m_fadingStopEnabled->isChecked());
-        m_stopFadeCurve->setEnabled(m_fadingStopEnabled->isChecked());
+    const auto enforceExclusiveOptions = [this]() {
+        if(m_fadingBoundaryEnabled->isChecked()) {
+            m_crossfadeAutoEnabled->setChecked(false);
+        }
+        else if(m_crossfadeAutoEnabled->isChecked()) {
+            m_fadingBoundaryEnabled->setChecked(false);
+        }
+    };
 
-        m_crossfadeSeekIn->setEnabled(m_crossfadeSeekEnabled->isChecked());
-        m_crossfadeSeekOut->setEnabled(m_crossfadeSeekEnabled->isChecked());
-        m_crossfadeManualIn->setEnabled(m_crossfadeManualEnabled->isChecked());
-        m_crossfadeManualOut->setEnabled(m_crossfadeManualEnabled->isChecked());
-        m_crossfadeAutoIn->setEnabled(m_crossfadeAutoEnabled->isChecked());
-        m_crossfadeAutoOut->setEnabled(m_crossfadeAutoEnabled->isChecked());
-        m_crossfadeAutoSwitchPolicy->setEnabled(m_crossfadeAutoEnabled->isChecked());
+    const auto updateRowStates = [this]() {
+        auto setEnabled = []<typename... Widgets>(bool enabled, Widgets... widgets) {
+            (widgets->setEnabled(enabled), ...);
+        };
+
+        const bool fadingEnabled      = m_fadingBox->isChecked();
+        const bool crossfadingEnabled = m_crossfadeBox->isChecked();
+
+        setEnabled(fadingEnabled && !m_crossfadeAutoEnabled->isChecked(), m_fadingBoundaryEnabled);
+        setEnabled(crossfadingEnabled && !m_fadingBoundaryEnabled->isChecked(), m_crossfadeAutoEnabled,
+                   m_crossfadeAutoSwitchPolicyLabel, m_crossfadeAutoSwitchPolicy);
+
+        const bool boundaryFadeActive    = m_fadingBoundaryEnabled->isChecked();
+        const bool autoCrossfadeActive   = m_crossfadeAutoEnabled->isChecked();
+        const bool pauseFadeActive       = m_fadingPauseEnabled->isChecked();
+        const bool stopFadeActive        = m_fadingStopEnabled->isChecked();
+        const bool seekCrossfadeActive   = m_crossfadeSeekEnabled->isChecked();
+        const bool manualCrossfadeActive = m_crossfadeManualEnabled->isChecked();
+
+        setEnabled(fadingEnabled && pauseFadeActive, m_fadingPauseIn, m_fadingPauseOut, m_pauseFadeCurve);
+        setEnabled(fadingEnabled && stopFadeActive, m_fadingStopIn, m_fadingStopOut, m_stopFadeCurve);
+        setEnabled(fadingEnabled && boundaryFadeActive, m_fadingBoundaryIn, m_fadingBoundaryOut, m_boundaryFadeCurve);
+
+        setEnabled(crossfadingEnabled && seekCrossfadeActive, m_crossfadeSeekIn, m_crossfadeSeekOut);
+        setEnabled(crossfadingEnabled && manualCrossfadeActive, m_crossfadeManualIn, m_crossfadeManualOut);
+        setEnabled(crossfadingEnabled && autoCrossfadeActive, m_crossfadeAutoIn, m_crossfadeAutoOut);
+        setEnabled(crossfadingEnabled && autoCrossfadeActive && m_crossfadeAutoEnabled->isEnabled(),
+                   m_crossfadeAutoSwitchPolicyLabel, m_crossfadeAutoSwitchPolicy);
     };
 
     const auto syncWatermarkRatioBounds = [this]() {
@@ -369,7 +417,8 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
         m_decodeWatermarkHint->setText(tr("Low %1 ms, High %2 ms").arg(lowMs).arg(highMs));
     };
 
-    const auto updateState = [syncBufferBounds, updateRowStates]() {
+    const auto updateState = [enforceExclusiveOptions, syncBufferBounds, updateRowStates]() {
+        enforceExclusiveOptions();
         updateRowStates();
         syncBufferBounds();
     };
@@ -379,6 +428,8 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     QObject::connect(m_fadingPauseOut, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_fadingStopIn, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_fadingStopOut, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
+    QObject::connect(m_fadingBoundaryIn, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
+    QObject::connect(m_fadingBoundaryOut, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_crossfadeManualIn, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_crossfadeManualOut, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_crossfadeAutoIn, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
@@ -387,11 +438,15 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
     QObject::connect(m_crossfadeSeekOut, &QSpinBox::valueChanged, this, [syncBufferBounds]() { syncBufferBounds(); });
     QObject::connect(m_bufferSize, &QSpinBox::valueChanged, this, [updateWatermarkHint]() { updateWatermarkHint(); });
 
+    QObject::connect(m_fadingBox, &QGroupBox::toggled, this, [updateRowStates]() { updateRowStates(); });
+    QObject::connect(m_crossfadeBox, &QGroupBox::toggled, this, [updateRowStates]() { updateRowStates(); });
     QObject::connect(m_fadingPauseEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
     QObject::connect(m_fadingStopEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
+    QObject::connect(m_fadingBoundaryEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
     QObject::connect(m_crossfadeSeekEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
     QObject::connect(m_crossfadeManualEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
     QObject::connect(m_crossfadeAutoEnabled, &QCheckBox::toggled, this, [updateState]() { updateState(); });
+
     QObject::connect(m_decodeLowWatermark, &QSpinBox::valueChanged, this,
                      [syncWatermarkRatioBounds]() { syncWatermarkRatioBounds(); });
     QObject::connect(m_decodeHighWatermark, &QSpinBox::valueChanged, this, [this](int value) {
@@ -463,6 +518,8 @@ void OutputPageWidget::load()
 
     loadFadeSpec(fadingValues.pause, m_fadingPauseEnabled, m_fadingPauseIn, m_fadingPauseOut, m_pauseFadeCurve);
     loadFadeSpec(fadingValues.stop, m_fadingStopEnabled, m_fadingStopIn, m_fadingStopOut, m_stopFadeCurve);
+    loadFadeSpec(fadingValues.boundary, m_fadingBoundaryEnabled, m_fadingBoundaryIn, m_fadingBoundaryOut,
+                 m_boundaryFadeCurve);
 
     m_crossfadeBox->setChecked(m_settings->value<Settings::Core::Internal::EngineCrossfading>());
     const auto crossfadingValues
@@ -477,6 +534,10 @@ void OutputPageWidget::load()
     const int policyIndex
         = m_crossfadeAutoSwitchPolicy->findData(static_cast<int>(policy), Qt::UserRole, Qt::MatchExactly);
     m_crossfadeAutoSwitchPolicy->setCurrentIndex(policyIndex >= 0 ? policyIndex : 0);
+
+    if(m_crossfadeAutoEnabled->isChecked() && m_fadingBoundaryEnabled->isChecked()) {
+        m_fadingBoundaryEnabled->setChecked(false);
+    }
 }
 
 void OutputPageWidget::apply()
@@ -522,11 +583,17 @@ void OutputPageWidget::apply()
     Engine::FadingValues fadingValues;
     saveFadeSpec(fadingValues.pause, m_fadingPauseEnabled, m_fadingPauseIn, m_fadingPauseOut, m_pauseFadeCurve);
     saveFadeSpec(fadingValues.stop, m_fadingStopEnabled, m_fadingStopIn, m_fadingStopOut, m_stopFadeCurve);
+    saveFadeSpec(fadingValues.boundary, m_fadingBoundaryEnabled, m_fadingBoundaryIn, m_fadingBoundaryOut,
+                 m_boundaryFadeCurve);
 
     Engine::CrossfadingValues crossfadingValues;
     saveFadeSpec(crossfadingValues.manualChange, m_crossfadeManualEnabled, m_crossfadeManualIn, m_crossfadeManualOut);
     saveFadeSpec(crossfadingValues.autoChange, m_crossfadeAutoEnabled, m_crossfadeAutoIn, m_crossfadeAutoOut);
     saveFadeSpec(crossfadingValues.seek, m_crossfadeSeekEnabled, m_crossfadeSeekIn, m_crossfadeSeekOut);
+
+    if(crossfadingValues.autoChange.enabled && fadingValues.boundary.enabled) {
+        fadingValues.boundary.enabled = false;
+    }
 
     m_settings->set<Settings::Core::Internal::EngineFading>(m_fadingBox->isChecked());
     m_settings->set<Settings::Core::Internal::FadingValues>(QVariant::fromValue(fadingValues));

--- a/tests/core/engine/playbacktransitioncoordinatortest.cpp
+++ b/tests/core/engine/playbacktransitioncoordinatortest.cpp
@@ -150,6 +150,78 @@ TEST(PlaybackTransitionCoordinatorTest, GaplessReadinessIsIndependentFromCrossfa
     EXPECT_EQ(state.autoTransitionMode(), PlaybackTransitionCoordinator::AutoTransitionMode::Gapless);
 }
 
+TEST(PlaybackTransitionCoordinatorTest, BoundaryFadeReadinessSignalsAboutToFinishButNotReadyToSwitch)
+{
+    PlaybackTransitionCoordinator state;
+
+    PlaybackTransitionCoordinator::TrackEndingInput input;
+    input.positionMs             = 9500;
+    input.durationMs             = 10000;
+    input.remainingOutputMs      = 700;
+    input.endOfInput             = false;
+    input.bufferEmpty            = false;
+    input.autoCrossfadeEnabled   = false;
+    input.boundaryFadeEnabled    = true;
+    input.gaplessEnabled         = false;
+    input.boundaryFadeOutMs      = 500;
+    input.gaplessPrepareWindowMs = 300;
+
+    const auto aboutToFinish = state.evaluateTrackEnding(input);
+    EXPECT_TRUE(aboutToFinish.aboutToFinish);
+    EXPECT_FALSE(aboutToFinish.readyToSwitch);
+    EXPECT_FALSE(aboutToFinish.endReached);
+    EXPECT_TRUE(state.isReadyForGaplessHandoff());
+    EXPECT_EQ(state.autoTransitionMode(), PlaybackTransitionCoordinator::AutoTransitionMode::BoundaryFade);
+}
+
+TEST(PlaybackTransitionCoordinatorTest, BoundaryFadeModePreferredOverGaplessWhenBothReady)
+{
+    PlaybackTransitionCoordinator state;
+
+    PlaybackTransitionCoordinator::TrackEndingInput input;
+    input.positionMs             = 9700;
+    input.durationMs             = 10000;
+    input.remainingOutputMs      = 450;
+    input.endOfInput             = false;
+    input.bufferEmpty            = false;
+    input.autoCrossfadeEnabled   = false;
+    input.boundaryFadeEnabled    = true;
+    input.gaplessEnabled         = true;
+    input.boundaryFadeOutMs      = 200;
+    input.gaplessPrepareWindowMs = 300;
+
+    const auto aboutToFinish = state.evaluateTrackEnding(input);
+    EXPECT_TRUE(aboutToFinish.aboutToFinish);
+    EXPECT_FALSE(aboutToFinish.readyToSwitch);
+    EXPECT_FALSE(aboutToFinish.endReached);
+    EXPECT_TRUE(state.isReadyForGaplessHandoff());
+    EXPECT_EQ(state.autoTransitionMode(), PlaybackTransitionCoordinator::AutoTransitionMode::BoundaryFade);
+}
+
+TEST(PlaybackTransitionCoordinatorTest, BoundaryFadeWithZeroFadeOutStillPreparesAsBoundaryFade)
+{
+    PlaybackTransitionCoordinator state;
+
+    PlaybackTransitionCoordinator::TrackEndingInput input;
+    input.positionMs             = 9700;
+    input.durationMs             = 10000;
+    input.remainingOutputMs      = 450;
+    input.endOfInput             = false;
+    input.bufferEmpty            = false;
+    input.autoCrossfadeEnabled   = false;
+    input.boundaryFadeEnabled    = true;
+    input.gaplessEnabled         = false;
+    input.boundaryFadeOutMs      = 0;
+    input.gaplessPrepareWindowMs = 300;
+
+    const auto aboutToFinish = state.evaluateTrackEnding(input);
+    EXPECT_TRUE(aboutToFinish.aboutToFinish);
+    EXPECT_FALSE(aboutToFinish.readyToSwitch);
+    EXPECT_FALSE(aboutToFinish.endReached);
+    EXPECT_TRUE(state.isReadyForGaplessHandoff());
+    EXPECT_EQ(state.autoTransitionMode(), PlaybackTransitionCoordinator::AutoTransitionMode::BoundaryFade);
+}
+
 TEST(PlaybackTransitionCoordinatorTest, CrossfadeModeIsPreferredWhenGaplessBecomesReadyFirst)
 {
     PlaybackTransitionCoordinator state;


### PR DESCRIPTION
Adds automatic boundary fades for natural track transitions, with configurable fade-in, fade-out, and curve settings. 

Boundary fades provide a non-overlapping alternative to auto track-change crossfades. They are mutually exclusive with each other.

A minimum value of `100ms` for the fade-in and fade-out values for auto track change crossfades has also been set as using a crossfade to only fade in/out one side of a track boundary is no longer needed.