### PR TITLE
[gui] StatusWidget: Update playing text on pause

### DIFF
--- a/src/gui/widgets/statuswidget.cpp
+++ b/src/gui/widgets/statuswidget.cpp
@@ -345,9 +345,8 @@ void StatusWidgetPrivate::stateChanged(const Player::PlayState state)
             clearMessage();
             break;
         case(Player::PlayState::Playing):
-            updatePlayingText();
-            break;
         case(Player::PlayState::Paused):
+            updatePlayingText();
             break;
     }
 }


### PR DESCRIPTION
Somewhat counterintuitively, we also want to update the playing text on pause because the user may use a playback state dependent variable in the status script -- for example `%ispaused%`, which is how I noticed this.