### PR TITLE
[rgscanner] FFmpeg backend: Fix double free and clean up code

### DIFF
--- a/src/plugins/rgscanner/ffmpegscanner.cpp
+++ b/src/plugins/rgscanner/ffmpegscanner.cpp
@@ -166,7 +166,7 @@ ReplayGainFilter initialiseRGFilter(const Fooyin::AudioFormat& format, bool isPl
 
     AVFilterInOut* inputs   = nullptr;
     const auto filterParams = QString{u"ebur128=peak=%1,anullsink"_s}.arg(truePeak ? "true"_L1 : "sample"_L1);
-    rc = avfilter_graph_parse_ptr(filterGraph, filterParams.toUtf8().constData(), &inputs, &outputs, nullptr);
+    rc = avfilter_graph_parse(filterGraph, filterParams.toUtf8().constData(), inputs, outputs, nullptr);
     if(rc < 0) {
         Fooyin::Utils::printError(rc);
         return {};


### PR DESCRIPTION
Running fooyin in Valgrind, I was getting errors originating from `~FFmpegContext()` after running an RG scan with the FFmpeg backend. The reason is that `avfilter_graph_free()` [already takes care](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/avfiltergraph.c#L128) of freeing the `AVFilterContext`s associated with it, so we end up double freeing them after `ReplayGainFilter::filterGraph` gets destroyed.

[Similarly](https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/graphparser.c#L220-L223), we don't need to call `avfilter_inout_free()`. So remove the unused smart pointer deleters and add myself to the copyright header since I originally authored this file.