### PR TITLE
[gui] ExpandedTreeView: Fix artifacts in horizontal scrolling

### DIFF
--- a/src/gui/widgets/expandedtreeview.cpp
+++ b/src/gui/widgets/expandedtreeview.cpp
@@ -3783,8 +3783,7 @@ void ExpandedTreeView::scrollContentsBy(int dx, int dy)
     }
 
     p->m_scrollDelayOffset = {-dx, -dy};
-    scrollDirtyRegion(dx, dy);
-    viewport()->scroll(dx, dy);
+    viewport()->update();
     p->m_scrollDelayOffset = {0, 0};
 }
 


### PR DESCRIPTION
Update the viewport instead of just scrolling it.

Fixes this fun rendering bug:

[Screencast From 2026-03-20 18-45-47.webm](https://github.com/user-attachments/assets/719b32ce-ee8c-4e84-9804-c8a9ea3966d9)

The header text now stays at a constant position; we could move it along with the entries but keeping it in view looks better to me.