### PR TITLE
Add force-sorted autoplaylists and incremental autoplaylist updates

### DIFF
--- a/data/dbschema.xml
+++ b/data/dbschema.xml
@@ -345,4 +345,13 @@
             ALTER TABLE Playlists ADD COLUMN Query TEXT;
         </sql>
     </revision>
+    <revision version="15">
+        <description>
+            Add autoplaylist sort and force-sorted fields.
+        </description>
+        <sql>
+            ALTER TABLE Playlists ADD COLUMN SortQuery TEXT;
+            ALTER TABLE Playlists ADD COLUMN ForceSorted INTEGER DEFAULT 1;
+        </sql>
+    </revision>
 </schema>

--- a/include/core/playlist/playlist.h
+++ b/include/core/playlist/playlist.h
@@ -53,8 +53,7 @@ struct FYCORE_EXPORT PlaylistTrack
 
     static const Track& extractor(const PlaylistTrack& item);
 
-    bool operator==(const PlaylistTrack& other) const;
-    bool operator!=(const PlaylistTrack& other) const;
+    bool operator==(const PlaylistTrack& other) const = default;
     bool operator<(const PlaylistTrack& other) const;
 
     operator QVariant() const
@@ -125,6 +124,12 @@ public:
     [[nodiscard]] bool isAutoPlaylist() const;
     /** Returns the query used to generate this autoplaylist, else an empty string. */
     [[nodiscard]] QString query() const;
+    /** Returns the optional sort pattern used to order this autoplaylist. */
+    [[nodiscard]] QString sortQuery() const;
+    /** Returns @c true if this autoplaylist should be fully resorted on regeneration. */
+    [[nodiscard]] bool forceSorted() const;
+    /** Returns the tracks this autoplaylist would contain after regeneration with @p tracks. */
+    [[nodiscard]] TrackList autoPlaylistTracks(const TrackList& tracks) const;
 
     /** Regenerates this autoplaylist using the tracks @p tracks. */
     bool regenerateTracks(const TrackList& tracks);
@@ -163,11 +168,13 @@ private:
     static std::unique_ptr<Playlist> create(const QString& name, SettingsManager* settings);
     static std::unique_ptr<Playlist> create(int dbId, const QString& name, int index, SettingsManager* settings);
     static std::unique_ptr<Playlist> createAuto(int dbId, const QString& name, int index, const QString& query,
-                                                SettingsManager* settings);
+                                                const QString& sortQuery, bool forceSorted, SettingsManager* settings);
 
     void setName(const QString& name);
     void setIndex(int index);
     void setQuery(const QString& query);
+    void setSortQuery(const QString& query);
+    void setForceSorted(bool forceSorted);
 
     void setModified(bool modified);
     void setTracksModified(bool modified);

--- a/include/core/playlist/playlistchangeset.h
+++ b/include/core/playlist/playlistchangeset.h
@@ -1,0 +1,117 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/track.h>
+
+#include <optional>
+#include <unordered_set>
+
+namespace Fooyin {
+/*!
+ * Represents a single track move within a playlist patch.
+ * The move is applied against the current playlist state at the time the
+ * operation is executed.
+ */
+struct FYCORE_EXPORT PlaylistTrackMove
+{
+    /** Current playlist index of the track to move. */
+    int sourceIndex{-1};
+    /** Destination playlist index after the move is applied. */
+    int targetIndex{-1};
+
+    [[nodiscard]] bool isValid() const
+    {
+        return sourceIndex >= 0 && targetIndex >= 0 && sourceIndex != targetIndex;
+    }
+};
+
+/*!
+ * Represents a contiguous group of tracks to insert into a playlist patch.
+ * @note @c index is the destination playlist index before the insertion is applied.
+ */
+struct FYCORE_EXPORT PlaylistTrackInsertion
+{
+    /** Destination playlist index for the first inserted track. */
+    int index{-1};
+    /** Tracks to insert, in final order. */
+    TrackList tracks;
+
+    [[nodiscard]] bool isValid() const
+    {
+        return index >= 0 && !tracks.empty();
+    }
+};
+
+/*!
+ * Describes an incremental playlist update.
+ *
+ * The operations are interpreted in this order:
+ * 1. remove @c removedIndexes
+ * 2. apply @c insertions
+ * 3. apply @c moves
+ * 4. refresh @c updatedIndexes
+ *
+ * If @c requiresReset is set, callers should ignore the incremental fields and
+ * rebuild the playlist model from scratch instead.
+ */
+struct FYCORE_EXPORT PlaylistChangeset
+{
+    /** Playlist indexes to remove from the pre-change playlist. */
+    std::vector<int> removedIndexes;
+    /** Contiguous insertion groups to apply after removals. */
+    std::vector<PlaylistTrackInsertion> insertions;
+    /** Move operations to apply after insertions. */
+    std::vector<PlaylistTrackMove> moves;
+    /** Playlist indexes to refresh after structural changes are applied. */
+    std::vector<int> updatedIndexes;
+    /** Whether the change is too large or ambiguous for incremental application. */
+    bool requiresReset{false};
+
+    /** Returns @c true when there is no structural or metadata change to apply. */
+    [[nodiscard]] bool isEmpty() const
+    {
+        return !requiresReset && removedIndexes.empty() && insertions.empty() && moves.empty()
+            && updatedIndexes.empty();
+    }
+};
+
+using TrackKeySet = std::unordered_set<QString>;
+
+/*!
+ * Builds a playlist patch that transforms @p oldTracks into @p newTracks.
+ *
+ * Tracks are matched by @c Track::uniqueFilepath(). If the track identity is
+ * ambiguous, the function returns @c std::nullopt so callers can fall back to a
+ * full reset.
+ *
+ * @param updatedTrackPaths Optional set of matched track paths that should be
+ * treated as metadata updates even if the old and new track objects compare equal.
+ */
+[[nodiscard]] FYCORE_EXPORT std::optional<PlaylistChangeset>
+buildPlaylistChangeset(const TrackList& oldTracks, const TrackList& newTracks,
+                       const TrackKeySet& updatedTrackPaths = {});
+} // namespace Fooyin
+
+Q_DECLARE_METATYPE(Fooyin::PlaylistTrackMove)
+Q_DECLARE_METATYPE(Fooyin::PlaylistTrackInsertion)
+Q_DECLARE_METATYPE(Fooyin::PlaylistChangeset)

--- a/include/core/playlist/playlisthandler.h
+++ b/include/core/playlist/playlisthandler.h
@@ -23,6 +23,7 @@
 
 #include <core/engine/audioloader.h>
 #include <core/playlist/playlist.h>
+#include <core/playlist/playlistchangeset.h>
 #include <core/track.h>
 #include <utils/database/dbconnectionpool.h>
 
@@ -77,9 +78,11 @@ public:
      * will be changed. */
     Playlist* createNewTempPlaylist(const QString& name, const TrackList& tracks);
     /** Returns the autoplaylist called @p name if it exists, otherwise creates it. */
-    Playlist* createAutoPlaylist(const QString& name, const QString& query);
+    Playlist* createAutoPlaylist(const QString& name, const QString& query, const QString& sortQuery = {},
+                                 bool forceSorted = true);
     /** Creates and returns the autoplaylist called @p name. If it already exists, the name will be changed. */
-    Playlist* createNewAutoPlaylist(const QString& name, const QString& query);
+    Playlist* createNewAutoPlaylist(const QString& name, const QString& query, const QString& sortQuery = {},
+                                    bool forceSorted = true);
 
     /** Adds @p tracks to the end of the playlist with @p id if found. */
     void appendToPlaylist(const UId& id, const TrackList& tracks);
@@ -125,12 +128,14 @@ signals:
     void playlistAdded(Fooyin::Playlist* playlist);
     void playlistRemoved(Fooyin::Playlist* playlist);
     void playlistRenamed(Fooyin::Playlist* playlist);
+    void playlistUpdated(Fooyin::Playlist* playlist);
     void activePlaylistChanged(Fooyin::Playlist* playlist);
     void activePlaylistDeleted();
     void restoreCurrentTrackRequested(const Fooyin::PlaylistTrack& track);
     void playlistReferencesRemapRequested(const Fooyin::UId& fromPlaylistId, const Fooyin::UId& toPlaylistId);
 
     void tracksAdded(Fooyin::Playlist* playlist, const Fooyin::TrackList& tracks, int index);
+    void tracksPatched(Fooyin::Playlist* playlist, const Fooyin::PlaylistChangeset& changeSet);
     void tracksChanged(Fooyin::Playlist* playlist, const std::vector<int>& indexes);
     void tracksUpdated(Fooyin::Playlist* playlist, const std::vector<int>& indexes);
     void tracksRemoved(Fooyin::Playlist* playlist, const std::vector<int>& indexes);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/core/player/playercontroller.h
     ${CMAKE_SOURCE_DIR}/include/core/player/playerdefs.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlist.h
+    ${CMAKE_SOURCE_DIR}/include/core/playlist/playlistchangeset.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlisthandler.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlistparser.h
     ${CMAKE_SOURCE_DIR}/include/core/plugins/coreplugin.h
@@ -209,6 +210,7 @@ set(SOURCES
     playlist/parsers/m3uparser.cpp
     playlist/parsers/m3uparser.h
     playlist/playlist.cpp
+    playlist/playlistchangeset.cpp
     playlist/playlisthandler.cpp
     playlist/playlistloader.cpp
     playlist/playlistloader.h

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -30,7 +30,7 @@
 
 using namespace Qt::StringLiterals;
 
-constexpr auto CurrentSchemaVersion = 14;
+constexpr auto CurrentSchemaVersion = 15;
 
 namespace {
 Fooyin::DbConnection::DbParams dbConnectionParams()

--- a/src/core/database/playlistdatabase.cpp
+++ b/src/core/database/playlistdatabase.cpp
@@ -27,8 +27,8 @@ using namespace Qt::StringLiterals;
 namespace Fooyin {
 std::vector<PlaylistInfo> PlaylistDatabase::getAllPlaylists()
 {
-    const QString query
-        = u"SELECT PlaylistID, Name, PlaylistIndex, IsAutoPlaylist, Query FROM Playlists ORDER BY PlaylistIndex;"_s;
+    const QString query = u"SELECT PlaylistID, Name, PlaylistIndex, IsAutoPlaylist, Query, SortQuery, ForceSorted "
+                          "FROM Playlists ORDER BY PlaylistIndex;"_s;
 
     DbQuery q{db(), query};
 
@@ -46,6 +46,8 @@ std::vector<PlaylistInfo> PlaylistDatabase::getAllPlaylists()
         playlist.index          = q.value(2).toInt();
         playlist.isAutoPlaylist = q.value(3).toBool();
         playlist.query          = q.value(4).toString();
+        playlist.sortQuery      = q.value(5).toString();
+        playlist.forceSorted    = q.value(6).toBool();
 
         playlists.emplace_back(playlist);
     }
@@ -58,20 +60,24 @@ TrackList PlaylistDatabase::getPlaylistTracks(const Playlist& playlist, const st
     return populatePlaylistTracks(playlist, tracks);
 }
 
-int PlaylistDatabase::insertPlaylist(const QString& name, int index, bool isAutoPlaylist, const QString& autoQuery)
+int PlaylistDatabase::insertPlaylist(const QString& name, int index, bool isAutoPlaylist, const QString& autoQuery,
+                                     const QString& autoSortQuery, bool forceSorted)
 {
     if(name.isEmpty() || index < 0) {
         return -1;
     }
 
-    const QString statement = u"INSERT INTO Playlists (Name, PlaylistIndex, IsAutoPlaylist, Query) "
-                              "VALUES (:name, :index, :isAutoPlaylist, :query);"_s;
+    const QString statement = u"INSERT INTO Playlists (Name, PlaylistIndex, IsAutoPlaylist, Query, SortQuery, "
+                              "ForceSorted) VALUES (:name, :index, :isAutoPlaylist, :query, :sortQuery, "
+                              ":forceSorted);"_s;
 
     DbQuery query{db(), statement};
     query.bindValue(u":name"_s, name);
     query.bindValue(u":index"_s, index);
     query.bindValue(u":isAutoPlaylist"_s, isAutoPlaylist);
     query.bindValue(u":query"_s, autoQuery);
+    query.bindValue(u":sortQuery"_s, autoSortQuery);
+    query.bindValue(u":forceSorted"_s, forceSorted);
 
     if(!query.exec()) {
         return -1;
@@ -86,7 +92,8 @@ bool PlaylistDatabase::savePlaylist(Playlist& playlist)
 
     if(playlist.modified()) {
         const auto statement = u"UPDATE Playlists SET Name = :name, PlaylistIndex = :index, IsAutoPlaylist = "
-                               ":isAutoPlaylist, Query = :query WHERE PlaylistID = :id;"_s;
+                               ":isAutoPlaylist, Query = :query, SortQuery = :sortQuery, "
+                               "ForceSorted = :forceSorted WHERE PlaylistID = :id;"_s;
 
         DbQuery query{db(), statement};
 
@@ -94,12 +101,14 @@ bool PlaylistDatabase::savePlaylist(Playlist& playlist)
         query.bindValue(u":index"_s, playlist.index());
         query.bindValue(u":isAutoPlaylist"_s, playlist.isAutoPlaylist());
         query.bindValue(u":query"_s, playlist.query());
+        query.bindValue(u":sortQuery"_s, playlist.sortQuery());
+        query.bindValue(u":forceSorted"_s, playlist.forceSorted());
         query.bindValue(u":id"_s, playlist.dbId());
 
         updated = query.exec();
     }
 
-    if(!playlist.isAutoPlaylist() && playlist.tracksModified()) {
+    if(playlist.tracksModified()) {
         updated = insertPlaylistTracks(playlist.dbId(), playlist.tracks());
     }
 

--- a/src/core/database/playlistdatabase.h
+++ b/src/core/database/playlistdatabase.h
@@ -31,6 +31,8 @@ struct PlaylistInfo
     int index{-1};
     bool isAutoPlaylist{false};
     QString query;
+    QString sortQuery;
+    bool forceSorted{true};
 };
 
 class PlaylistDatabase : public DbModule
@@ -39,7 +41,8 @@ public:
     std::vector<PlaylistInfo> getAllPlaylists();
     TrackList getPlaylistTracks(const Playlist& playlist, const std::unordered_map<int, Track>& tracks);
 
-    int insertPlaylist(const QString& name, int index, bool isAutoPlaylist, const QString& autoQuery);
+    int insertPlaylist(const QString& name, int index, bool isAutoPlaylist, const QString& autoQuery,
+                       const QString& autoSortQuery = {}, bool forceSorted = true);
 
     bool savePlaylist(Playlist& playlist);
     bool saveModifiedPlaylists(const PlaylistList& playlists);

--- a/src/core/playlist/playlist.cpp
+++ b/src/core/playlist/playlist.cpp
@@ -29,6 +29,8 @@
 #include <random>
 #include <ranges>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 
 using namespace Qt::StringLiterals;
 
@@ -85,17 +87,6 @@ const Track& PlaylistTrack::extractor(const PlaylistTrack& item)
     return item.track;
 }
 
-bool PlaylistTrack::operator==(const PlaylistTrack& other) const
-{
-    return std::tie(track, playlistId, indexInPlaylist)
-        == std::tie(other.track, other.playlistId, other.indexInPlaylist);
-}
-
-bool PlaylistTrack::operator!=(const PlaylistTrack& other) const
-{
-    return !(*this == other);
-}
-
 bool PlaylistTrack::operator<(const PlaylistTrack& other) const
 {
     return std::tie(track, playlistId, indexInPlaylist)
@@ -112,6 +103,9 @@ class PlaylistPrivate
 {
 public:
     PlaylistPrivate(int dbId, QString name, int index, SettingsManager* settings);
+
+    [[nodiscard]] TrackList filteredAutoTracks(const TrackList& tracks);
+    [[nodiscard]] TrackList updatedAutoTracks(const TrackList& tracks);
 
     void createShuffleOrder();
     void createAlbumShuffleOrder();
@@ -154,6 +148,8 @@ public:
 
     bool m_isAutoPlaylist{false};
     QString m_query;
+    QString m_sortQuery;
+    bool m_forceSorted{false};
 };
 
 PlaylistPrivate::PlaylistPrivate(int dbId, QString name, int index, SettingsManager* settings)
@@ -163,6 +159,56 @@ PlaylistPrivate::PlaylistPrivate(int dbId, QString name, int index, SettingsMana
     , m_index{index}
     , m_settings{settings}
 { }
+
+TrackList PlaylistPrivate::filteredAutoTracks(const TrackList& tracks)
+{
+    QString query{m_query};
+    if(!m_sortQuery.isEmpty()) {
+        if(!query.isEmpty()) {
+            query.append(u' ');
+        }
+        query.append(m_sortQuery);
+    }
+
+    m_parser.clearCache();
+    return m_parser.filter(query, tracks);
+}
+
+TrackList PlaylistPrivate::updatedAutoTracks(const TrackList& tracks)
+{
+    TrackList filteredTracks = filteredAutoTracks(tracks);
+
+    if(m_forceSorted) {
+        return filteredTracks;
+    }
+
+    std::unordered_map<QString, int> filteredIndexes;
+    filteredIndexes.reserve(filteredTracks.size());
+
+    for(int i{0}; i < static_cast<int>(filteredTracks.size()); ++i) {
+        filteredIndexes.emplace(filteredTracks[i].uniqueFilepath(), i);
+    }
+
+    std::vector<char> used(filteredTracks.size(), false);
+
+    TrackList updatedTracks;
+    updatedTracks.reserve(filteredTracks.size());
+
+    for(const auto& track : m_tracks) {
+        if(const auto it = filteredIndexes.find(track.uniqueFilepath()); it != filteredIndexes.end()) {
+            updatedTracks.emplace_back(filteredTracks[it->second]);
+            used[it->second] = true;
+        }
+    }
+
+    for(size_t i{0}; i < filteredTracks.size(); ++i) {
+        if(!used[i]) {
+            updatedTracks.emplace_back(filteredTracks[i]);
+        }
+    }
+
+    return updatedTracks;
+}
 
 void PlaylistPrivate::createShuffleOrder()
 {
@@ -579,15 +625,32 @@ QString Playlist::query() const
     return p->m_query;
 }
 
+QString Playlist::sortQuery() const
+{
+    return p->m_sortQuery;
+}
+
+bool Playlist::forceSorted() const
+{
+    return p->m_forceSorted;
+}
+
+TrackList Playlist::autoPlaylistTracks(const TrackList& tracks) const
+{
+    if(!isAutoPlaylist()) {
+        return p->m_tracks;
+    }
+
+    return p->updatedAutoTracks(tracks);
+}
+
 bool Playlist::regenerateTracks(const TrackList& tracks)
 {
     if(!isAutoPlaylist()) {
         return false;
     }
 
-    // In case current date in previous query is cached
-    p->m_parser.clearCache();
-    const TrackList filteredTracks = p->m_parser.filter(p->m_query, tracks);
+    const TrackList filteredTracks = autoPlaylistTracks(tracks);
 
     if(filteredTracks != p->m_tracks) {
         replaceTracks(filteredTracks);
@@ -667,11 +730,13 @@ std::unique_ptr<Playlist> Playlist::create(int dbId, const QString& name, int in
 }
 
 std::unique_ptr<Playlist> Playlist::createAuto(int dbId, const QString& name, int index, const QString& query,
-                                               SettingsManager* settings)
+                                               const QString& sortQuery, bool forceSorted, SettingsManager* settings)
 {
     auto playlist                 = std::make_unique<Playlist>(PrivateKey{}, dbId, name, index, settings);
     playlist->p->m_isAutoPlaylist = true;
     playlist->setQuery(query);
+    playlist->setSortQuery(sortQuery);
+    playlist->setForceSorted(forceSorted);
     return playlist;
 }
 
@@ -692,6 +757,20 @@ void Playlist::setIndex(int index)
 void Playlist::setQuery(const QString& query)
 {
     if(std::exchange(p->m_query, query) != query) {
+        p->m_modified = true;
+    }
+}
+
+void Playlist::setSortQuery(const QString& query)
+{
+    if(std::exchange(p->m_sortQuery, query) != query) {
+        p->m_modified = true;
+    }
+}
+
+void Playlist::setForceSorted(bool forceSorted)
+{
+    if(std::exchange(p->m_forceSorted, forceSorted) != forceSorted) {
         p->m_modified = true;
     }
 }

--- a/src/core/playlist/playlistchangeset.cpp
+++ b/src/core/playlist/playlistchangeset.cpp
@@ -1,0 +1,167 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/playlist/playlistchangeset.h>
+
+#include <utility>
+
+constexpr auto ResetThreshold = 500;
+
+namespace Fooyin {
+namespace {
+using TrackKeyList = std::vector<QString>;
+
+TrackKeyList playlistTrackKeys(const TrackList& tracks)
+{
+    TrackKeyList result;
+    result.reserve(tracks.size());
+    std::ranges::transform(tracks, std::back_inserter(result), &Track::uniqueFilepath);
+    return result;
+}
+
+std::optional<std::vector<PlaylistTrackMove>> buildPlaylistMoves(TrackKeyList currentKeys, const TrackKeyList& newKeys)
+{
+    if(currentKeys.size() != newKeys.size()) {
+        return {};
+    }
+
+    std::vector<PlaylistTrackMove> result;
+
+    for(int targetIndex{0}; std::cmp_less(targetIndex, newKeys.size()); ++targetIndex) {
+        if(currentKeys.at(static_cast<size_t>(targetIndex)) == newKeys.at(static_cast<size_t>(targetIndex))) {
+            continue;
+        }
+
+        const auto sourceIt = std::ranges::find(currentKeys.cbegin() + targetIndex, currentKeys.cend(),
+                                                newKeys.at(static_cast<size_t>(targetIndex)));
+        if(sourceIt == currentKeys.cend()) {
+            return {};
+        }
+
+        const int sourceIndex = static_cast<int>(std::distance(currentKeys.cbegin(), sourceIt));
+        result.push_back({.sourceIndex = sourceIndex, .targetIndex = targetIndex});
+
+        std::rotate(currentKeys.begin() + targetIndex, currentKeys.begin() + sourceIndex,
+                    currentKeys.begin() + sourceIndex + 1);
+    }
+
+    return result;
+}
+} // namespace
+
+std::optional<PlaylistChangeset> buildPlaylistChangeset(const TrackList& oldTracks, const TrackList& newTracks,
+                                                        const TrackKeySet& updatedTrackPaths)
+{
+    PlaylistChangeset result;
+    const TrackKeyList newTrackKeys = playlistTrackKeys(newTracks);
+    std::set<int> updatedIndexes;
+
+    std::unordered_map<QString, int> newTrackIndexes;
+    newTrackIndexes.reserve(newTracks.size());
+
+    for(int newIndex{0}; const auto& key : newTrackKeys) {
+        if(!newTrackIndexes.emplace(key, newIndex++).second) {
+            return {};
+        }
+    }
+
+    std::unordered_set<QString> oldTrackKeys;
+    oldTrackKeys.reserve(oldTracks.size());
+
+    TrackKeyList retainedTrackKeys;
+    retainedTrackKeys.reserve(std::min(oldTracks.size(), newTracks.size()));
+
+    for(int oldIndex{0}; const auto& oldTrack : oldTracks) {
+        const QString key = oldTrack.uniqueFilepath();
+        if(!oldTrackKeys.emplace(key).second) {
+            return {};
+        }
+
+        const auto newIndexIt = newTrackIndexes.find(key);
+        if(newIndexIt == newTrackIndexes.cend()) {
+            result.removedIndexes.push_back(oldIndex);
+            ++oldIndex;
+            continue;
+        }
+
+        const int newIndex = newIndexIt->second;
+        retainedTrackKeys.push_back(key);
+
+        if(oldTrack != newTracks.at(static_cast<size_t>(newIndex))) {
+            updatedIndexes.emplace(newIndex);
+        }
+        if(updatedTrackPaths.contains(key)) {
+            updatedIndexes.emplace(newIndex);
+        }
+
+        ++oldIndex;
+    }
+
+    PlaylistTrackInsertion insertion;
+    for(int newIndex{0}; const auto& track : newTracks) {
+        const bool isNewTrack = !oldTrackKeys.contains(track.uniqueFilepath());
+        if(isNewTrack) {
+            if(insertion.index < 0) {
+                insertion.index = newIndex;
+            }
+            insertion.tracks.push_back(track);
+        }
+        else if(insertion.isValid()) {
+            result.insertions.push_back(std::move(insertion));
+            insertion = {};
+        }
+        ++newIndex;
+    }
+    if(insertion.isValid()) {
+        result.insertions.push_back(std::move(insertion));
+    }
+
+    TrackKeyList currentKeys{retainedTrackKeys};
+    for(const auto& groupedInsertion : result.insertions) {
+        const TrackKeyList insertionKeys = playlistTrackKeys(groupedInsertion.tracks);
+        currentKeys.insert(currentKeys.begin() + groupedInsertion.index, insertionKeys.cbegin(), insertionKeys.cend());
+    }
+
+    if(const auto moves = buildPlaylistMoves(std::move(currentKeys), newTrackKeys)) {
+        result.moves = *moves;
+    }
+    else {
+        return {};
+    }
+
+    result.updatedIndexes.assign(updatedIndexes.cbegin(), updatedIndexes.cend());
+
+    int insertedTrackCount{0};
+    for(const auto& insertionGroup : result.insertions) {
+        insertedTrackCount += static_cast<int>(insertionGroup.tracks.size());
+    }
+
+    const int changedTrackCount = static_cast<int>(result.removedIndexes.size()) + insertedTrackCount
+                                + static_cast<int>(result.moves.size())
+                                + static_cast<int>(result.updatedIndexes.size());
+    const int baselineTrackCount
+        = static_cast<int>(oldTracks.size() > newTracks.size() ? oldTracks.size() : newTracks.size());
+
+    if(changedTrackCount > ResetThreshold || changedTrackCount > (baselineTrackCount / 2)) {
+        result.requiresReset = true;
+    }
+
+    return result;
+}
+} // namespace Fooyin

--- a/src/core/playlist/playlisthandler.cpp
+++ b/src/core/playlist/playlisthandler.cpp
@@ -46,6 +46,18 @@ constexpr auto ActiveId    = "Playlist/ActiveId";
 constexpr auto ActiveIndex = "Playlist/ActiveTrackIndex";
 
 namespace Fooyin {
+namespace {
+TrackKeySet playlistTrackKeySet(const TrackList& tracks)
+{
+    TrackKeySet result;
+    result.reserve(tracks.size());
+    for(const auto& track : tracks) {
+        result.emplace(track.uniqueFilepath());
+    }
+    return result;
+}
+} // namespace
+
 class PlaylistHandlerPrivate
 {
 public:
@@ -54,7 +66,7 @@ public:
 
     void reloadPlaylists();
     void populatePlaylists();
-    void regenerateAutoPlaylists();
+    void regenerateAutoPlaylists(const TrackList& updatedTracks = {});
     bool noConcretePlaylists();
 
     void handleTracksChanged(const TrackList& tracks);
@@ -78,7 +90,7 @@ public:
 
     void restoreActivePlaylist();
     Playlist* addNewPlaylist(const QString& name, bool isTemporary = false);
-    Playlist* addNewAutoPlaylist(const QString& name, const QString& query);
+    Playlist* addNewAutoPlaylist(const QString& name, const QString& query, const QString& sortQuery, bool forceSorted);
 
     PlaylistHandler* m_self;
 
@@ -113,7 +125,8 @@ void PlaylistHandlerPrivate::reloadPlaylists()
 
     for(const auto& info : infos) {
         if(info.isAutoPlaylist) {
-            m_playlists.emplace_back(Playlist::createAuto(info.dbId, info.name, info.index, info.query, m_settings));
+            m_playlists.emplace_back(Playlist::createAuto(info.dbId, info.name, info.index, info.query, info.sortQuery,
+                                                          info.forceSorted, m_settings));
         }
         else {
             m_playlists.emplace_back(Playlist::create(info.dbId, info.name, info.index, m_settings));
@@ -132,6 +145,11 @@ void PlaylistHandlerPrivate::populatePlaylists()
 
     for(const auto& playlist : m_playlists) {
         if(playlist->isAutoPlaylist()) {
+            if(!playlist->forceSorted()) {
+                const TrackList playlistTracks = m_playlistConnector.getPlaylistTracks(*playlist, idTracks);
+                playlist->replaceTracks(playlistTracks);
+                playlist->setTracksModified(false);
+            }
             playlist->regenerateTracks(tracks);
         }
         else {
@@ -145,11 +163,30 @@ void PlaylistHandlerPrivate::populatePlaylists()
     emit m_self->playlistsPopulated();
 }
 
-void PlaylistHandlerPrivate::regenerateAutoPlaylists()
+void PlaylistHandlerPrivate::regenerateAutoPlaylists(const TrackList& updatedTracks)
 {
-    const TrackList tracks = m_library->tracks();
+    const TrackList tracks            = m_library->tracks();
+    const TrackKeySet updatedTrackIds = playlistTrackKeySet(updatedTracks);
+
     for(auto& playlist : m_playlists) {
-        if(playlist->regenerateTracks(tracks)) {
+        if(!playlist->isAutoPlaylist()) {
+            continue;
+        }
+
+        const TrackList oldTracks = playlist->tracks();
+        const TrackList newTracks = playlist->autoPlaylistTracks(tracks);
+
+        const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks, updatedTrackIds);
+        if(changeSet && changeSet->isEmpty()) {
+            continue;
+        }
+
+        playlist->replaceTracks(newTracks);
+
+        if(changeSet) {
+            emit m_self->tracksPatched(playlist.get(), changeSet.value());
+        }
+        else {
             emit m_self->tracksChanged(playlist.get(), {});
         }
     }
@@ -181,6 +218,10 @@ void PlaylistHandlerPrivate::handleTracksChanged(const TrackList& tracks)
 void PlaylistHandlerPrivate::handleTracksUpdated(const TrackList& tracks)
 {
     for(auto& playlist : m_playlists) {
+        if(playlist->isAutoPlaylist()) {
+            continue;
+        }
+
         TrackList playlistTracks  = playlist->tracks();
         const auto updatedIndexes = Utils::updateCommonTracks(playlistTracks, tracks, Utils::CommonOperation::Update);
 
@@ -215,7 +256,7 @@ void PlaylistHandlerPrivate::prepareUpcomingTrack()
 void PlaylistHandlerPrivate::resetShuffleOrder()
 {
     for(auto& playlist : m_playlists) {
-        playlist->reset();
+        (*playlist).reset();
     }
 }
 
@@ -313,7 +354,7 @@ bool PlaylistHandlerPrivate::validName(const QString& name) const
 
 bool PlaylistHandlerPrivate::validIndex(int index) const
 {
-    return (index >= 0 && index < static_cast<int>(m_playlists.size()));
+    return (index >= 0 && std::cmp_less(index, m_playlists.size()));
 }
 
 void PlaylistHandlerPrivate::restoreActivePlaylist()
@@ -372,7 +413,8 @@ Playlist* PlaylistHandlerPrivate::addNewPlaylist(const QString& name, bool isTem
     return nullptr;
 }
 
-Playlist* PlaylistHandlerPrivate::addNewAutoPlaylist(const QString& name, const QString& query)
+Playlist* PlaylistHandlerPrivate::addNewAutoPlaylist(const QString& name, const QString& query,
+                                                     const QString& sortQuery, bool forceSorted)
 {
     auto existingIndex = indexFromName(name);
 
@@ -383,11 +425,13 @@ Playlist* PlaylistHandlerPrivate::addNewAutoPlaylist(const QString& name, const 
     const QString playlistName = !name.isEmpty() ? name : findUniqueName(u"Auto Playlist"_s);
 
     const int index = nextValidIndex();
-    const int dbId  = m_playlistConnector.insertPlaylist(playlistName, index, true, query);
+    const int dbId  = m_playlistConnector.insertPlaylist(playlistName, index, true, query, sortQuery, forceSorted);
 
     if(dbId >= 0) {
-        auto* playlist
-            = m_playlists.emplace_back(Playlist::createAuto(dbId, playlistName, index, query, m_settings)).get();
+        auto* playlist = m_playlists
+                             .emplace_back(Playlist::createAuto(dbId, playlistName, index, query, sortQuery,
+                                                                forceSorted, m_settings))
+                             .get();
         return playlist;
     }
 
@@ -410,11 +454,11 @@ PlaylistHandler::PlaylistHandler(DbConnectionPoolPtr dbPool, std::shared_ptr<Aud
     QObject::connect(p->m_library, &MusicLibrary::tracksDeleted, this, [this]() { p->regenerateAutoPlaylists(); });
     QObject::connect(p->m_library, &MusicLibrary::tracksMetadataChanged, this, [this](const TrackList& tracks) {
         p->handleTracksChanged(tracks);
-        p->regenerateAutoPlaylists();
+        p->regenerateAutoPlaylists(tracks);
     });
     QObject::connect(p->m_library, &MusicLibrary::tracksUpdated, this, [this](const TrackList& tracks) {
         p->handleTracksUpdated(tracks);
-        p->regenerateAutoPlaylists();
+        p->regenerateAutoPlaylists(tracks);
     });
 
     p->m_settings->subscribe<Settings::Core::ShuffleAlbumsGroupScript>(this, [this]() { p->resetShuffleOrder(); });
@@ -606,16 +650,25 @@ Playlist* PlaylistHandler::createNewTempPlaylist(const QString& name, const Trac
     return playlist;
 }
 
-Playlist* PlaylistHandler::createAutoPlaylist(const QString& name, const QString& query)
+Playlist* PlaylistHandler::createAutoPlaylist(const QString& name, const QString& query, const QString& sortQuery,
+                                              bool forceSorted)
 {
     const bool isNew = p->indexFromName(name) < 0;
-    auto* playlist   = p->addNewAutoPlaylist(name, query);
+    auto* playlist   = p->addNewAutoPlaylist(name, query, sortQuery, forceSorted);
 
     if(playlist) {
-        if(isNew || playlist->query() != query) {
+        const bool queryChanged       = playlist->query() != query;
+        const bool sortQueryChanged   = playlist->sortQuery() != sortQuery;
+        const bool forceSortedChanged = playlist->forceSorted() != forceSorted;
+        if(isNew || queryChanged || sortQueryChanged || forceSortedChanged) {
             playlist->setQuery(query);
+            playlist->setSortQuery(sortQuery);
+            playlist->setForceSorted(forceSorted);
             if(playlist->regenerateTracks(p->m_library->tracks())) {
                 emit tracksChanged(playlist, {});
+            }
+            else if(!isNew) {
+                emit playlistUpdated(playlist);
             }
         }
         if(isNew) {
@@ -626,10 +679,11 @@ Playlist* PlaylistHandler::createAutoPlaylist(const QString& name, const QString
     return playlist;
 }
 
-Playlist* PlaylistHandler::createNewAutoPlaylist(const QString& name, const QString& query)
+Playlist* PlaylistHandler::createNewAutoPlaylist(const QString& name, const QString& query, const QString& sortQuery,
+                                                 bool forceSorted)
 {
     const QString newName = p->findUniqueName(name);
-    auto* playlist        = p->addNewAutoPlaylist(newName, query);
+    auto* playlist        = p->addNewAutoPlaylist(newName, query, sortQuery, forceSorted);
 
     if(playlist) {
         playlist->regenerateTracks(p->m_library->tracks());

--- a/src/gui/dialog/autoplaylistdialog.cpp
+++ b/src/gui/dialog/autoplaylistdialog.cpp
@@ -49,6 +49,8 @@ AutoPlaylistDialog::AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlis
     , m_queryChanged{false}
     , m_queryBox{new QComboBox(this)}
     , m_queryEdit{new ScriptTextEdit(this)}
+    , m_sortQueryEdit{new QLineEdit(this)}
+    , m_forceSorted{new QCheckBox(tr("Force-sorted"), this)}
     , m_loadButton{new QPushButton(tr("&Load"), this)}
     , m_saveButton{new QPushButton(tr("&Save"), this)}
     , m_deleteButton{new QPushButton(tr("&Delete"), this)}
@@ -79,6 +81,12 @@ AutoPlaylistDialog::AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlis
     QObject::connect(m_resetButton, &QAbstractButton::clicked, this, &AutoPlaylistDialog::resetQueries);
     QObject::connect(m_queryBox, &QComboBox::editTextChanged, this, &AutoPlaylistDialog::updateButtonState);
     QObject::connect(m_queryEdit, &QPlainTextEdit::textChanged, this, &AutoPlaylistDialog::updateButtonState);
+    QObject::connect(m_sortQueryEdit, &QLineEdit::textChanged, this, &AutoPlaylistDialog::updateButtonState);
+    QObject::connect(m_forceSorted, &QCheckBox::toggled, this, &AutoPlaylistDialog::updateButtonState);
+    m_forceSorted->setToolTip(
+        tr("When enabled, the autoplaylist is fully reordered by its sort pattern whenever it regenerates. \n"
+           "When disabled, existing track order is preserved and only newly added matching tracks are sorted and then "
+           "appended."));
 
     auto* layout = new QGridLayout(this);
 
@@ -88,6 +96,9 @@ AutoPlaylistDialog::AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlis
     layout->addWidget(m_queryBox, row++, 1);
     layout->addWidget(new QLabel(tr("Query") + ":"_L1, this), row, 0, Qt::AlignTop);
     layout->addWidget(m_queryEdit, row++, 1);
+    layout->addWidget(new QLabel(tr("Sort") + ":"_L1, this), row, 0);
+    layout->addWidget(m_sortQueryEdit, row++, 1);
+    layout->addWidget(m_forceSorted, row++, 1, Qt::AlignLeft);
     layout->addWidget(buttonBox, row++, 0, 1, 3);
     layout->setColumnStretch(1, 1);
 
@@ -97,6 +108,8 @@ AutoPlaylistDialog::AutoPlaylistDialog(PlaylistHandler* playlisthandler, Playlis
     if(m_playlist && m_playlist->isAutoPlaylist()) {
         m_queryBox->setEditText(m_playlist->name());
         m_queryEdit->setText(m_playlist->query());
+        m_sortQueryEdit->setText(m_playlist->sortQuery());
+        m_forceSorted->setChecked(m_playlist->forceSorted());
     }
 
     updateButtonState();
@@ -114,13 +127,14 @@ void AutoPlaylistDialog::accept()
     const QString name = m_queryBox->currentText();
 
     if(m_playlistHandler && m_playlist) {
-        m_playlistHandler->createAutoPlaylist(m_playlist->name(), m_queryEdit->text());
+        m_playlistHandler->createAutoPlaylist(m_playlist->name(), m_queryEdit->text(), m_sortQueryEdit->text(),
+                                              m_forceSorted->isChecked());
         if(name != m_playlist->name()) {
             m_playlistHandler->renamePlaylist(m_playlist->id(), name);
         }
     }
 
-    emit playlistEdited(name, m_queryEdit->text());
+    emit playlistEdited(name, m_queryEdit->text(), m_sortQueryEdit->text(), m_forceSorted->isChecked());
     QDialog::accept();
 }
 
@@ -139,8 +153,10 @@ void AutoPlaylistDialog::updateButtonState() const
 AutoPlaylistQuery AutoPlaylistDialog::currentQuery() const
 {
     AutoPlaylistQuery query;
-    query.name  = m_queryBox->currentText();
-    query.query = m_queryEdit->text();
+    query.name        = m_queryBox->currentText();
+    query.query       = m_queryEdit->text();
+    query.sortQuery   = m_sortQueryEdit->text();
+    query.forceSorted = m_forceSorted->isChecked();
     return query;
 }
 
@@ -186,6 +202,8 @@ void AutoPlaylistDialog::loadQuery()
     if(query != m_queries.cend()) {
         m_queryBox->setEditText(query->name);
         m_queryEdit->setText(query->query);
+        m_sortQueryEdit->setText(query->sortQuery);
+        m_forceSorted->setChecked(query->forceSorted);
     }
 }
 
@@ -212,6 +230,8 @@ void AutoPlaylistDialog::resetQueries()
     m_queryChanged = false;
     populateQueries();
     m_queryBox->setEditText({});
+    m_sortQueryEdit->clear();
+    m_forceSorted->setChecked(true);
 }
 
 void AutoPlaylistDialog::saveQueries() const
@@ -276,10 +296,10 @@ void AutoPlaylistDialog::populateQueries()
 
 void AutoPlaylistDialog::loadDefaultQueries()
 {
-    m_queries = {{tr("Most Played"), u"playcount>0 LIMIT 25 SORT- playcount"_s},
-                 {tr("Recently Added"), u"addedtime DURING LAST 2 WEEKS SORT- addedtime"_s},
-                 {tr("Last Played 2 Weeks"), u"lastplayed DURING LAST 2 WEEKS SORT- lastplayed"_s},
-                 {tr("Has Lyrics"), u"lyrics PRESENT"_s}};
+    m_queries = {{tr("Most Played"), u"playcount>0 LIMIT 25"_s, u"SORT- playcount"_s},
+                 {tr("Recently Added"), u"addedtime DURING LAST 2 WEEKS"_s, u"SORT- addedtime"_s},
+                 {tr("Last Played 2 Weeks"), u"lastplayed DURING LAST 2 WEEKS"_s, u"SORT- lastplayed"_s},
+                 {tr("Has Lyrics"), u"lyrics PRESENT"_s, {}}};
 }
 } // namespace Fooyin
 

--- a/src/gui/dialog/autoplaylistdialog.h
+++ b/src/gui/dialog/autoplaylistdialog.h
@@ -34,13 +34,17 @@ struct AutoPlaylistQuery
 {
     QString name;
     QString query;
+    QString sortQuery;
+    bool forceSorted{false};
 
     friend QDataStream& operator<<(QDataStream& stream, const AutoPlaylistQuery& preset)
     {
-        static constexpr int version{1};
+        static constexpr int version{2};
         stream << version;
         stream << preset.name;
         stream << preset.query;
+        stream << preset.sortQuery;
+        stream << preset.forceSorted;
 
         return stream;
     }
@@ -49,8 +53,14 @@ struct AutoPlaylistQuery
     {
         int version{0};
         stream >> version;
+
         stream >> preset.name;
         stream >> preset.query;
+
+        if(version >= 2) {
+            stream >> preset.sortQuery;
+            stream >> preset.forceSorted;
+        }
 
         return stream;
     }
@@ -68,7 +78,7 @@ public:
     void accept() override;
 
 signals:
-    void playlistEdited(const QString& name, const QString& query);
+    void playlistEdited(const QString& name, const QString& query, const QString& sortQuery, bool forceSorted);
 
 private:
     void updateButtonState() const;
@@ -92,6 +102,8 @@ private:
 
     QComboBox* m_queryBox;
     ScriptTextEdit* m_queryEdit;
+    QLineEdit* m_sortQueryEdit;
+    QCheckBox* m_forceSorted;
     QPushButton* m_loadButton;
     QPushButton* m_saveButton;
     QPushButton* m_deleteButton;

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -1039,8 +1039,9 @@ void GuiApplicationPrivate::createNewAutoPlaylist()
     auto* autoDialog = new AutoPlaylistDialog(m_mainWindow.get());
     autoDialog->setAttribute(Qt::WA_DeleteOnClose);
     QObject::connect(autoDialog, &AutoPlaylistDialog::playlistEdited, autoDialog,
-                     [this](const QString& name, const QString& query) {
-                         if(auto* playlist = m_playlistHandler->createNewAutoPlaylist(name, query)) {
+                     [this](const QString& name, const QString& query, const QString& sortQuery, bool forceSorted) {
+                         if(auto* playlist
+                            = m_playlistHandler->createNewAutoPlaylist(name, query, sortQuery, forceSorted)) {
                              m_playlistController->changeCurrentPlaylist(playlist);
                          }
                      });

--- a/src/gui/playlist/detachedplaylistsession.cpp
+++ b/src/gui/playlist/detachedplaylistsession.cpp
@@ -65,6 +65,16 @@ bool DetachedSearchSession::canResetWithoutPlaylist() const
     return true;
 }
 
+void DetachedSearchSession::handleTracksChanged(PlaylistWidgetSessionHost& host, const std::vector<int>& /*indexes*/,
+                                                bool /*allNew*/)
+{
+    if(search().isEmpty() && filteredTracks().empty()) {
+        return;
+    }
+
+    searchEvent(host, search());
+}
+
 void DetachedSearchSession::handleSearchChanged(PlaylistWidgetSessionHost& host, const QString& /*search*/)
 {
     host.resetSort(true);

--- a/src/gui/playlist/detachedplaylistsession.h
+++ b/src/gui/playlist/detachedplaylistsession.h
@@ -32,6 +32,7 @@ public:
     [[nodiscard]] PlaylistTrackList modelTracks(Playlist* currentPlaylist) const override;
     [[nodiscard]] bool canResetWithoutPlaylist() const override;
 
+    void handleTracksChanged(PlaylistWidgetSessionHost& host, const std::vector<int>& indexes, bool allNew) override;
     void handleSearchChanged(PlaylistWidgetSessionHost& host, const QString& search) override;
     void finalise(PlaylistWidgetSessionHost& host) override;
 };

--- a/src/gui/playlist/editableplaylistsession.cpp
+++ b/src/gui/playlist/editableplaylistsession.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <utility>
 
 namespace Fooyin {
 namespace {
@@ -55,6 +56,16 @@ PlaylistWidgetSessionHost& widgetSessionHost(PlaylistWidget* widget)
 EditablePlaylistSessionHost& editableHost(PlaylistWidget* widget)
 {
     return widget->editableSessionHost();
+}
+
+bool canEditPlaylistTracks(const Playlist* playlist)
+{
+    return playlist && !playlist->isAutoPlaylist();
+}
+
+bool canReorderPlaylist(const Playlist* playlist)
+{
+    return playlist && (!playlist->isAutoPlaylist() || !playlist->forceSorted());
 }
 } // namespace
 
@@ -68,6 +79,7 @@ EditablePlaylistSession::EditablePlaylistSession()
     , m_pendingFocus{false}
     , m_dropIndex{-1}
     , m_currentIndex{-1}
+    , m_sortRequestToken{0}
     , m_undoAction{nullptr}
     , m_redoAction{nullptr}
     , m_cropAction{nullptr}
@@ -77,10 +89,29 @@ EditablePlaylistSession::EditablePlaylistSession()
     , m_pasteAction{nullptr}
     , m_clearAction{nullptr}
     , m_removeTrackAction{nullptr}
+    , m_removeDuplicatesAction{nullptr}
+    , m_removeDeadTracksAction{nullptr}
     , m_addToQueueAction{nullptr}
     , m_queueNextAction{nullptr}
     , m_removeFromQueueAction{nullptr}
 { }
+
+uint64_t EditablePlaylistSession::beginSortRequest()
+{
+    return ++m_sortRequestToken;
+}
+
+void EditablePlaylistSession::finishSortRequest(uint64_t token, bool sortingColumn)
+{
+    if(token != m_sortRequestToken) {
+        return;
+    }
+
+    if(sortingColumn) {
+        setSortingColumn(false);
+    }
+    setSorting(false);
+}
 
 PlaylistWidget::ModeCapabilities EditablePlaylistSession::capabilities() const
 {
@@ -191,6 +222,12 @@ void EditablePlaylistSession::ensureActions(QWidget* parent)
         m_removeTrackAction
             = new QAction(Utils::iconFromTheme(Constants::Icons::Remove), PlaylistWidget::tr("&Remove"), parent);
     }
+    if(!m_removeDuplicatesAction) {
+        m_removeDuplicatesAction = new QAction(PlaylistWidget::tr("Remove duplicates"), parent);
+    }
+    if(!m_removeDeadTracksAction) {
+        m_removeDeadTracksAction = new QAction(PlaylistWidget::tr("Remove dead tracks"), parent);
+    }
     if(!m_addToQueueAction) {
         m_addToQueueAction = new QAction(Utils::iconFromTheme(Constants::Icons::Add),
                                          PlaylistWidget::tr("Add to playback &queue"), parent);
@@ -253,6 +290,10 @@ void EditablePlaylistSession::setupConnections(PlaylistWidgetSessionHost& sessio
                      [widget, this](const TrackList& tracks, int index) {
                          playlistTracksAdded(widgetSessionHost(widget), tracks, index);
                      });
+    QObject::connect(widget->playlistController(), &PlaylistController::currentPlaylistTracksPatched, widget,
+                     [widget, this](const PlaylistChangeset& changeSet) {
+                         applyPlaylistChangeSet(widgetSessionHost(widget), changeSet);
+                     });
     QObject::connect(widget->playlistController()->uiController(), &PlaylistUiController::selectTracks, widget,
                      [widget, this](const std::vector<int>& ids) { selectTrackIds(widget, ids); });
     QObject::connect(widget->playlistController()->uiController(), &PlaylistUiController::filterTracks, widget,
@@ -303,10 +344,8 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
     editMenu->addAction(undoCmd);
     QObject::connect(m_undoAction, &QAction::triggered, widget,
                      [widget]() { editableHost(widget).playlistController()->undoPlaylistChanges(); });
-    QObject::connect(host.playlistController(), &PlaylistController::playlistHistoryChanged, widget, [this, widget]() {
-        m_undoAction->setEnabled(editableHost(widget).playlistController()->canUndo());
-    });
-    m_undoAction->setEnabled(host.playlistController()->canUndo());
+    QObject::connect(host.playlistController(), &PlaylistController::playlistHistoryChanged, widget,
+                     [this, widget]() { refreshActionState(widget); });
 
     m_redoAction->setStatusTip(PlaylistWidget::tr("Redo the previous playlist change"));
     auto* redoCmd = host.actionManager()->registerAction(m_redoAction, Constants::Actions::Redo,
@@ -316,10 +355,8 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
     editMenu->addAction(redoCmd);
     QObject::connect(m_redoAction, &QAction::triggered, widget,
                      [widget]() { editableHost(widget).playlistController()->redoPlaylistChanges(); });
-    QObject::connect(host.playlistController(), &PlaylistController::playlistHistoryChanged, widget, [this, widget]() {
-        m_redoAction->setEnabled(editableHost(widget).playlistController()->canRedo());
-    });
-    m_redoAction->setEnabled(host.playlistController()->canRedo());
+    QObject::connect(host.playlistController(), &PlaylistController::playlistHistoryChanged, widget,
+                     [this, widget]() { refreshActionState(widget); });
 
     editMenu->addSeparator();
 
@@ -331,7 +368,6 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
     editMenu->addAction(cutCommand);
     QObject::connect(m_cutAction, &QAction::triggered, widget,
                      [widget, this]() { cutTracks(widgetSessionHost(widget)); });
-    m_cutAction->setEnabled(host.playlistView()->selectionModel()->hasSelection());
 
     m_copyAction->setStatusTip(PlaylistWidget::tr("Copy the selected tracks"));
     auto* copyCommand = host.actionManager()->registerAction(m_copyAction, Constants::Actions::Copy,
@@ -349,12 +385,10 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
     pasteCommand->setCategories(editCategory);
     pasteCommand->setDefaultShortcut(QKeySequence::Paste);
     editMenu->addAction(m_pasteAction);
-    QObject::connect(host.playlistController(), &PlaylistController::clipboardChanged, widget, [this, widget]() {
-        m_pasteAction->setEnabled(!editableHost(widget).playlistController()->clipboardEmpty());
-    });
+    QObject::connect(host.playlistController(), &PlaylistController::clipboardChanged, widget,
+                     [this, widget]() { refreshActionState(widget); });
     QObject::connect(m_pasteAction, &QAction::triggered, widget,
                      [widget, this]() { pasteTracks(widgetSessionHost(widget)); });
-    m_pasteAction->setEnabled(!host.playlistController()->clipboardEmpty());
 
     editMenu->addSeparator();
 
@@ -366,7 +400,6 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
     editMenu->addAction(clearCmd);
     QObject::connect(m_clearAction, &QAction::triggered, widget,
                      [widget, this]() { clearTracks(widgetSessionHost(widget)); });
-    m_clearAction->setEnabled(host.playlistModel()->rowCount({}) > 0);
 
     m_removeTrackAction->setStatusTip(PlaylistWidget::tr("Remove the selected tracks from the current playlist"));
     m_removeTrackAction->setEnabled(false);
@@ -402,20 +435,19 @@ void EditablePlaylistSession::setupActions(PlaylistWidgetSessionHost& sessionHos
 
     editMenu->addSeparator();
 
-    auto* removeDuplicatesAction = new QAction(PlaylistWidget::tr("Remove duplicates"), widget);
-    removeDuplicatesAction->setStatusTip(PlaylistWidget::tr("Remove duplicate tracks from the playlist"));
-    editMenu->addAction(removeDuplicatesAction);
-    QObject::connect(removeDuplicatesAction, &QAction::triggered, widget,
+    m_removeDuplicatesAction->setStatusTip(PlaylistWidget::tr("Remove duplicate tracks from the playlist"));
+    editMenu->addAction(m_removeDuplicatesAction);
+    QObject::connect(m_removeDuplicatesAction, &QAction::triggered, widget,
                      [widget, this]() { removeDuplicates(widgetSessionHost(widget)); });
 
-    auto* removeDeadTracksAction = new QAction(PlaylistWidget::tr("Remove dead tracks"), widget);
-    removeDeadTracksAction->setStatusTip(PlaylistWidget::tr("Remove dead (non-existant) tracks from the playlist"));
-    editMenu->addAction(removeDeadTracksAction);
-    QObject::connect(removeDeadTracksAction, &QAction::triggered, widget,
+    m_removeDeadTracksAction->setStatusTip(PlaylistWidget::tr("Remove dead (non-existant) tracks from the playlist"));
+    editMenu->addAction(m_removeDeadTracksAction);
+    QObject::connect(m_removeDeadTracksAction, &QAction::triggered, widget,
                      [widget, this]() { removeDeadTracks(widgetSessionHost(widget)); });
 
     editMenu->addSeparator();
 
+    refreshActionState(widget);
     updateSelectionState(sessionHost, {}, {}, {});
 }
 
@@ -469,6 +501,90 @@ void EditablePlaylistSession::destroy(PlaylistWidgetSessionHost& sessionHost)
     host.playlistController()->clearHistory();
 }
 
+void EditablePlaylistSession::refreshActionState(PlaylistWidget* widget)
+{
+    auto& host                  = editableHost(widget);
+    auto* currentPlaylist       = host.playlistController()->currentPlaylist();
+    const bool canEditTracks    = canEditPlaylistTracks(currentPlaylist);
+    const bool canReorderTracks = canReorderPlaylist(currentPlaylist);
+    const bool hasSelection
+        = host.playlistView()->selectionModel() && host.playlistView()->selectionModel()->hasSelection();
+
+    m_undoAction->setEnabled(canReorderTracks && host.playlistController()->canUndo());
+    m_redoAction->setEnabled(canReorderTracks && host.playlistController()->canRedo());
+    m_cropAction->setEnabled(canEditTracks && hasSelection);
+    m_cutAction->setEnabled(canEditTracks && hasSelection);
+    m_copyAction->setEnabled(hasSelection);
+    m_pasteAction->setEnabled(canEditTracks && !host.playlistController()->clipboardEmpty());
+    m_clearAction->setEnabled(canEditTracks && host.playlistModel()->rowCount({}) > 0);
+    m_removeTrackAction->setEnabled(canEditTracks && hasSelection);
+    m_removeDuplicatesAction->setEnabled(canEditTracks);
+    m_removeDeadTracksAction->setEnabled(canEditTracks);
+}
+
+void EditablePlaylistSession::applyPlaylistChangeSet(PlaylistWidgetSessionHost& sessionHost,
+                                                     const PlaylistChangeset& changeSet)
+{
+    auto& host            = editableHost(sessionHost.sessionWidget());
+    auto* currentPlaylist = host.playlistController()->currentPlaylist();
+    if(!currentPlaylist) {
+        return;
+    }
+
+    if(changeSet.requiresReset || hasSearch()) {
+        handleTracksChanged(sessionHost, {}, false);
+        return;
+    }
+
+    QModelIndexList trackIndexesToRemove;
+    for(const int index : changeSet.removedIndexes) {
+        const QModelIndex trackIndex = host.playlistModel()->indexAtPlaylistIndex(index, false);
+        if(trackIndex.isValid()) {
+            trackIndexesToRemove.push_back(trackIndex);
+        }
+    }
+    if(!trackIndexesToRemove.empty()) {
+        host.playlistModel()->removeTracks(trackIndexesToRemove);
+    }
+
+    const auto applyMovesAndUpdates
+        = [model = host.playlistModel(), moves = changeSet.moves, updatedIndexes = changeSet.updatedIndexes,
+           currentPlaylist, this, widget                                         = sessionHost.sessionWidget()] {
+              for(const auto& move : moves) {
+                  if(!move.isValid()) {
+                      continue;
+                  }
+
+                  MoveOperation operation;
+                  operation.emplace_back(move.targetIndex, TrackIndexRangeList{{move.sourceIndex, move.sourceIndex}});
+                  model->moveTracks(operation);
+              }
+
+              if(!updatedIndexes.empty()) {
+                  model->updateTracks(updatedIndexes);
+              }
+
+              model->updateHeader(currentPlaylist);
+              refreshActionState(widget);
+          };
+
+    TrackGroups insertions;
+    for(const auto& insertion : changeSet.insertions) {
+        if(insertion.isValid()) {
+            insertions[insertion.index] = PlaylistTrack::fromTracks(insertion.tracks, currentPlaylist->id());
+        }
+    }
+
+    if(!insertions.empty()) {
+        QObject::connect(host.playlistModel(), &PlaylistModel::playlistTracksChanged, host.playlistModel(),
+                         applyMovesAndUpdates, Qt::SingleShotConnection);
+        host.playlistModel()->insertTracks(insertions);
+    }
+    else {
+        applyMovesAndUpdates();
+    }
+}
+
 void EditablePlaylistSession::handleAboutToBeReset(PlaylistWidgetSessionHost& sessionHost)
 {
     auto& host = editableHost(sessionHost.sessionWidget());
@@ -497,7 +613,7 @@ void EditablePlaylistSession::resetTree(PlaylistWidgetSessionHost& sessionHost)
 
     host.resetSort(false);
     restorePlaylistViewState(host, host.playlistController()->currentPlaylist());
-    m_clearAction->setEnabled(!host.playlistController()->currentIsAuto() && host.playlistModel()->rowCount({}) > 0);
+    refreshActionState(sessionHost.sessionWidget());
 
     if(m_pendingFocus) {
         m_pendingFocus = false;
@@ -580,32 +696,41 @@ void EditablePlaylistSession::handleTracksChanged(PlaylistWidgetSessionHost& ses
 
 void EditablePlaylistSession::applyReadOnlyState(PlaylistWidgetSessionHost& sessionHost, bool readOnly)
 {
-    auto& host = editableHost(sessionHost.sessionWidget());
-    host.playlistView()->setDragDropMode(!readOnly ? QAbstractItemView::DragDrop : QAbstractItemView::NoDragDrop);
-    host.playlistView()->viewport()->setAcceptDrops(!readOnly);
-    host.playlistView()->setDragEnabled(!readOnly);
-    host.playlistView()->setDefaultDropAction(!readOnly ? Qt::MoveAction : Qt::IgnoreAction);
+    auto& host            = editableHost(sessionHost.sessionWidget());
+    auto* currentPlaylist = host.playlistController()->currentPlaylist();
+    const bool canReorder = canReorderPlaylist(currentPlaylist) && !readOnly;
 
-    m_undoAction->setEnabled(!readOnly);
-    m_redoAction->setEnabled(!readOnly);
-    m_removeTrackAction->setEnabled(!readOnly);
-    m_removeFromQueueAction->setEnabled(!readOnly);
-    m_clearAction->setEnabled(!readOnly);
-    m_cutAction->setEnabled(!readOnly);
-    m_pasteAction->setEnabled(!readOnly);
+    if(canEditPlaylistTracks(currentPlaylist)) {
+        host.playlistView()->setDragDropMode(QAbstractItemView::DragDrop);
+    }
+    else if(canReorder) {
+        host.playlistView()->setDragDropMode(QAbstractItemView::InternalMove);
+    }
+    else {
+        host.playlistView()->setDragDropMode(QAbstractItemView::NoDragDrop);
+    }
+
+    host.playlistView()->viewport()->setAcceptDrops(canReorder);
+    host.playlistView()->setDragEnabled(canReorder);
+    host.playlistView()->setDefaultDropAction(canReorder ? Qt::MoveAction : Qt::IgnoreAction);
+
+    refreshActionState(sessionHost.sessionWidget());
 }
 
 void EditablePlaylistSession::updateContextMenuState(PlaylistWidgetSessionHost& sessionHost,
                                                      const QModelIndexList& selected,
                                                      PlaylistWidget::ContextMenuState& state)
 {
-    const auto& host          = editableHost(sessionHost.sessionWidget());
-    const bool isAutoPlaylist = host.playlistController()->currentIsAuto();
+    const auto& host   = editableHost(sessionHost.sessionWidget());
+    auto* playlist     = host.playlistController()->currentPlaylist();
+    const bool canEdit = canEditPlaylistTracks(playlist);
+    const bool canSort = canReorderPlaylist(playlist);
 
     state.showStopAfter = host.playlistController()->currentIsActive() && host.playlistView()->currentIndex().isValid()
                        && host.playlistView()->currentIndex().data(PlaylistItem::Type).toInt() == PlaylistItem::Track;
-    state.showEditablePlaylistActions = !isAutoPlaylist;
-    state.showClipboard               = !isAutoPlaylist;
+    state.showEditablePlaylistActions = canEdit;
+    state.showSortMenu                = canSort;
+    state.showClipboard               = canEdit;
     state.usePlaylistQueueCommands    = true;
     state.disableSortMenu             = selected.size() == 1;
 }
@@ -625,16 +750,9 @@ void EditablePlaylistSession::updateSelectionState(PlaylistWidgetSessionHost& se
     }
 
     const bool hasSelection = !trackIndexes.empty();
-    if(!host.playlistController()->currentIsAuto()) {
-        m_cutAction->setEnabled(true);
-        m_pasteAction->setEnabled(true);
-        m_removeTrackAction->setEnabled(true);
-    }
-
-    m_copyAction->setEnabled(true);
-    m_removeTrackAction->setEnabled(hasSelection);
     m_addToQueueAction->setEnabled(hasSelection);
     m_queueNextAction->setEnabled(hasSelection);
+    refreshActionState(sessionHost.sessionWidget());
 }
 
 void EditablePlaylistSession::queueSelectedTracks(PlaylistWidgetSessionHost& sessionHost, bool next, bool send)
@@ -691,7 +809,7 @@ void EditablePlaylistSession::dequeueSelectedTracks(PlaylistWidgetSessionHost& s
 void EditablePlaylistSession::removeDuplicates(PlaylistWidgetSessionHost& sessionHost)
 {
     auto& host = editableHost(sessionHost.sessionWidget());
-    if(auto* playlist = host.playlistController()->currentPlaylist()) {
+    if(auto* playlist = host.playlistController()->currentPlaylist(); canEditPlaylistTracks(playlist)) {
         tracksRemoved(sessionHost, host.playlistController()->playlistHandler()->duplicateTrackIndexes(playlist->id()));
     }
 }
@@ -699,7 +817,7 @@ void EditablePlaylistSession::removeDuplicates(PlaylistWidgetSessionHost& sessio
 void EditablePlaylistSession::removeDeadTracks(PlaylistWidgetSessionHost& sessionHost)
 {
     auto& host = editableHost(sessionHost.sessionWidget());
-    if(auto* playlist = host.playlistController()->currentPlaylist()) {
+    if(auto* playlist = host.playlistController()->currentPlaylist(); canEditPlaylistTracks(playlist)) {
         tracksRemoved(sessionHost, host.playlistController()->playlistHandler()->deadTrackIndexes(playlist->id()));
     }
 }
@@ -740,7 +858,7 @@ void EditablePlaylistSession::tracksInserted(PlaylistWidgetSessionHost& sessionH
     auto* command = new InsertTracks(host.playerController(), host.playlistModel(),
                                      host.playlistController()->currentPlaylistId(), tracks);
     host.playlistController()->addToHistory(command);
-    m_clearAction->setEnabled(host.playlistModel()->rowCount({}) > 0);
+    refreshActionState(sessionHost.sessionWidget());
     if(host.playlistController()->currentPlaylist()) {
         host.playlistModel()->updateHeader(host.playlistController()->currentPlaylist());
     }
@@ -779,7 +897,7 @@ void EditablePlaylistSession::tracksRemoved(PlaylistWidgetSessionHost& sessionHo
         host.playlistController()->addToHistory(delCmd);
     }
 
-    m_clearAction->setEnabled(host.playlistModel()->rowCount({}) > 0);
+    refreshActionState(sessionHost.sessionWidget());
     host.playlistModel()->updateHeader(host.playlistController()->currentPlaylist());
 }
 
@@ -928,16 +1046,26 @@ void EditablePlaylistSession::sortTracks(PlaylistWidgetSessionHost& sessionHost,
 {
     auto* widget = sessionHost.sessionWidget();
     auto& host   = editableHost(widget);
-    if(!host.playlistController()->currentPlaylist()) {
+    if(!canReorderPlaylist(host.playlistController()->currentPlaylist())) {
         return;
     }
 
     auto* currentPlaylist    = host.playlistController()->currentPlaylist();
     const auto currentTracks = currentPlaylist->playlistTracks();
+    const auto playlistId    = currentPlaylist->id();
+    const auto sortToken     = beginSortRequest();
 
-    auto handleSortedTracks = [hostPtr = &host, currentPlaylist](const PlaylistTrackList& sortedTracks) {
-        auto* sortCmd = new ResetTracks(hostPtr->playerController(), hostPtr->playlistModel(), currentPlaylist->id(),
-                                        currentPlaylist->playlistTracks(), sortedTracks);
+    auto handleSortedTracks = [hostPtr = &host, this, playlistId, currentTracks, trackCount = currentTracks.size(),
+                               sortToken](const PlaylistTrackList& sortedTracks) {
+        auto* activePlaylist = hostPtr->playlistController()->currentPlaylist();
+        if(sortToken != m_sortRequestToken || !activePlaylist || activePlaylist->id() != playlistId
+           || std::cmp_not_equal(activePlaylist->trackCount(), trackCount)) {
+            finishSortRequest(sortToken, false);
+            return;
+        }
+
+        auto* sortCmd = new ResetTracks(hostPtr->playerController(), hostPtr->playlistModel(), playlistId,
+                                        currentTracks, sortedTracks);
         hostPtr->playlistController()->addToHistory(sortCmd);
     };
 
@@ -973,7 +1101,7 @@ void EditablePlaylistSession::sortColumn(PlaylistWidgetSessionHost& sessionHost,
 {
     auto* widget = sessionHost.sessionWidget();
     auto& host   = editableHost(widget);
-    if(!host.playlistController()->currentPlaylist() || column < 0
+    if(!canReorderPlaylist(host.playlistController()->currentPlaylist()) || column < 0
        || std::cmp_greater_equal(column, host.layoutState().columns.size())) {
         return;
     }
@@ -983,17 +1111,28 @@ void EditablePlaylistSession::sortColumn(PlaylistWidgetSessionHost& sessionHost,
 
     auto* currentPlaylist    = host.playlistController()->currentPlaylist();
     const auto currentTracks = currentPlaylist->playlistTracks();
+    const auto playlistId    = currentPlaylist->id();
     const QString sortField  = host.layoutState().columns.at(column).field;
+    const auto sortToken     = beginSortRequest();
 
     Utils::asyncExec([libraryManager = host.libraryManager(), sortField, currentTracks, order]() {
         TrackSorter sorter{libraryManager};
         auto tracks = sorter.calcSortTracks(sortField, currentTracks, PlaylistTrack::extractor, order);
         return PlaylistTrack::updateIndexes(tracks);
-    }).then(widget, [hostPtr = &host, currentPlaylist, currentTracks](const PlaylistTrackList& sortedTracks) {
-        auto* sortCmd = new ResetTracks(hostPtr->playerController(), hostPtr->playlistModel(), currentPlaylist->id(),
-                                        currentTracks, sortedTracks);
-        hostPtr->playlistController()->addToHistory(sortCmd);
-    });
+    })
+        .then(widget, [hostPtr = &host, this, playlistId, currentTracks, trackCount = currentTracks.size(),
+                       sortToken](const PlaylistTrackList& sortedTracks) {
+            auto* activePlaylist = hostPtr->playlistController()->currentPlaylist();
+            if(sortToken != m_sortRequestToken || !activePlaylist || activePlaylist->id() != playlistId
+               || std::cmp_not_equal(activePlaylist->trackCount(), trackCount)) {
+                finishSortRequest(sortToken, true);
+                return;
+            }
+
+            auto* sortCmd = new ResetTracks(hostPtr->playerController(), hostPtr->playlistModel(), playlistId,
+                                            currentTracks, sortedTracks);
+            hostPtr->playlistController()->addToHistory(sortCmd);
+        });
 }
 
 QAction* EditablePlaylistSession::cropAction() const

--- a/src/gui/playlist/editableplaylistsession.h
+++ b/src/gui/playlist/editableplaylistsession.h
@@ -21,6 +21,8 @@
 
 #include "playlistwidgetsession.h"
 
+#include <core/playlist/playlistchangeset.h>
+
 class QWidget;
 
 namespace Fooyin {
@@ -89,6 +91,11 @@ public:
     [[nodiscard]] QAction* removeFromQueueAction() const override;
 
 private:
+    [[nodiscard]] uint64_t beginSortRequest();
+    void finishSortRequest(uint64_t token, bool sortingColumn);
+
+    void applyPlaylistChangeSet(PlaylistWidgetSessionHost& host, const PlaylistChangeset& changeSet);
+    void refreshActionState(PlaylistWidget* widget);
     void handleTrackIndexesChanged(PlaylistWidget* widget, int playingIndex);
     void stopAfterTrack(PlaylistWidget* widget) const;
     void handlePlayingTrackChanged(PlaylistWidget* widget, const PlaylistTrack& track) const;
@@ -100,6 +107,7 @@ private:
     bool m_pendingFocus;
     int m_dropIndex;
     int m_currentIndex;
+    uint64_t m_sortRequestToken;
 
     QAction* m_undoAction;
     QAction* m_redoAction;
@@ -110,6 +118,8 @@ private:
     QAction* m_pasteAction;
     QAction* m_clearAction;
     QAction* m_removeTrackAction;
+    QAction* m_removeDuplicatesAction;
+    QAction* m_removeDeadTracksAction;
     QAction* m_addToQueueAction;
     QAction* m_queueNextAction;
     QAction* m_removeFromQueueAction;

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -393,12 +393,14 @@ void PlaylistOrganiser::createPlaylist(const QModelIndex& index, bool autoPlayli
         auto* autoDialog = new AutoPlaylistDialog(Utils::getMainWindow());
         autoDialog->setAttribute(Qt::WA_DeleteOnClose);
         QObject::connect(autoDialog, &QDialog::finished, this, [this]() { m_creatingPlaylist = false; });
-        QObject::connect(autoDialog, &AutoPlaylistDialog::playlistEdited, this,
-                         [this, addToModel](const QString& name, const QString& query) {
-                             if(auto* playlist = m_playlistInteractor->handler()->createNewAutoPlaylist(name, query)) {
-                                 addToModel(playlist);
-                             }
-                         });
+        QObject::connect(
+            autoDialog, &AutoPlaylistDialog::playlistEdited, this,
+            [this, addToModel](const QString& name, const QString& query, const QString& sortQuery, bool forceSorted) {
+                if(auto* playlist
+                   = m_playlistInteractor->handler()->createNewAutoPlaylist(name, query, sortQuery, forceSorted)) {
+                    addToModel(playlist);
+                }
+            });
         autoDialog->show();
         return;
     }

--- a/src/gui/playlist/playlistcontroller.cpp
+++ b/src/gui/playlist/playlistcontroller.cpp
@@ -51,6 +51,10 @@ PlaylistController::PlaylistController(Application* app, TrackSelectionControlle
 
     QObject::connect(m_handler, &PlaylistHandler::playlistsPopulated, this, &PlaylistController::restoreLastPlaylist);
     QObject::connect(m_handler, &PlaylistHandler::playlistAdded, this, &PlaylistController::handlePlaylistAdded);
+    QObject::connect(m_handler, &PlaylistHandler::playlistUpdated, this,
+                     &PlaylistController::handlePlaylistMetadataUpdated);
+    QObject::connect(m_handler, &PlaylistHandler::tracksPatched, this,
+                     &PlaylistController::handlePlaylistTracksPatched);
     QObject::connect(m_handler, &PlaylistHandler::tracksChanged, this, &PlaylistController::handlePlaylistUpdated);
     QObject::connect(m_handler, &PlaylistHandler::tracksUpdated, this, &PlaylistController::handleTracksUpdated);
     QObject::connect(m_handler, &PlaylistHandler::tracksAdded, this, &PlaylistController::handlePlaylistTracksAdded);
@@ -305,11 +309,40 @@ void PlaylistController::handlePlaylistAdded(Playlist* playlist)
     }
 }
 
+void PlaylistController::handlePlaylistMetadataUpdated(Playlist* playlist)
+{
+    if(m_workspace->isCurrentPlaylist(playlist)) {
+        emit currentPlaylistUpdated(playlist);
+    }
+}
+
 void PlaylistController::handlePlaylistTracksAdded(Playlist* playlist, const TrackList& tracks, int index)
 {
     if(m_workspace->isCurrentPlaylist(playlist)) {
         emit currentPlaylistTracksAdded(tracks, index);
     }
+}
+
+void PlaylistController::handlePlaylistTracksPatched(Playlist* playlist, const PlaylistChangeset& changeSet)
+{
+    if(m_changingTracks || !m_workspace->isCurrentPlaylist(playlist)) {
+        return;
+    }
+
+    const bool affectsQueueIndexes
+        = !changeSet.removedIndexes.empty() || !changeSet.insertions.empty() || !changeSet.moves.empty();
+    if(affectsQueueIndexes) {
+        auto queueTracks = m_playerController->playbackQueue().tracks();
+        for(auto& track : queueTracks) {
+            if(track.playlistId == playlist->id()) {
+                track.playlistId      = {};
+                track.indexInPlaylist = -1;
+            }
+        }
+        m_playerController->replaceTracks(queueTracks);
+    }
+
+    emit currentPlaylistTracksPatched(changeSet);
 }
 
 void PlaylistController::handleTracksQueued(const QueueTracks& tracks)
@@ -450,7 +483,7 @@ void PlaylistController::handleTracksUpdated(Playlist* playlist, const std::vect
     }
 
     if(m_workspace->isCurrentPlaylist(playlist)) {
-        emit currentPlaylistTracksPlayed(indexes);
+        emit currentPlaylistTracksUpdated(indexes);
     }
 }
 

--- a/src/gui/playlist/playlistcontroller.h
+++ b/src/gui/playlist/playlistcontroller.h
@@ -23,6 +23,7 @@
 
 #include <core/player/playbackqueue.h>
 #include <core/playlist/playlist.h>
+#include <core/playlist/playlistchangeset.h>
 
 #include <QObject>
 
@@ -105,8 +106,10 @@ public:
 signals:
     void playlistsLoaded();
     void currentPlaylistChanged(Fooyin::Playlist* prevPlaylist, Fooyin::Playlist* playlist);
+    void currentPlaylistUpdated(Fooyin::Playlist* playlist);
+    void currentPlaylistTracksPatched(const Fooyin::PlaylistChangeset& changeSet);
     void currentPlaylistTracksChanged(const std::vector<int>& indexes, bool allNew);
-    void currentPlaylistTracksPlayed(const std::vector<int>& indexes);
+    void currentPlaylistTracksUpdated(const std::vector<int>& indexes);
     void currentPlaylistTracksAdded(const Fooyin::TrackList& tracks, int index);
     void currentPlaylistTracksRemoved(const std::vector<int>& indexes);
     void currentPlaylistQueueChanged(const std::vector<int>& tracks);
@@ -123,7 +126,9 @@ private:
     void restoreLastPlaylist();
 
     void handlePlaylistAdded(Playlist* playlist);
+    void handlePlaylistMetadataUpdated(Playlist* playlist);
     void handlePlaylistTracksAdded(Playlist* playlist, const TrackList& tracks, int index);
+    void handlePlaylistTracksPatched(Playlist* playlist, const PlaylistChangeset& changeSet);
 
     void handleTracksQueued(const QueueTracks& tracks);
     void handleTracksDequeued(const QueueTracks& tracks);

--- a/src/gui/playlist/playlistpopulator.cpp
+++ b/src/gui/playlist/playlistpopulator.cpp
@@ -607,7 +607,9 @@ void PlaylistPopulator::run(Playlist* playlist, const PlaylistPreset& preset, co
     const int preloadCount = p->m_preloadCount > 0 ? p->m_preloadCount : static_cast<int>(tracks.size());
     p->runBatch(preloadCount, 0);
 
-    emit finished();
+    if(mayRun()) {
+        emit finished();
+    }
 
     setState(Idle);
 }

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -297,8 +297,9 @@ void PlaylistTabs::contextMenuEvent(QContextMenuEvent* event)
         auto* autoDialog = new AutoPlaylistDialog(Utils::getMainWindow());
         autoDialog->setAttribute(Qt::WA_DeleteOnClose);
         QObject::connect(autoDialog, &AutoPlaylistDialog::playlistEdited, autoDialog,
-                         [this](const QString& name, const QString& query) {
-                             if(auto* playlist = m_playlistHandler->createNewAutoPlaylist(name, query)) {
+                         [this](const QString& name, const QString& query, const QString& sortQuery, bool forceSorted) {
+                             if(auto* playlist
+                                = m_playlistHandler->createNewAutoPlaylist(name, query, sortQuery, forceSorted)) {
                                  m_playlistController->changeCurrentPlaylist(playlist);
                              }
                          });

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -474,8 +474,12 @@ void PlaylistWidget::populateTrackContextMenu(QMenu* menu, const QModelIndexList
             if(auto* cropAction = m_session->cropAction()) {
                 menu->addAction(cropAction);
             }
+        }
 
-            addSortMenu(menu, state.disableSortMenu);
+        if(state.showEditablePlaylistActions || state.showSortMenu) {
+            if(state.showSortMenu) {
+                addSortMenu(menu, state.disableSortMenu);
+            }
             menu->addSeparator();
         }
     }
@@ -532,23 +536,19 @@ void PlaylistWidget::setupConnections()
     // clang-format off
     QObject::connect(m_header, &QHeaderView::sectionCountChanged, m_playlistView, &PlaylistView::setupRatingDelegate);
     QObject::connect(m_header, &QHeaderView::sectionResized, this, [this](int column, int /*oldSize*/, int newSize) { m_model->setPixmapColumnSize(column, newSize); });
-    QObject::connect(m_header, &QHeaderView::sortIndicatorChanged, this,
-                     [this](int column, Qt::SortOrder order) { m_session->sortColumn(sessionHost(), column, order); });
-    QObject::connect(m_header, &QHeaderView::customContextMenuRequested, this,
-                     [this](const QPoint& pos) { showHeaderMenu(pos); });
-    QObject::connect(m_playlistView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
-                     [this]() { m_session->selectionChanged(sessionHost()); });
-    QObject::connect(m_playlistView, &PlaylistView::tracksRated, m_library, [this](const TrackList& tracks) { m_library->updateTrackStats(tracks); });
+    QObject::connect(m_header, &QHeaderView::sortIndicatorChanged, this, [this](int column, Qt::SortOrder order) { m_session->sortColumn(sessionHost(), column, order); });
+    QObject::connect(m_header, &QHeaderView::customContextMenuRequested, this, &PlaylistWidget::showHeaderMenu);
+    QObject::connect(m_playlistView->selectionModel(), &QItemSelectionModel::selectionChanged, this, [this]() { m_session->selectionChanged(sessionHost()); });
+    QObject::connect(m_playlistView, &PlaylistView::tracksRated, m_library, qOverload<const TrackList&>(&MusicLibrary::updateTrackStats));
     QObject::connect(m_playlistView, &QAbstractItemView::doubleClicked, this, &PlaylistWidget::doubleClicked);
-    QObject::connect(m_model, &QAbstractItemModel::modelAboutToBeReset, this,
-                     [this]() { m_session->handleAboutToBeReset(sessionHost()); });
+    QObject::connect(m_model, &QAbstractItemModel::modelAboutToBeReset, this, [this]() { m_session->handleAboutToBeReset(sessionHost()); });
     QObject::connect(m_model, &PlaylistModel::playlistLoaded, m_playlistView->viewport(), qOverload<>(&QWidget::update));
-    QObject::connect(m_playlistController, &PlaylistController::currentPlaylistTracksPlayed, m_model,[this](const std::vector<int>& indexes){m_model->refreshTracks(indexes);});
+    QObject::connect(m_playlistController, &PlaylistController::currentPlaylistTracksUpdated, m_model,
+                     [this](const std::vector<int>& indexes) { m_model->refreshTracks(indexes); });
+    QObject::connect(m_playlistController, &PlaylistController::currentPlaylistUpdated, this, &PlaylistWidget::resetModelThrottled);
 
-    QObject::connect(m_columnRegistry, &PlaylistColumnRegistry::itemRemoved, this,
-                     [this](int id) { handleColumnRemoved(id); });
-    QObject::connect(m_columnRegistry, &PlaylistColumnRegistry::columnChanged, this,
-                     [this](const PlaylistColumn& column) { handleColumnChanged(column); });
+    QObject::connect(m_columnRegistry, &PlaylistColumnRegistry::itemRemoved, this, &PlaylistWidget::handleColumnRemoved);
+    QObject::connect(m_columnRegistry, &PlaylistColumnRegistry::columnChanged, this, &PlaylistWidget::handleColumnChanged);
 
     QObject::connect(m_resetThrottler, &SignalThrottler::triggered, this, &PlaylistWidget::resetModel);
     // clang-format on
@@ -593,10 +593,11 @@ void PlaylistWidget::resetModel()
 
     Playlist* currentPlaylist = m_playlistController->currentPlaylist();
 
-    const bool isAutoPlaylist = m_playlistController->currentIsAuto();
-    const bool readOnly       = (m_session->hasSearch() || isAutoPlaylist);
+    const bool forceSortedAutoPlaylist
+        = currentPlaylist && currentPlaylist->isAutoPlaylist() && currentPlaylist->forceSorted();
+    const bool readOnly = m_session->hasSearch() || forceSortedAutoPlaylist;
 
-    setReadOnly(readOnly, !isAutoPlaylist);
+    setReadOnly(readOnly, currentPlaylist && (!currentPlaylist->isAutoPlaylist() || !currentPlaylist->forceSorted()));
 
     if(m_session->canResetWithoutPlaylist() || currentPlaylist) {
         m_model->reset(layoutState().currentPreset,

--- a/src/gui/playlist/playlistwidget.h
+++ b/src/gui/playlist/playlistwidget.h
@@ -83,6 +83,7 @@ public:
         bool hasSelection{false};
         bool showStopAfter{false};
         bool showEditablePlaylistActions{false};
+        bool showSortMenu{false};
         bool showClipboard{false};
         bool usePlaylistQueueCommands{false};
         bool disableSortMenu{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ fooyin_add_test(test_playlistnavigator core/playback/playlistnavigatortest.cpp)
 
 fooyin_add_test(test_cueparser core/playlist/cueparsertest.cpp data/playlists.qrc)
 fooyin_add_test(test_m3uparser core/playlist/m3uparsertest.cpp data/playlists.qrc)
+fooyin_add_test(test_playlistchangeset core/playlist/playlistchangesettest.cpp)
 
 fooyin_add_test(test_scriptformatter core/scripting/scriptformattertest.cpp)
 fooyin_add_test(test_scriptparser core/scripting/scriptparsertest.cpp)

--- a/tests/core/playlist/playlistchangesettest.cpp
+++ b/tests/core/playlist/playlistchangesettest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/playlist/playlistchangeset.h>
+#include <core/track.h>
+
+#include <gtest/gtest.h>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Testing {
+namespace {
+Track makeTrack(const QString& path, uint64_t durationMs = 1000, const QString& hash = u"default"_s)
+{
+    Track track{path};
+    track.setDuration(durationMs);
+    track.setHash(hash);
+    return track;
+}
+} // namespace
+
+TEST(PlaylistChangesetTest, BuildsInsertionPatchForAppendedTracks)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s),
+                              makeTrack(u"/music/c.flac"_s), makeTrack(u"/music/d.flac"_s)};
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks);
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_FALSE(changeSet->requiresReset);
+    EXPECT_TRUE(changeSet->removedIndexes.empty());
+    ASSERT_EQ(changeSet->insertions.size(), 1U);
+    EXPECT_EQ(changeSet->insertions.front().index, 2);
+    ASSERT_EQ(changeSet->insertions.front().tracks.size(), 2U);
+    EXPECT_EQ(changeSet->insertions.front().tracks.front().uniqueFilepath(), u"/music/c.flac"_s);
+    EXPECT_TRUE(changeSet->moves.empty());
+    EXPECT_TRUE(changeSet->updatedIndexes.empty());
+}
+
+TEST(PlaylistChangesetTest, BuildsRemovalPatch)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s),
+                              makeTrack(u"/music/c.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/c.flac"_s)};
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks);
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_FALSE(changeSet->requiresReset);
+    ASSERT_EQ(changeSet->removedIndexes.size(), 1U);
+    EXPECT_EQ(changeSet->removedIndexes.front(), 1);
+    EXPECT_TRUE(changeSet->insertions.empty());
+    EXPECT_TRUE(changeSet->moves.empty());
+}
+
+TEST(PlaylistChangesetTest, BuildsMovePatchForReorderedTracks)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s),
+                              makeTrack(u"/music/c.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/c.flac"_s), makeTrack(u"/music/a.flac"_s),
+                              makeTrack(u"/music/b.flac"_s)};
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks);
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_FALSE(changeSet->requiresReset);
+    EXPECT_TRUE(changeSet->removedIndexes.empty());
+    EXPECT_TRUE(changeSet->insertions.empty());
+    ASSERT_EQ(changeSet->moves.size(), 1U);
+    EXPECT_EQ(changeSet->moves.front().sourceIndex, 2);
+    EXPECT_EQ(changeSet->moves.front().targetIndex, 0);
+}
+
+TEST(PlaylistChangesetTest, BuildsUpdatedIndexesForChangedTrackMetadata)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s, 1000, u"old"_s), makeTrack(u"/music/b.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/a.flac"_s, 1000, u"new"_s), makeTrack(u"/music/b.flac"_s)};
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks);
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_FALSE(changeSet->requiresReset);
+    ASSERT_EQ(changeSet->updatedIndexes.size(), 1U);
+    EXPECT_EQ(changeSet->updatedIndexes.front(), 0);
+}
+
+TEST(PlaylistChangesetTest, BuildsUpdatedIndexesForExplicitlyUpdatedPaths)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s)};
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks, TrackKeySet{u"/music/b.flac"_s});
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_FALSE(changeSet->requiresReset);
+    ASSERT_EQ(changeSet->updatedIndexes.size(), 1U);
+    EXPECT_EQ(changeSet->updatedIndexes.front(), 1);
+}
+
+TEST(PlaylistChangesetTest, FallsBackWhenTrackPathsAreDuplicated)
+{
+    const TrackList oldTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/a.flac"_s)};
+    const TrackList newTracks{makeTrack(u"/music/a.flac"_s), makeTrack(u"/music/b.flac"_s)};
+
+    EXPECT_FALSE(buildPlaylistChangeset(oldTracks, newTracks).has_value());
+}
+
+TEST(PlaylistChangesetTest, MarksLargeChangesetForReset)
+{
+    TrackList oldTracks;
+    TrackList newTracks;
+
+    oldTracks.reserve(600);
+    newTracks.reserve(600);
+
+    for(int i{0}; i < 600; ++i) {
+        oldTracks.push_back(makeTrack(u"/music/old_%1.flac"_s.arg(i)));
+        newTracks.push_back(makeTrack(u"/music/new_%1.flac"_s.arg(i)));
+    }
+
+    const auto changeSet = buildPlaylistChangeset(oldTracks, newTracks);
+    ASSERT_TRUE(changeSet.has_value());
+    EXPECT_TRUE(changeSet->requiresReset);
+}
+} // namespace Fooyin::Testing


### PR DESCRIPTION
This reworks autoplaylists so they no longer behave like fully regenerated, always resetting playlists.

  What changed:
  - Add separate autoplaylist sort pattern and force-sort options.
  - Persist the new autoplaylist fields in the database.

  Behavior changes:
  - `force-sorted` = true
      - autoplaylist order is fully derived from the query + sort pattern
      - regeneration can reorder the entire playlist
      - manual/column sorting remains disabled
  - `force-sorted` = false
      - existing order is preserved
      - tracks that no longer match are removed
      - newly matched tracks are appended at the end
      - if a sort pattern is present, it is only used to order the newly added batch
      - manual/column sorting is allowed

  Performance improvements:
  - Autoplaylists now use an incremental diff patch instead of always forcing a full reset.
  - Fall back to full reset only for large or ambiguous diffs.