### PR TITLE
[gui] Add external drag support for playlist tracks

### DIFF
--- a/include/gui/guiutils.h
+++ b/include/gui/guiutils.h
@@ -28,12 +28,15 @@
 #include <QByteArray>
 #include <QModelIndexList>
 
+class QMimeData;
+
 namespace Fooyin {
 class MusicLibrary;
 class SettingsManager;
 
 namespace Gui {
 FYGUI_EXPORT TrackList tracksFromMimeData(MusicLibrary* library, QByteArray data);
+FYGUI_EXPORT void populateExternalTrackMimeData(const TrackList& tracks, QMimeData* mimeData);
 FYGUI_EXPORT TrackList sortTracksForLibraryViewerPlaylist(SettingsManager* settings, const TrackList& tracks);
 FYGUI_EXPORT TrackIds sortTrackIdsForLibraryViewerPlaylist(MusicLibrary* library, SettingsManager* settings,
                                                            const TrackIds& ids);

--- a/src/gui/guiutils.cpp
+++ b/src/gui/guiutils.cpp
@@ -26,8 +26,13 @@
 #include <utils/settings/settingsmanager.h>
 
 #include <QApplication>
+#include <QDir>
+#include <QFileInfo>
 #include <QIODevice>
+#include <QMimeData>
+#include <QSet>
 #include <QStyle>
+#include <QUrl>
 
 namespace Fooyin::Gui {
 TrackList tracksFromMimeData(MusicLibrary* library, QByteArray data)
@@ -39,6 +44,44 @@ TrackList tracksFromMimeData(MusicLibrary* library, QByteArray data)
     TrackList tracks = library->tracksForIds(ids);
 
     return tracks;
+}
+
+void populateExternalTrackMimeData(const TrackList& tracks, QMimeData* mimeData)
+{
+    if(!mimeData) {
+        return;
+    }
+
+    QList<QUrl> urls;
+    QStringList paths;
+    QSet<QString> seenPaths;
+
+    for(const Track& track : tracks) {
+        if(!track.isValid() || track.isInArchive()) {
+            continue;
+        }
+
+        const QFileInfo fileInfo{track.filepath()};
+        if(!fileInfo.exists() || !fileInfo.isFile()) {
+            continue;
+        }
+
+        const QString path = QDir::cleanPath(fileInfo.absoluteFilePath());
+        if(path.isEmpty() || seenPaths.contains(path)) {
+            continue;
+        }
+
+        seenPaths.insert(path);
+        urls.push_back(QUrl::fromLocalFile(path));
+        paths.push_back(path);
+    }
+
+    if(urls.empty()) {
+        return;
+    }
+
+    mimeData->setUrls(urls);
+    mimeData->setText(paths.join(QStringLiteral("\n")));
 }
 
 TrackList sortTracksForLibraryViewerPlaylist(SettingsManager* settings, const TrackList& tracks)

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -504,18 +504,7 @@ bool PlaylistOrganiserModel::dropMimeData(const QMimeData* data, Qt::DropAction 
         return false;
     }
 
-    if(data->hasUrls()) {
-        if(auto* item = itemForIndex(parent)) {
-            if(item->type() == PlaylistOrganiserItem::PlaylistItem) {
-                emit filesDroppedOnPlaylist(data->urls(), item->playlist()->id());
-            }
-            else {
-                emit filesDroppedOnGroup(data->urls(), item->title(), row);
-            }
-            return true;
-        }
-    }
-    else if(data->hasFormat(QString::fromLatin1(Constants::Mime::TrackIds))) {
+    if(data->hasFormat(QString::fromLatin1(Constants::Mime::TrackIds))) {
         auto trackData = data->data(QString::fromLatin1(Constants::Mime::TrackIds));
         std::vector<int> ids;
         QDataStream stream(&trackData, QIODevice::ReadOnly);
@@ -527,6 +516,17 @@ bool PlaylistOrganiserModel::dropMimeData(const QMimeData* data, Qt::DropAction 
             }
             else {
                 emit tracksDroppedOnGroup(ids, item->title(), row);
+            }
+            return true;
+        }
+    }
+    else if(data->hasUrls()) {
+        if(auto* item = itemForIndex(parent)) {
+            if(item->type() == PlaylistOrganiserItem::PlaylistItem) {
+                emit filesDroppedOnPlaylist(data->urls(), item->playlist()->id());
+            }
+            else {
+                emit filesDroppedOnGroup(data->urls(), item->title(), row);
             }
             return true;
         }

--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -1782,11 +1782,6 @@ bool PlaylistModel::prepareDrop(const QMimeData* data, Qt::DropAction action, in
 {
     const int dropIndex = determineDropIndex(this, parent, row);
 
-    if(data->hasUrls()) {
-        emit filesDropped(data->urls(), dropIndex);
-        return true;
-    }
-
     bool sameModel{false};
 
     if(data->hasFormat(QString::fromLatin1(MimeModelId))) {
@@ -1827,22 +1822,28 @@ bool PlaylistModel::prepareDrop(const QMimeData* data, Qt::DropAction action, in
 
     const TrackList tracks
         = Gui::tracksFromMimeData(m_library, data->data(QString::fromLatin1(Constants::Mime::TrackIds)));
-    if(tracks.empty()) {
-        return false;
+    if(!tracks.empty()) {
+        PlaylistTrackList playlistTracks;
+        playlistTracks.reserve(tracks.size());
+
+        for(const auto& track : tracks) {
+            PlaylistTrack playlistTrack{.track      = track,
+                                        .playlistId = m_currentPlaylist ? m_currentPlaylist->id() : UId{}};
+            playlistTracks.push_back(playlistTrack);
+        }
+
+        const TrackGroups groups{{dropIndex, playlistTracks}};
+        emit tracksInserted(groups);
+
+        return true;
     }
 
-    PlaylistTrackList playlistTracks;
-    playlistTracks.reserve(tracks.size());
-
-    for(const auto& track : tracks) {
-        PlaylistTrack playlistTrack{.track = track, .playlistId = m_currentPlaylist ? m_currentPlaylist->id() : UId{}};
-        playlistTracks.push_back(playlistTrack);
+    if(data->hasUrls()) {
+        emit filesDropped(data->urls(), dropIndex);
+        return true;
     }
 
-    const TrackGroups groups{{dropIndex, playlistTracks}};
-    emit tracksInserted(groups);
-
-    return true;
+    return false;
 }
 
 PlaylistModel::DropTargetResult PlaylistModel::findDropTarget(PlaylistItem* source, PlaylistItem* target, int& row)
@@ -2119,6 +2120,14 @@ void PlaylistModel::storeMimeData(const QModelIndexList& indexes, QMimeData* mim
 
         QModelIndexList sortedIndexes{indexes};
         std::ranges::sort(sortedIndexes, Utils::sortModelIndexes);
+
+        TrackList tracks;
+        tracks.reserve(sortedIndexes.size());
+        for(const QModelIndex& index : sortedIndexes) {
+            tracks.push_back(index.data(PlaylistItem::Role::ItemData).value<PlaylistTrack>().track);
+        }
+
+        Gui::populateExternalTrackMimeData(tracks, mimeData);
         mimeData->setData(QString::fromLatin1(Constants::Mime::TrackIds), saveTracks(sortedIndexes));
         if(m_currentPlaylist) {
             mimeData->setData(QString::fromLatin1(Constants::Mime::PlaylistItems),

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -469,12 +469,12 @@ void PlaylistTabs::dropEvent(QDropEvent* event)
         }
     }
 
-    if(event->mimeData()->hasUrls()) {
-        emit filesDropped(event->mimeData()->urls(), id);
+    if(event->mimeData()->hasFormat(QString::fromLatin1(Constants::Mime::TrackIds))) {
+        emit tracksDropped(event->mimeData()->data(QString::fromLatin1(Constants::Mime::TrackIds)), id);
         event->acceptProposedAction();
     }
-    else if(event->mimeData()->hasFormat(QString::fromLatin1(Constants::Mime::TrackIds))) {
-        emit tracksDropped(event->mimeData()->data(QString::fromLatin1(Constants::Mime::TrackIds)), id);
+    else if(event->mimeData()->hasUrls()) {
+        emit filesDropped(event->mimeData()->urls(), id);
         event->acceptProposedAction();
     }
     else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,4 +51,5 @@ fooyin_add_test(test_track core/tracktest.cpp)
 fooyin_add_test(test_tagreader core/tagging/tagreadertest.cpp data/audio.qrc)
 fooyin_add_test(test_tagwriter core/tagging/tagwritertest.cpp data/audio.qrc)
 
+fooyin_add_test(test_guiutils gui/guiutilstest.cpp)
 fooyin_add_test(test_scriptformatter gui/scriptformattertest.cpp)

--- a/tests/gui/guiutilstest.cpp
+++ b/tests/gui/guiutilstest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gui/guiutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QFile>
+#include <QMimeData>
+#include <QTemporaryDir>
+#include <QUrl>
+
+namespace Fooyin::Testing {
+TEST(GuiUtilsTest, PopulateExternalTrackMimeDataIncludesUniqueExistingLocalFiles)
+{
+    const QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString firstPath  = tempDir.filePath(QStringLiteral("first.flac"));
+    const QString secondPath = tempDir.filePath(QStringLiteral("second.mp3"));
+
+    QFile firstFile{firstPath};
+    ASSERT_TRUE(firstFile.open(QIODevice::WriteOnly));
+    firstFile.close();
+
+    QFile secondFile{secondPath};
+    ASSERT_TRUE(secondFile.open(QIODevice::WriteOnly));
+    secondFile.close();
+
+    const TrackList tracks{
+        Track{firstPath},
+        Track{firstPath},
+        Track{tempDir.filePath(QStringLiteral("missing.ogg"))},
+        Track{secondPath},
+    };
+
+    QMimeData mimeData;
+    Gui::populateExternalTrackMimeData(tracks, &mimeData);
+
+    ASSERT_TRUE(mimeData.hasUrls());
+    const QList<QUrl> urls = mimeData.urls();
+    ASSERT_EQ(2, urls.size());
+    EXPECT_EQ(QUrl::fromLocalFile(firstPath), urls.at(0));
+    EXPECT_EQ(QUrl::fromLocalFile(secondPath), urls.at(1));
+    EXPECT_EQ(firstPath + QStringLiteral("\n") + secondPath, mimeData.text());
+}
+
+TEST(GuiUtilsTest, PopulateExternalTrackMimeDataSkipsInvalidSelections)
+{
+    QMimeData mimeData;
+    Gui::populateExternalTrackMimeData({Track{}, Track{QStringLiteral("/definitely/missing.flac")}}, &mimeData);
+
+    EXPECT_FALSE(mimeData.hasUrls());
+    EXPECT_FALSE(mimeData.hasText());
+}
+} // namespace Fooyin::Testing


### PR DESCRIPTION
# I don't know
When I used windows I relied on foobar2000 to manage my sfx collection.
Now on linux the best fucking alternative is fooyin and it doesn't have the function to drag the file link into another program. I already did a PR #788 but didn't like the quality of code and since it was my first pr I deleted it lmao.

## Summary
- expose dragged playlist tracks as external file URLs and plain-text paths
- keep internal fooyin drag and drop working by prioritizing fooyin MIME data before generic URLs
- add tests for external track MIME data generation

## What changed
This change makes playlist track drag-and-drop also expose real local file data for other apps.

Dragged tracks now include:
- `file://` URLs
- plain text local paths

So from user side it should behave much closer to dragging the same files from a file manager.

At the same time, internal fooyin drag and drop is still preserved. I had to make sure fooyin-specific MIME data is still preferred for internal drops, otherwise internal drag actions could be treated like external file drops just because URLs are now also present.

## Implementation notes
- add a helper to populate `QMimeData` with valid local file URLs and plain text paths
- skip invalid files, archive-backed tracks, and duplicates
- use that helper when building playlist drag MIME data
- keep internal playlist drops preferring fooyin MIME payloads first, and only use URLs as fallback
- add unit tests for valid files, duplicates, and invalid selections

## Validation
- configured with `cmake --preset debug -DBUILD_CCACHE=OFF`
- built with `cmake --build build-debug -j$(nproc)`
- passed `build-debug/run/bin/test_guiutils`
- `ctest --test-dir build-debug/tests --output-on-failure -j$(nproc)` still shows one unrelated existing failure:
  - `AudioLoaderTest.SavesAndRestoresStateAcrossInstances`