### PR TITLE
[core,wavebar] Implement support for multichapter-files

### DIFF
--- a/include/core/track.h
+++ b/include/core/track.h
@@ -72,6 +72,13 @@ public:
         Other
     };
 
+    enum class SegmentType : uint8_t
+    {
+        None = 0,
+        Cue,
+        Chapter
+    };
+
     using ExtraTags       = FlatStringMap<QStringList>;
     using ExtraProperties = FlatStringMap<QString>;
 
@@ -130,7 +137,7 @@ public:
     //! Returns a grouping key for album-oriented views; this is not persisted like the track identity hash.
     [[nodiscard]] QString albumHash() const;
     [[nodiscard]] QString filepath() const;
-    //! Returns filepath plus cue offset for cue tracks, so multiple cue entries in one file can be distinguished.
+    //! Returns filepath plus logical segment identity, so multiple entries in one file can be distinguished.
     [[nodiscard]] QString uniqueFilepath() const;
     //! Returns a display path; archive entries are shown as "archive/path/entry" instead of their unpack URL.
     [[nodiscard]] QString prettyFilepath() const;
@@ -219,6 +226,12 @@ public:
     [[nodiscard]] bool hasEmbeddedCue() const;
     //! External cue file path, or "Embedded" for tracks generated from an embedded CUESHEET tag.
     [[nodiscard]] QString cuePath() const;
+    //! Logical segment type for tracks that represent a bounded region of a continuous file.
+    [[nodiscard]] SegmentType segmentType() const;
+    //! True for CUE tracks and chapter tracks that are bounded by offset + duration.
+    [[nodiscard]] bool isBoundedSegment() const;
+    //! True for segments that can be played by continuing the same decoded stream.
+    [[nodiscard]] bool isSameStreamSegment() const;
 
     //! Archive paths use fooyin's unpack:// URL format.
     static bool isArchivePath(const QString& path);
@@ -332,6 +345,8 @@ public:
 
     //! Sets the cue source path; use "Embedded" for tracks generated from an embedded cue sheet.
     void setCuePath(const QString& path);
+    //! Marks this track as a chapter segment; cue segments are driven by setCuePath().
+    void setIsChapter(bool isChapter);
 
     //! Raw rating tag values are stored as internal extra properties so the configured rating tag can be round-tripped.
     [[nodiscard]] QString rawRatingTag(const QString& tag) const;

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -2005,13 +2005,13 @@ void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_
 
     const bool pendingBoundaryRenderedGaplessReached
         = m_autoAdvanceState.boundaryPendingUntilAudible && preparedGaplessActive && preparedGaplessReleaseReady;
-    const bool cueBoundaryMode        = isBoundedSegmentTrack(m_currentTrack);
+    const bool cueBoundaryMode = isBoundedSegmentTrack(m_currentTrack);
     const bool hasDistinctUpcomingCandidate
         = m_upcomingTrackCandidate.isValid() && !samePlaybackItem(upcomingTrackCandidateItem(), currentPlaybackItem());
     const bool boundedSegmentHandoffPending = cueBoundaryMode && hasDistinctUpcomingCandidate;
-    const bool audibleBoundaryReached = m_currentTrack.duration() == 0
-                                     || boundaryAudiblePosMs >= m_currentTrack.duration()
-                                     || pendingBoundaryRenderedGaplessReached;
+    const bool audibleBoundaryReached       = m_currentTrack.duration() == 0
+                                           || boundaryAudiblePosMs >= m_currentTrack.duration()
+                                           || pendingBoundaryRenderedGaplessReached;
 
     const bool deferBoundaryUntilAudible = preparedGaplessActive || boundedSegmentHandoffPending;
     const bool boundaryWasPending        = m_autoAdvanceState.boundaryPendingUntilAudible;

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -724,6 +724,8 @@ void AudioEngine::startSeekCrossfade(uint64_t positionMs, int fadeOutDurationMs,
         return;
     }
 
+    setStreamToTrackOriginForTrack(m_currentTrack);
+
     const int requestedPrefillMs = std::max(fadeInDurationMs, m_playbackBufferLengthMs / 4);
     const int prefillTargetMs    = adjustedCrossfadePrefillMs(requestedPrefillMs);
     prefillActiveStream(prefillTargetMs);
@@ -842,6 +844,7 @@ void AudioEngine::performSimpleSeek(uint64_t positionMs, uint64_t requestId, int
 
     m_decoder.seek(seekPosMs);
     m_decoder.syncStreamPosition();
+    setStreamToTrackOriginForTrack(m_currentTrack);
 
     if(!m_decoder.isDecoding()) {
         m_decoder.start();

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -62,7 +62,7 @@ Q_LOGGING_CATEGORY(ENGINE, "fy.engine")
 namespace {
 bool isBoundedSegmentTrack(const Fooyin::Track& track)
 {
-    return track.hasCue() || track.hasExtraProperty(QStringLiteral("CHAPTER"));
+    return track.isBoundedSegment();
 }
 
 constexpr auto BasePrefillDecodeFrames      = 4096;
@@ -2006,11 +2006,14 @@ void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_
     const bool pendingBoundaryRenderedGaplessReached
         = m_autoAdvanceState.boundaryPendingUntilAudible && preparedGaplessActive && preparedGaplessReleaseReady;
     const bool cueBoundaryMode        = isBoundedSegmentTrack(m_currentTrack);
+    const bool hasDistinctUpcomingCandidate
+        = m_upcomingTrackCandidate.isValid() && !samePlaybackItem(upcomingTrackCandidateItem(), currentPlaybackItem());
+    const bool boundedSegmentHandoffPending = cueBoundaryMode && hasDistinctUpcomingCandidate;
     const bool audibleBoundaryReached = m_currentTrack.duration() == 0
                                      || boundaryAudiblePosMs >= m_currentTrack.duration()
                                      || pendingBoundaryRenderedGaplessReached;
 
-    const bool deferBoundaryUntilAudible = preparedGaplessActive || cueBoundaryMode;
+    const bool deferBoundaryUntilAudible = preparedGaplessActive || boundedSegmentHandoffPending;
     const bool boundaryWasPending        = m_autoAdvanceState.boundaryPendingUntilAudible;
     if(result.boundaryReached && !audibleBoundaryReached && deferBoundaryUntilAudible) {
         m_autoAdvanceState.boundaryPendingUntilAudible = true;
@@ -2111,7 +2114,7 @@ void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_
         }
 
         const bool deferTrackEndStatusForPendingGaplessBoundary
-            = ((gaplessBoundaryMode && preparedGaplessActive) || cueBoundaryMode)
+            = ((gaplessBoundaryMode && preparedGaplessActive) || boundedSegmentHandoffPending)
            && (!m_autoAdvanceState.boundaryAnchorSeen || m_autoAdvanceState.boundaryPendingUntilAudible);
         if(deferTrackEndStatusForPendingGaplessBoundary) {
             qCDebug(ENGINE) << "Deferring track-end status until pending boundary resolves:"

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -60,6 +60,11 @@
 Q_LOGGING_CATEGORY(ENGINE, "fy.engine")
 
 namespace {
+bool isBoundedSegmentTrack(const Fooyin::Track& track)
+{
+    return track.hasCue() || track.hasExtraProperty(QStringLiteral("CHAPTER"));
+}
+
 constexpr auto BasePrefillDecodeFrames      = 4096;
 constexpr auto MaxPrefillDecodeFrames       = 262144;
 constexpr auto PrefillChunkDurationMs       = 10;
@@ -2000,7 +2005,7 @@ void AudioEngine::handleTrackEndingSignals(const AudioStreamPtr& stream, uint64_
 
     const bool pendingBoundaryRenderedGaplessReached
         = m_autoAdvanceState.boundaryPendingUntilAudible && preparedGaplessActive && preparedGaplessReleaseReady;
-    const bool cueBoundaryMode        = m_currentTrack.hasCue();
+    const bool cueBoundaryMode        = isBoundedSegmentTrack(m_currentTrack);
     const bool audibleBoundaryReached = m_currentTrack.duration() == 0
                                      || boundaryAudiblePosMs >= m_currentTrack.duration()
                                      || pendingBoundaryRenderedGaplessReached;
@@ -2200,7 +2205,7 @@ void AudioEngine::updatePosition()
         uint64_t boundaryAudiblePosMs  = output.relativePosMs;
         const bool hasMappedAudiblePos = pipelineStatus.positionIsMapped || output.hasRenderedSegment;
 
-        if(!hasMappedAudiblePos || m_currentTrack.hasCue()) {
+        if(!hasMappedAudiblePos || isBoundedSegmentTrack(m_currentTrack)) {
             uint64_t timelineDelayMs{pipelineDelayMs};
             if(timelineDelayMs > 0) {
                 timelineDelayMs = scaledDelayMs(timelineDelayMs, delayToSourceScale);
@@ -2208,8 +2213,9 @@ void AudioEngine::updatePosition()
 
             const uint64_t estimatedAudiblePosMs
                 = output.trackEndingPosMs > timelineDelayMs ? (output.trackEndingPosMs - timelineDelayMs) : 0;
-            boundaryAudiblePosMs = m_currentTrack.hasCue() ? estimatedAudiblePosMs
-                                                           : std::max(estimatedAudiblePosMs, boundaryAudiblePosMs);
+            boundaryAudiblePosMs = isBoundedSegmentTrack(m_currentTrack)
+                                     ? estimatedAudiblePosMs
+                                     : std::max(estimatedAudiblePosMs, boundaryAudiblePosMs);
         }
 
         handleTrackEndingSignals(stream, output.trackEndingPosMs, output.relativePosMs, boundaryAudiblePosMs,
@@ -2701,7 +2707,7 @@ AudioEngine::TrackEndingResult AudioEngine::checkTrackEnding(const AudioStreamPt
 
     input.positionMs                     = crossfadeUsesAudibleBoundary ? audiblePosMs : relativePosMs;
     input.durationMs                     = m_currentTrack.duration();
-    input.durationBoundaryEnabled        = m_currentTrack.hasCue();
+    input.durationBoundaryEnabled        = isBoundedSegmentTrack(m_currentTrack);
     input.predictiveTimelineHintsEnabled = shouldEnableTimelineTransitionHints(m_currentTrack, m_decoderPlaybackHints);
     input.timelineDelayMs                = crossfadeUsesAudibleBoundary ? 0 : timelineDelayMs;
     input.remainingOutputMs              = remainingOutputMs;
@@ -2914,9 +2920,15 @@ bool AudioEngine::setStreamToTrackOriginForSegmentSwitch(const Track& track, uin
         return true;
     }
 
-    qCWarning(ENGINE) << "Segment switch stream position exceeded target offset; aborting segment switch:"
-                      << "trackOffsetMs=" << track.offset() << "streamPosMs=" << streamPosMs;
-    return false;
+    // The decoder has already read past the next segment's start offset.
+    // This happens naturally for bounded-segment tracks (chapters / CUE) when
+    // the boundary signal is deferred until the audible position catches up.
+    // The existing stream-to-track origin mapping is still valid because we
+    // are on the same continuous stream, so keep it unchanged.
+    qCDebug(ENGINE) << "Segment switch: stream position already past target offset, keeping current origin:"
+                    << "trackOffsetMs=" << track.offset() << "streamPosMs=" << streamPosMs
+                    << "currentOriginMs=" << m_streamToTrackOriginMs;
+    return true;
 }
 
 bool AudioEngine::initDecoder(const Engine::PlaybackItem& item, bool allowPreparedStream)

--- a/src/core/engine/enginehelpers.cpp
+++ b/src/core/engine/enginehelpers.cpp
@@ -43,7 +43,7 @@ bool isContiguousSameFileSegment(const Track& currentTrack, const Track& nextTra
         return false;
     }
 
-    return nextTrack.filepath() == currentTrack.filepath() && nextTrack.subsong() == currentTrack.subsong()
+    return nextTrack.filepath() == currentTrack.filepath()
         && nextTrack.offset() == currentTrack.offset() + currentTrack.duration();
 }
 

--- a/src/core/engine/enginehelpers.cpp
+++ b/src/core/engine/enginehelpers.cpp
@@ -43,7 +43,8 @@ bool isContiguousSameFileSegment(const Track& currentTrack, const Track& nextTra
         return false;
     }
 
-    return nextTrack.filepath() == currentTrack.filepath()
+    return currentTrack.isSameStreamSegment() && nextTrack.isSameStreamSegment()
+        && currentTrack.segmentType() == nextTrack.segmentType() && nextTrack.filepath() == currentTrack.filepath()
         && nextTrack.offset() == currentTrack.offset() + currentTrack.duration();
 }
 

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -946,7 +946,8 @@ public:
             m_ioContext.reset();
         }
 
-        m_stream = {};
+        m_stream       = {};
+        m_chapterCount = 0;
     }
 
     bool setup(const AudioSource& source)
@@ -962,12 +963,21 @@ public:
         }
 
         m_stream = Utils::findAudioStream(m_context.get());
-        return m_stream.isValid();
+        if(!m_stream.isValid()) {
+            return false;
+        }
+
+        if(m_context->nb_chapters > 1) {
+            m_chapterCount = static_cast<int>(m_context->nb_chapters);
+        }
+
+        return true;
     }
 
     IOContextPtr m_ioContext;
     FormatContextPtr m_context;
     Stream m_stream;
+    int m_chapterCount{0};
 };
 
 FFmpegReader::FFmpegReader()
@@ -990,6 +1000,11 @@ bool FFmpegReader::canReadCover() const
 bool FFmpegReader::canWriteMetaData() const
 {
     return false;
+}
+
+int FFmpegReader::subsongCount() const
+{
+    return p->m_chapterCount > 1 ? p->m_chapterCount : 1;
 }
 
 bool FFmpegReader::init(const AudioSource& source)
@@ -1062,6 +1077,51 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
     AVDictionaryEntry* tag{nullptr};
     while((tag = av_dict_get(p->m_context->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
         parseTag(track, tag);
+    }
+
+    const int subsong = track.subsong();
+    if(p->m_chapterCount > 1 && subsong >= 0 && subsong < p->m_chapterCount) {
+        const AVChapter* chapter = p->m_context->chapters[subsong];
+
+        const uint64_t startMs = av_rescale_q(chapter->start, chapter->time_base, TimeBaseMs);
+        const uint64_t endMs   = av_rescale_q(chapter->end, chapter->time_base, TimeBaseMs);
+
+        // Container title becomes album (e.g. audiobook title)
+        if(!track.title().isEmpty()) {
+            track.setAlbum(track.title());
+        }
+
+        track.setOffset(startMs);
+        track.setDuration(endMs - startMs);
+
+        // Read chapter-level metadata
+        AVDictionaryEntry* chapterTag{nullptr};
+        QString chapterTitle;
+        QString chapterTrackNumber;
+
+        while((chapterTag = av_dict_get(chapter->metadata, "", chapterTag, AV_DICT_IGNORE_SUFFIX))) {
+            if(strcasecmp(chapterTag->key, "title") == 0) {
+                chapterTitle = convertString(chapterTag->value);
+            }
+            else if(strcasecmp(chapterTag->key, "track") == 0 || strcasecmp(chapterTag->key, "part_number") == 0) {
+                chapterTrackNumber = convertString(chapterTag->value);
+            }
+        }
+
+        if(!chapterTitle.isEmpty()) {
+            track.setTitle(chapterTitle);
+        }
+
+        if(!chapterTrackNumber.isEmpty()) {
+            track.setTrackNumber(chapterTrackNumber);
+        }
+        else {
+            track.setTrackNumber(QString::number(subsong + 1));
+        }
+
+        track.setTrackTotal(QString::number(p->m_chapterCount));
+
+        track.setExtraProperty(u"CHAPTER"_s, u"1"_s);
     }
 
     return true;

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -1098,6 +1098,8 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
         AVDictionaryEntry* chapterTag{nullptr};
         QString chapterTitle;
         QString chapterTrackNumber;
+        float chapterRGTrackGain{Fooyin::Constants::InvalidGain};
+        float chapterRGTrackPeak{Fooyin::Constants::InvalidPeak};
 
         while((chapterTag = av_dict_get(chapter->metadata, "", chapterTag, AV_DICT_IGNORE_SUFFIX))) {
             if(strcasecmp(chapterTag->key, "title") == 0) {
@@ -1105,6 +1107,12 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
             }
             else if(strcasecmp(chapterTag->key, "track") == 0 || strcasecmp(chapterTag->key, "part_number") == 0) {
                 chapterTrackNumber = convertString(chapterTag->value);
+            }
+            else if(strcasecmp(chapterTag->key, "REPLAYGAIN_TRACK_GAIN") == 0) {
+                chapterRGTrackGain = parseReplayGain(convertString(chapterTag->value));
+            }
+            else if(strcasecmp(chapterTag->key, "REPLAYGAIN_TRACK_PEAK") == 0) {
+                chapterRGTrackPeak = parseReplayPeak(convertString(chapterTag->value));
             }
         }
 
@@ -1120,6 +1128,13 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
         }
 
         track.setTrackTotal(QString::number(p->m_chapterCount));
+
+        if(chapterRGTrackGain != Fooyin::Constants::InvalidGain) {
+            track.setRGTrackGain(chapterRGTrackGain);
+        }
+        if(chapterRGTrackPeak != Fooyin::Constants::InvalidPeak) {
+            track.setRGTrackPeak(chapterRGTrackPeak);
+        }
 
         track.setExtraProperty(u"CHAPTER"_s, u"1"_s);
     }

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -967,7 +967,7 @@ public:
             return false;
         }
 
-        if(m_context->nb_chapters > 1) {
+        if(m_context->nb_chapters >= 1) {
             m_chapterCount = static_cast<int>(m_context->nb_chapters);
         }
 

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -207,7 +207,13 @@ float parseReplayPeak(const QString& peakStr)
     return ok ? peak : Fooyin::Constants::InvalidPeak;
 }
 
-void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
+enum class TagScope : uint8_t
+{
+    Global,
+    Track
+};
+
+void parseTag(Fooyin::Track& track, const AVDictionaryEntry* tag, TagScope scope, int chapterCount)
 {
     if(strcasecmp(tag->key, "album") == 0) {
         track.setAlbum(convertString(tag->value));
@@ -219,7 +225,12 @@ void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
         track.setAlbumArtists({convertString(tag->value)});
     }
     else if(strcasecmp(tag->key, "title") == 0) {
-        track.setTitle(convertString(tag->value));
+        if(scope == TagScope::Global && chapterCount > 1 && track.album().isEmpty()) {
+            track.setAlbum(convertString(tag->value));
+        }
+        else {
+            track.setTitle(convertString(tag->value));
+        }
     }
     else if(strcasecmp(tag->key, "genre") == 0) {
         track.setGenres({convertString(tag->value)});
@@ -286,6 +297,24 @@ void parseTag(Fooyin::Track& track, AVDictionaryEntry* tag)
     }
     else if(strcasecmp(tag->key, "REPLAYGAIN_ALBUM_PEAK") == 0) {
         track.setRGAlbumPeak(parseReplayPeak(convertString(tag->value)));
+    }
+    else if(strcasecmp(tag->key, "REPLAYGAIN_GAIN") == 0) {
+        const float gain = parseReplayGain(convertString(tag->value));
+        if(scope == TagScope::Global) {
+            track.setRGAlbumGain(gain);
+        }
+        else {
+            track.setRGTrackGain(gain);
+        }
+    }
+    else if(strcasecmp(tag->key, "REPLAYGAIN_PEAK") == 0) {
+        const float peak = parseReplayPeak(convertString(tag->value));
+        if(scope == TagScope::Global) {
+            track.setRGAlbumPeak(peak);
+        }
+        else {
+            track.setRGTrackPeak(peak);
+        }
     }
     else {
         track.addExtraTag(convertString(tag->key).toUpper(), convertString(tag->value));
@@ -1062,7 +1091,7 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
             duration = p->m_context->duration;
             timeBase = TimeBaseAv;
         }
-        const uint64_t durationMs = av_rescale_q(duration, timeBase, TimeBaseMs);
+        const auto durationMs = static_cast<uint64_t>(av_rescale_q(duration, timeBase, TimeBaseMs));
         track.setDuration(durationMs);
     }
 
@@ -1074,22 +1103,22 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
         track.setBitrate(bitrate);
     }
 
-    AVDictionaryEntry* tag{nullptr};
+    const AVDictionaryEntry* tag{nullptr};
     while((tag = av_dict_get(p->m_context->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
-        parseTag(track, tag);
+        parseTag(track, tag, TagScope::Global, p->m_chapterCount);
+    }
+
+    const AVDictionaryEntry* streamTag{nullptr};
+    while((streamTag = av_dict_get(avStream->metadata, "", streamTag, AV_DICT_IGNORE_SUFFIX))) {
+        parseTag(track, streamTag, TagScope::Track, p->m_chapterCount);
     }
 
     const int subsong = track.subsong();
     if(p->m_chapterCount > 1 && subsong >= 0 && subsong < p->m_chapterCount) {
         const AVChapter* chapter = p->m_context->chapters[subsong];
 
-        const uint64_t startMs = av_rescale_q(chapter->start, chapter->time_base, TimeBaseMs);
-        const uint64_t endMs   = av_rescale_q(chapter->end, chapter->time_base, TimeBaseMs);
-
-        // Container title becomes album (e.g. audiobook title)
-        if(!track.title().isEmpty()) {
-            track.setAlbum(track.title());
-        }
+        const auto startMs = static_cast<uint64_t>(av_rescale_q(chapter->start, chapter->time_base, TimeBaseMs));
+        const auto endMs   = static_cast<uint64_t>(av_rescale_q(chapter->end, chapter->time_base, TimeBaseMs));
 
         track.setOffset(startMs);
 
@@ -1097,16 +1126,16 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
         track.setTrackNumber(QString::number(subsong + 1));
 
         // Read chapter-level metadata (overrides container tags where defined)
-        AVDictionaryEntry* chapterTag{nullptr};
+        const AVDictionaryEntry* chapterTag{nullptr};
         while((chapterTag = av_dict_get(chapter->metadata, "", chapterTag, AV_DICT_IGNORE_SUFFIX))) {
-            parseTag(track, chapterTag);
+            parseTag(track, chapterTag, TagScope::Track, p->m_chapterCount);
         }
 
         // Ensure chapter timing and totals are authoritative
         track.setDuration(endMs - startMs);
         track.setTrackTotal(QString::number(p->m_chapterCount));
 
-        track.setExtraProperty(u"CHAPTER"_s, u"1"_s);
+        track.setIsChapter(true);
     }
 
     return true;

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -1092,49 +1092,19 @@ bool FFmpegReader::readTrack(const AudioSource& /*source*/, Track& track)
         }
 
         track.setOffset(startMs);
-        track.setDuration(endMs - startMs);
 
-        // Read chapter-level metadata
+        // Set default track number before parsing chapter tags
+        track.setTrackNumber(QString::number(subsong + 1));
+
+        // Read chapter-level metadata (overrides container tags where defined)
         AVDictionaryEntry* chapterTag{nullptr};
-        QString chapterTitle;
-        QString chapterTrackNumber;
-        float chapterRGTrackGain{Fooyin::Constants::InvalidGain};
-        float chapterRGTrackPeak{Fooyin::Constants::InvalidPeak};
-
         while((chapterTag = av_dict_get(chapter->metadata, "", chapterTag, AV_DICT_IGNORE_SUFFIX))) {
-            if(strcasecmp(chapterTag->key, "title") == 0) {
-                chapterTitle = convertString(chapterTag->value);
-            }
-            else if(strcasecmp(chapterTag->key, "track") == 0 || strcasecmp(chapterTag->key, "part_number") == 0) {
-                chapterTrackNumber = convertString(chapterTag->value);
-            }
-            else if(strcasecmp(chapterTag->key, "REPLAYGAIN_TRACK_GAIN") == 0) {
-                chapterRGTrackGain = parseReplayGain(convertString(chapterTag->value));
-            }
-            else if(strcasecmp(chapterTag->key, "REPLAYGAIN_TRACK_PEAK") == 0) {
-                chapterRGTrackPeak = parseReplayPeak(convertString(chapterTag->value));
-            }
+            parseTag(track, chapterTag);
         }
 
-        if(!chapterTitle.isEmpty()) {
-            track.setTitle(chapterTitle);
-        }
-
-        if(!chapterTrackNumber.isEmpty()) {
-            track.setTrackNumber(chapterTrackNumber);
-        }
-        else {
-            track.setTrackNumber(QString::number(subsong + 1));
-        }
-
+        // Ensure chapter timing and totals are authoritative
+        track.setDuration(endMs - startMs);
         track.setTrackTotal(QString::number(p->m_chapterCount));
-
-        if(chapterRGTrackGain != Fooyin::Constants::InvalidGain) {
-            track.setRGTrackGain(chapterRGTrackGain);
-        }
-        if(chapterRGTrackPeak != Fooyin::Constants::InvalidPeak) {
-            track.setRGTrackPeak(chapterRGTrackPeak);
-        }
 
         track.setExtraProperty(u"CHAPTER"_s, u"1"_s);
     }

--- a/src/core/engine/input/ffmpeg/ffmpeginput.h
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.h
@@ -68,6 +68,7 @@ public:
     [[nodiscard]] bool canReadCover() const override;
     [[nodiscard]] bool canWriteMetaData() const override;
 
+    [[nodiscard]] int subsongCount() const override;
     [[nodiscard]] bool init(const AudioSource& source) override;
     [[nodiscard]] bool readTrack(const AudioSource& source, Track& track) override;
     [[nodiscard]] QByteArray readCover(const AudioSource& source, const Track& track, Track::Cover cover) override;

--- a/src/core/library/libraryscanner.cpp
+++ b/src/core/library/libraryscanner.cpp
@@ -236,7 +236,7 @@ void LibraryScanner::scanTracks(const TrackList& tracks, const bool onlyModified
             }
         }
 
-        Track updatedTrack{track.filepath(), track.metadataStore()};
+        Track updatedTrack{track.filepath(), track.subsong(), track.metadataStore()};
 
         if(m_audioLoader->readTrackMetadata(updatedTrack)) {
             updatedTrack.setId(track.id());

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -38,10 +38,12 @@
 
 using namespace Qt::StringLiterals;
 
-constexpr auto MaxStarCount   = 10;
-constexpr auto YearRegex      = R"lit(\b\d{4}\b)lit";
-constexpr auto YearMonthRegex = R"lit(\b(\d{4})-(\d{2})\b)lit";
-constexpr auto FullDateRegex  = R"lit(\b(\d{4})-(\d{2})-(\d{2})\b)lit";
+constexpr auto MaxStarCount    = 10;
+constexpr auto YearRegex       = R"lit(\b\d{4}\b)lit";
+constexpr auto YearMonthRegex  = R"lit(\b(\d{4})-(\d{2})\b)lit";
+constexpr auto FullDateRegex   = R"lit(\b(\d{4})-(\d{2})-(\d{2})\b)lit";
+constexpr auto ChapterProperty = "_CHAPTER"_L1;
+constexpr auto ChapterValue    = "1"_L1;
 
 namespace {
 QString validNum(auto num)
@@ -188,14 +190,17 @@ float opusHeaderLinearGain(const Fooyin::Track& track)
 
 void normaliseExtraProperties(Fooyin::Track::ExtraProperties& props)
 {
-    const QString* opusHeader = props.find(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
-    if(!opusHeader) {
-        return;
+    if(const QString* opusHeader = props.find(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78))) {
+        bool ok{false};
+        if(const int gain = opusHeader->toInt(&ok); ok && gain == 0) {
+            props.erase(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+        }
     }
 
-    bool ok{false};
-    if(const int gain = opusHeader->toInt(&ok); ok && gain == 0) {
-        props.erase(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+    if(const QString* chapter = props.find(ChapterProperty)) {
+        if(*chapter != ChapterValue) {
+            props.erase(ChapterProperty);
+        }
     }
 }
 
@@ -661,7 +666,13 @@ QString Track::uniqueFilepath() const
 {
     QString path{p->filepath};
 
-    if(hasCue() || p->offset > 0) {
+    if(hasCue()) {
+        path.append(QString::number(p->offset));
+    }
+    else if(segmentType() == SegmentType::Chapter) {
+        path.append(u"#chapter="_s);
+        path.append(QString::number(p->subsong));
+        path.append(u':');
         path.append(QString::number(p->offset));
     }
 
@@ -1084,6 +1095,37 @@ bool Track::hasEmbeddedCue() const
 QString Track::cuePath() const
 {
     return p->cuePath;
+}
+
+Track::SegmentType Track::segmentType() const
+{
+    if(hasCue()) {
+        return SegmentType::Cue;
+    }
+
+    if(p->extraProps.contains(ChapterProperty)) {
+        return SegmentType::Chapter;
+    }
+
+    return SegmentType::None;
+}
+
+bool Track::isBoundedSegment() const
+{
+    return segmentType() != SegmentType::None;
+}
+
+bool Track::isSameStreamSegment() const
+{
+    switch(segmentType()) {
+        case SegmentType::Cue:
+        case SegmentType::Chapter:
+            return true;
+        case SegmentType::None:
+            return false;
+    }
+
+    return false;
 }
 
 bool Track::isArchivePath(const QString& path)
@@ -1840,6 +1882,16 @@ std::optional<int64_t> Track::dateValue(const QString& name) const
 void Track::setCuePath(const QString& path)
 {
     p->cuePath = path;
+}
+
+void Track::setIsChapter(bool isChapter)
+{
+    if(isChapter) {
+        setExtraProperty(ChapterProperty, ChapterValue);
+    }
+    else {
+        removeExtraProperty(ChapterProperty);
+    }
 }
 
 void Track::addExtraTag(const QString& tag, const QString& value)

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -661,7 +661,7 @@ QString Track::uniqueFilepath() const
 {
     QString path{p->filepath};
 
-    if(hasCue()) {
+    if(hasCue() || p->offset > 0) {
         path.append(QString::number(p->offset));
     }
 

--- a/src/plugins/wavebar/waveformgenerator.cpp
+++ b/src/plugins/wavebar/waveformgenerator.cpp
@@ -196,6 +196,8 @@ void WaveformGenerator::generate(const Track& track, int samplesPerChannel, bool
     m_loadedDecoder.decoder->start();
     m_loadedDecoder.decoder->seek(track.offset());
 
+    const uint64_t trackOffsetMs = track.offset();
+
     while(true) {
         if(!mayRun()) {
             m_loadedDecoder.decoder->stop();
@@ -226,6 +228,31 @@ void WaveformGenerator::generate(const Track& track, int samplesPerChannel, bool
             break;
         }
 
+        buffer = Audio::convert(buffer, m_requiredFormat);
+
+        // Trim any audio that the decoder produced from before the track's
+        // start offset.  This happens when a seek lands on a keyframe/cluster
+        // earlier than the requested position (common for chapters in MKA/M4B).
+        if(trackOffsetMs > 0 && buffer.startTime() < trackOffsetMs) {
+            const uint64_t bufEndMs = buffer.endTime();
+            if(bufEndMs <= trackOffsetMs) {
+                // Entire buffer is before the chapter start – skip it without
+                // counting against the byte budget.
+                continue;
+            }
+
+            // Partial overlap – trim the leading portion.
+            const uint64_t trimMs = trackOffsetMs - buffer.startTime();
+            const int trimFrames  = m_requiredFormat.framesForDuration(trimMs);
+            const auto trimBytes  = static_cast<size_t>(trimFrames * m_requiredFormat.bytesPerFrame());
+            const auto totalBytes = static_cast<size_t>(buffer.byteCount());
+
+            if(trimBytes > 0 && trimBytes < totalBytes) {
+                buffer = AudioBuffer{buffer.constData().subspan(trimBytes, totalBytes - trimBytes), m_requiredFormat,
+                                     trackOffsetMs};
+            }
+        }
+
         const uint64_t decodedBytes = static_cast<uint64_t>(buffer.byteCount());
         if(decodedBytes > std::numeric_limits<uint64_t>::max() - processedBytes) {
             processedBytes = std::numeric_limits<uint64_t>::max();
@@ -234,7 +261,6 @@ void WaveformGenerator::generate(const Track& track, int samplesPerChannel, bool
             processedBytes += decodedBytes;
         }
 
-        buffer = Audio::convert(buffer, m_requiredFormat);
         processBuffer(buffer);
 
         if(render && processedCount++ == updateThreshold) {

--- a/src/plugins/wavebar/waveformgenerator.cpp
+++ b/src/plugins/wavebar/waveformgenerator.cpp
@@ -244,16 +244,20 @@ void WaveformGenerator::generate(const Track& track, int samplesPerChannel, bool
             // Partial overlap – trim the leading portion.
             const uint64_t trimMs = trackOffsetMs - buffer.startTime();
             const int trimFrames  = m_requiredFormat.framesForDuration(trimMs);
-            const auto trimBytes  = static_cast<size_t>(trimFrames * m_requiredFormat.bytesPerFrame());
+            const auto trimBytes  = static_cast<size_t>(trimFrames) * m_requiredFormat.bytesPerFrame();
             const auto totalBytes = static_cast<size_t>(buffer.byteCount());
 
             if(trimBytes > 0 && trimBytes < totalBytes) {
+                const uint64_t trimmedStartMs = buffer.startTime() + m_requiredFormat.durationForFrames(trimFrames);
                 buffer = AudioBuffer{buffer.constData().subspan(trimBytes, totalBytes - trimBytes), m_requiredFormat,
-                                     trackOffsetMs};
+                                     trimmedStartMs};
+            }
+            else if(trimBytes >= totalBytes) {
+                continue;
             }
         }
 
-        const uint64_t decodedBytes = static_cast<uint64_t>(buffer.byteCount());
+        const auto decodedBytes = static_cast<uint64_t>(buffer.byteCount());
         if(decodedBytes > std::numeric_limits<uint64_t>::max() - processedBytes) {
             processedBytes = std::numeric_limits<uint64_t>::max();
         }
@@ -351,7 +355,7 @@ void WaveformGenerator::processBuffer(const AudioBuffer& buffer)
 
         const int frameOffset = i * channels;
         for(int ch{0}; ch < channels; ++ch) {
-            const float sample                  = samples[static_cast<size_t>(frameOffset + ch)];
+            const float sample                  = samples[static_cast<size_t>(frameOffset) + ch];
             channelMax[static_cast<size_t>(ch)] = std::max(channelMax[static_cast<size_t>(ch)], sample);
             channelMin[static_cast<size_t>(ch)] = std::min(channelMin[static_cast<size_t>(ch)], sample);
             channelRms[static_cast<size_t>(ch)] += sample * sample;

--- a/tests/core/engine/audioenginetest.cpp
+++ b/tests/core/engine/audioenginetest.cpp
@@ -716,7 +716,8 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, ContiguousSegmentSwitchDoesNo
     ensureCoreApplication();
     EngineHarness harness{false};
 
-    const Track firstTrack = harness.createTrack(u"segments.fyt"_s, 0, 100000);
+    Track firstTrack = harness.createTrack(u"segments.fyt"_s, 0, 100000);
+    firstTrack.setIsChapter(true);
     harness.engine.loadTrack(makePlaybackItem(firstTrack, 1), false);
     ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.trackStatus() == Engine::TrackStatus::Loaded; }));
 
@@ -728,6 +729,7 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, ContiguousSegmentSwitchDoesNo
     const int outputUninitBefore = harness.outputStats->uninitCalls.load();
 
     Track nextSegment = firstTrack;
+    nextSegment.setIsChapter(true);
     nextSegment.setOffset(firstTrack.offset() + firstTrack.duration());
     nextSegment.setDuration(firstTrack.duration());
 
@@ -739,6 +741,44 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, ContiguousSegmentSwitchDoesNo
     EXPECT_EQ(harness.outputStats->uninitCalls.load(), outputUninitBefore);
     EXPECT_EQ(harness.engine.playbackState(), Engine::PlaybackState::Playing);
     EXPECT_NE(harness.engine.trackStatus(), Engine::TrackStatus::Invalid);
+}
+
+FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, SeekAfterContiguousSegmentSwitchPublishesTargetPosition)
+{
+    ensureCoreApplication();
+    EngineHarness harness{false};
+
+    Track firstTrack = harness.createTrack(u"segments-seek.fyt"_s, 0, 10000);
+    firstTrack.setIsChapter(true);
+    harness.engine.loadTrack(makePlaybackItem(firstTrack, 1), false);
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.trackStatus() == Engine::TrackStatus::Loaded; }));
+
+    harness.engine.play();
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.playbackState() == Engine::PlaybackState::Playing; }));
+
+    Track nextSegment = firstTrack;
+    nextSegment.setIsChapter(true);
+    nextSegment.setOffset(firstTrack.offset() + firstTrack.duration());
+    nextSegment.setDuration(12000);
+
+    harness.engine.loadTrack(makePlaybackItem(nextSegment, 2), false);
+    ASSERT_TRUE(pumpUntil([&harness]() { return AudioEngineTestAccessor::currentTrackItemId(harness.engine) == 2; }));
+
+    static constexpr uint64_t seekPositionMs = 5000;
+    harness.engine.seek(seekPositionMs);
+
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.decoderStats->seekCalls.load() >= 1; }, 2000ms));
+    ASSERT_TRUE(pumpUntil(
+        [&harness]() {
+            const uint64_t positionMs = harness.engine.position();
+            return positionMs >= (seekPositionMs > 1000 ? seekPositionMs - 1000 : 0)
+                && positionMs <= seekPositionMs + 1800;
+        },
+        700ms));
+
+    const uint64_t postSeekPositionMs = harness.engine.position();
+    EXPECT_GE(postSeekPositionMs, seekPositionMs > 1000 ? seekPositionMs - 1000 : 0);
+    EXPECT_LE(postSeekPositionMs, seekPositionMs + 1800);
 }
 
 FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, PlayPauseStopWithFadeCompletesStateTransitions)

--- a/tests/core/tracktest.cpp
+++ b/tests/core/tracktest.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <core/constants.h>
+#include <core/engine/enginehelpers.h>
 #include <core/track.h>
 #include <core/trackmetadatastore.h>
 
@@ -199,6 +200,51 @@ TEST(TrackTest, SameIdentityAsUsesIdThenSegmentIdentity)
 
     Track invalidTrack;
     EXPECT_FALSE(segmentTrackA.sameIdentityAs(invalidTrack));
+}
+
+TEST(TrackTest, ChapterSegmentsHaveExplicitIdentityAtOffsetZero)
+{
+    Track wholeFile{u"/music/book.m4b"_s, 0};
+    wholeFile.setDuration(10000);
+
+    Track chapter{u"/music/book.m4b"_s, 0};
+    chapter.setIsChapter(true);
+    chapter.setOffset(0);
+    chapter.setDuration(5000);
+
+    EXPECT_EQ(chapter.segmentType(), Track::SegmentType::Chapter);
+    EXPECT_TRUE(chapter.isBoundedSegment());
+    EXPECT_TRUE(chapter.isSameStreamSegment());
+    EXPECT_NE(chapter.uniqueFilepath(), wholeFile.uniqueFilepath());
+    EXPECT_EQ(chapter.uniqueFilepath(), u"/music/book.m4b#chapter=0:0"_s);
+}
+
+TEST(TrackTest, ContiguousSameFileSegmentRequiresSameStreamSegmentType)
+{
+    Track chapterOne{u"/music/book.m4b"_s, 0};
+    chapterOne.setIsChapter(true);
+    chapterOne.setOffset(0);
+    chapterOne.setDuration(5000);
+
+    Track chapterTwo{u"/music/book.m4b"_s, 1};
+    chapterTwo.setIsChapter(true);
+    chapterTwo.setOffset(5000);
+    chapterTwo.setDuration(4000);
+
+    EXPECT_TRUE(isContiguousSameFileSegment(chapterOne, chapterTwo));
+
+    Track plainSubsong{u"/music/book.m4b"_s, 1};
+    plainSubsong.setOffset(5000);
+    plainSubsong.setDuration(4000);
+
+    EXPECT_FALSE(isContiguousSameFileSegment(chapterOne, plainSubsong));
+
+    Track cueTrack{u"/music/book.m4b"_s, 1};
+    cueTrack.setCuePath(u"/music/book.cue"_s);
+    cueTrack.setOffset(5000);
+    cueTrack.setDuration(4000);
+
+    EXPECT_FALSE(isContiguousSameFileSegment(chapterOne, cueTrack));
 }
 
 TEST(TrackTest, MigratesPooledMetadataToExplicitStore)


### PR DESCRIPTION
Full disclosure, I have not written C++ in forever. I generated these changes with AI - so sorry for the noise.

I created two example "books" for testing: [TheLibrary.zip](https://github.com/user-attachments/files/26326890/TheLibrary.zip)

- **TheLibrary.m4b**: AAC VBR stream in a mp4 container (so literally the same thing as a .m4a or .mp4 file, just different file extension). .m4b is pretty much the default format for long-form chaptered audio. E.g. used by Audible. AAC is a well established format, so most players and software works with it just fine.
- **TheLibrary.mka**: Opus stream in a Matroska container. .mka is more of a niche. Not sure many people use it, but they probably should. For stuff like podcasts and audiobooks Opus makes sense as it sounds mostly transparent for speech at very low bitrates. .mka as a container is more flexible than .mp4. But also less supported on hardware - though I would argue e.g. FFmpeg has better support for .mka/.mkv than .mp4.

In theory, FFmpeg can generate other containers as well. E.g. a .mp3 with chapters, but these never worked well for me so I never used them - though could generate them for testing as well.

The .m4b seems to work well with these changes, but I had to set:
Playback/Library/Tag readers - moved FFmpeg to the top.
Playback/Library/FFmpeg/Enable all supported extension - enabled

The .mka file plays as well, but there are issues with the WaveBar widget. After the first chapter the waveform is no longer in sync with the audio.

This relates to this issue: https://github.com/fooyin/fooyin/issues/694
@kode54  made a draft for the same issue here: https://github.com/fooyin/fooyin/pull/790

Files downloaded with yt-dlp, as suggested here: https://github.com/fooyin/fooyin/pull/790#issuecomment-3657954715  by @tmtom  work just fine for me.

I hope this can contribute to a proper implementation of the feature.