### PR TITLE
[gui] ElidedLabel: Use QFontMetrics::size() instead of boundingRect()

### DIFF
--- a/src/gui/widgets/elidedlabel.cpp
+++ b/src/gui/widgets/elidedlabel.cpp
@@ -94,7 +94,7 @@ PreparedTextLine prepareRichTextLine(const RichText& richText, const QFont& base
         prepared.text   = text;
         prepared.font   = font;
         prepared.colour = block.format.colour.isValid() ? block.format.colour : baseColour;
-        prepared.width  = fm.boundingRect(text).width();
+        prepared.width  = fm.size(Qt::TextSingleLine, text).width();
         prepared.height = fm.height();
 
         line.totalWidth += prepared.width;
@@ -133,7 +133,7 @@ QSize richTextNaturalSize(const RichText& richText, const QFont& baseFont)
         const QFont font = resolvedBlockFont(baseFont, block.format);
         const QFontMetrics fm{font};
 
-        width += fm.boundingRect(text).width();
+        width += fm.size(Qt::TextSingleLine, text).width();
         height = std::max(height, fm.height());
     }
 


### PR DESCRIPTION
`boundingRect()` does not account for spaces, so having a bunch of them in the status bar will make the size hint too conservative and cause text elision to happen early. Also reproducible with certain font and text combinations, for example here is Droid Sans with %playtime%:

<img width="634" height="184" alt="image" src="https://github.com/user-attachments/assets/e6009b3d-6c93-4504-884f-869d23955e34" />
