### PR TITLE
Fix: Show directory controls and location hiding after being enabled

### DIFF
--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -58,9 +58,6 @@
 #include <QTreeView>
 #include <QUndoCommand>
 
-// TEMP
-#include <iostream>
-
 using namespace Qt::StringLiterals;
 
 // Settings keys
@@ -629,7 +626,18 @@ void DirBrowser::updateFilters()
 
 void DirBrowser::setControlsEnabled(bool enabled)
 {
-    if(enabled && !m_upDir && !m_backDir && !m_forwardDir) {
+    if(!enabled) {
+        if(m_backDir) {
+            m_backDir->deleteLater();
+        }
+        if(m_forwardDir) {
+            m_forwardDir->deleteLater();
+        }
+        if(m_upDir) {
+            m_upDir->deleteLater();
+        }
+    }
+    else if(!m_upDir && !m_backDir && !m_forwardDir) {
         m_upDir      = new ToolButton(this);
         m_backDir    = new ToolButton(this);
         m_forwardDir = new ToolButton(this);
@@ -642,31 +650,20 @@ void DirBrowser::setControlsEnabled(bool enabled)
         m_controlLayout->insertWidget(0, m_forwardDir);
         m_controlLayout->insertWidget(0, m_backDir);
     }
-    else if(!enabled) {
-        if(m_backDir) {
-            m_backDir->deleteLater();
-        }
-        if(m_forwardDir) {
-            m_forwardDir->deleteLater();
-        }
-        if(m_upDir) {
-            m_upDir->deleteLater();
-        }
-    }
 }
 
 void DirBrowser::setLocationEnabled(bool enabled)
 {
-    if(enabled && !m_dirEdit) {
+    if(!enabled) {
+        if(m_dirEdit) {
+            m_dirEdit->deleteLater();
+        }
+    }
+    else if(!m_dirEdit) {
         m_dirEdit = new QLineEdit(this);
         QObject::connect(m_dirEdit, &QLineEdit::textEdited, this, [this](const QString& dir) { changeRoot(dir); });
         m_controlLayout->addWidget(m_dirEdit, 1);
         m_dirEdit->setText(m_model->rootPath());
-    }
-    else if(!enabled) {
-        if(m_dirEdit) {
-            m_dirEdit->deleteLater();
-        }
     }
 }
 


### PR DESCRIPTION
The conditionals for whether or not to display the settings were:
```
if(enabled && !m_upDir && ..) {
    // show controls
} else {
    // hide controls, even if they should be enabled (once m_upDir et al. is defined)
}
```
which would enable it right when you enable the setting, but immediately disable it due to m_upDir being defined after initially enabling it.

Fixed it by making it so the else block only runs if `enabled` is false. it's now 
```
if(enabled && !m_upDir && ..) {
    // show controls
} else if (!enabled) {
    // hide controls, only if disabled
 }
```