### PR TITLE
[gui] Selection Info: Improve view resizing

### DIFF
--- a/src/gui/selectioninfo/infoview.cpp
+++ b/src/gui/selectioninfo/infoview.cpp
@@ -40,19 +40,21 @@ InfoView::InfoView(QWidget* parent)
 
 void InfoView::resizeView()
 {
-    const int lastColumn = model()->columnCount() - 1;
+    const int lastColumn    = model()->columnCount() - 1;
+    const int viewportWidth = viewport()->width();
 
     if(!m_elideText) {
-        const int geometryWidth = geometry().width();
-
         header()->setSectionResizeMode(lastColumn, QHeaderView::Fixed);
-        header()->resizeSection(lastColumn, static_cast<int>(static_cast<double>(geometryWidth) * 1.25));
+        header()->resizeSection(lastColumn, static_cast<int>(static_cast<double>(viewportWidth) * 1.25));
         header()->setStretchLastSection(false);
     }
     else {
-        header()->setSectionResizeMode(lastColumn, QHeaderView::Stretch);
-        header()->adjustSize();
-        header()->setStretchLastSection(true);
+        int columnsWidth = 0;
+        for(int i = 0; i < lastColumn; ++i) {
+            columnsWidth += sizeHintForColumn(i);
+        }
+        header()->setSectionResizeMode(lastColumn, QHeaderView::Fixed);
+        header()->resizeSection(lastColumn, std::max(0, viewportWidth - columnsWidth));
     }
 }
 


### PR DESCRIPTION
`InfoView::resizeView()` always uses `header()` to change the layout. When "Show header" is disabled, the column length won't change because the header is hidden and `adjustSize()` won't do anything (this is relevant when toggling the horizontal scrollbar). My fix is to calculate the column length and resize manually. Also use viewport width instead of geometry width so there isn't a small leftover margin that keeps the view horizontally scrollable.