### PR TITLE
Implement mouse forward and back buttons

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <gui/guisettings.h>
 #include <gui/iconloader.h>
 #include <utils/actions/actionmanager.h>
+#include <utils/actions/command.h>
 #include <utils/enum.h>
 #include <utils/settings/settingsdialogcontroller.h>
 #include <utils/settings/settingsmanager.h>
@@ -52,6 +53,7 @@ namespace Fooyin {
 MainWindow::MainWindow(ActionManager* actionManager, MainMenuBar* menubar, MusicLibrary* library,
                        SettingsManager* settings, QWidget* parent)
     : QMainWindow{parent}
+    , m_actionManager{actionManager}
     , m_mainMenu{menubar}
     , m_library{library}
     , m_settings{settings}
@@ -266,6 +268,21 @@ void MainWindow::showScanProgress(const ScanProgress& progress)
 
     m_statusWidget->setScanProgress(scanText,
                                     [library = m_library, scanId = progress.id]() { library->cancelScan(scanId); });
+}
+
+void MainWindow::mousePressEvent(QMouseEvent* event)
+{
+    if(event->button() == Qt::BackButton) {
+        if(auto* prevCmd = m_actionManager->command(Constants::Actions::Previous)) {
+            prevCmd->action()->activate(QAction::Trigger);
+        }
+    }
+    if(event->button() == Qt::ForwardButton) {
+        if(auto* nextCmd = m_actionManager->command(Constants::Actions::Next)) {
+            nextCmd->action()->activate(QAction::Trigger);
+        }
+    }
+    QMainWindow::mousePressEvent(event);
 }
 
 MainWindow::WindowState MainWindow::currentState()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -73,6 +73,7 @@ protected:
     bool event(QEvent* event) override;
     void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
 private:
     void showScanProgress(const ScanProgress& progress);
@@ -82,6 +83,7 @@ private:
     void restoreState(WindowState state);
     void hideToTray(bool hide);
 
+    ActionManager* m_actionManager;
     MainMenuBar* m_mainMenu;
     MusicLibrary* m_library;
     SettingsManager* m_settings;

--- a/src/plugins/lyrics/lyricsview.cpp
+++ b/src/plugins/lyrics/lyricsview.cpp
@@ -116,6 +116,7 @@ void LyricsView::mousePressEvent(QMouseEvent* event)
     QListView::mousePressEvent(event);
 
     if(event->button() != Qt::LeftButton || !m_displayString.isEmpty()) {
+        event->ignore();
         return;
     }
 


### PR DESCRIPTION
Implement mouse forward and back buttons for controlling playback in main window.

`MainWindow` now has to store `ActionManager* m_actionManager` to access the `Previous` and `Next` commands.

`#include <utils/actions/command.h>` is necessary to dereference the `prevCmd`/`nextCmd` pointers with `->action()`, otherwise compiler complains that `pointer or reference to incomplete type "Fooyin::Command" is not allowed`.

Tested with all widgets; works on all of them except directory browser, where forward and back buttons navigate the directory browser instead (which is should be desirable). Had to add an `event->ignore()` I'd missed in `LyricsView` to make it work there, otherwise forward and back button wouldn't do anything in the lyrics widget.