### PR TITLE
[core,gui] Add per-device output profiles and output selector

### DIFF
--- a/include/core/engine/enginecontroller.h
+++ b/include/core/engine/enginecontroller.h
@@ -55,6 +55,8 @@ public:
     [[nodiscard]] virtual OutputNames getAllOutputs() const = 0;
     //! Available devices for a specific output backend.
     [[nodiscard]] virtual OutputDevices getOutputDevices(const QString& output) const = 0;
+    //! Apply a combined output/device/DSP/bitdepth profile.
+    virtual void applyOutputProfile(const Engine::OutputProfileRequest& request) = 0;
 
     /*!
      * Registers an audio output backend factory under @p name.

--- a/include/core/engine/enginedefs.h
+++ b/include/core/engine/enginedefs.h
@@ -236,6 +236,74 @@ struct LiveDspSettingsUpdate
     uint64_t revision{0};
 };
 
+struct OutputDeviceProfile
+{
+    QString output;
+    QString device;
+    bool enabled{true};
+    SampleFormat bitDepth{SampleFormat::Unknown};
+    bool dither{false};
+    int dspPresetId{-1};
+
+    [[nodiscard]] bool isValid() const
+    {
+        return !output.isEmpty() && !device.isEmpty();
+    }
+
+    bool operator==(const OutputDeviceProfile&) const = default;
+};
+
+using OutputDeviceProfiles = std::vector<OutputDeviceProfile>;
+
+inline QDataStream& operator<<(QDataStream& stream, const OutputDeviceProfiles& profiles)
+{
+    DataStream::writeContainer(stream, profiles);
+    return stream;
+}
+
+inline QDataStream& operator>>(QDataStream& stream, OutputDeviceProfiles& profiles)
+{
+    DataStream::readContainer(stream, profiles);
+    return stream;
+}
+
+inline QDataStream& operator<<(QDataStream& stream, const OutputDeviceProfile& profile)
+{
+    stream << profile.output;
+    stream << profile.device;
+    stream << profile.enabled;
+    stream << static_cast<quint8>(profile.bitDepth);
+    stream << profile.dither;
+    stream << profile.dspPresetId;
+
+    return stream;
+}
+
+inline QDataStream& operator>>(QDataStream& stream, OutputDeviceProfile& profile)
+{
+    stream >> profile.output;
+    stream >> profile.device;
+    stream >> profile.enabled;
+
+    quint8 bits{0};
+    stream >> bits;
+    profile.bitDepth = static_cast<SampleFormat>(bits);
+
+    stream >> profile.dither;
+    stream >> profile.dspPresetId;
+
+    return stream;
+}
+
+struct OutputProfileRequest
+{
+    QString output;
+    QString device;
+    SampleFormat bitDepth{SampleFormat::Unknown};
+    bool dither{false};
+    DspChains chain;
+};
+
 } // namespace Fooyin::Engine
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Fooyin::Engine::RGProcessing)
@@ -247,3 +315,5 @@ Q_DECLARE_METATYPE(Fooyin::Engine::TrackCommitContext)
 Q_DECLARE_METATYPE(Fooyin::Engine::AnalysisDataTypes)
 Q_DECLARE_METATYPE(Fooyin::LevelFrame)
 Q_DECLARE_METATYPE(Fooyin::Engine::LiveDspSettingsUpdate)
+Q_DECLARE_METATYPE(Fooyin::Engine::OutputDeviceProfiles)
+Q_DECLARE_METATYPE(Fooyin::Engine::OutputProfileRequest)

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -206,6 +206,7 @@ constexpr auto GeneralCore           = "Fooyin.Page.General.Core";
 constexpr auto Playback              = "Fooyin.Page.Playback";
 constexpr auto Fading                = "Fooyin.Page.Playback.Fading";
 constexpr auto Output                = "Fooyin.Page.Playback.Output";
+constexpr auto OutputDevices         = "Fooyin.Page.Playback.Output.Devices";
 constexpr auto Decoding              = "Fooyin.Page.Playback.Decoding";
 constexpr auto ReplayGain            = "Fooyin.Page.Playback.ReplayGain";
 constexpr auto DspManager            = "Fooyin.Page.Playback.DspManager";

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -4283,6 +4283,63 @@ void AudioEngine::setAudioOutput(const OutputCreator& output, const QString& dev
     }
 }
 
+void AudioEngine::applyOutputProfile(const OutputCreator& output, const QString& device, SampleFormat bitdepth,
+                                     bool dither, const Engine::DspChains& chain)
+{
+    qCDebug(ENGINE) << "Applying output profile:" << "device=" << device << "bitdepth=" << static_cast<int>(bitdepth)
+                    << "dither=" << dither;
+
+    const bool wasPlaying = m_playbackState.load(std::memory_order_relaxed) == Engine::PlaybackState::Playing;
+
+    if(wasPlaying) {
+        cancelFadesForReinit();
+        m_outputController.pauseOutputImmediate(true);
+    }
+
+    m_outputController.setOutputCreator(output);
+    m_outputController.setOutputDevice(device);
+
+    m_pipeline.setOutputBitdepth(bitdepth);
+    m_pipeline.setDither(dither);
+
+    const auto buildNodes = [this](const Engine::DspChain& defs) -> std::vector<DspNodePtr> {
+        if(!m_dspRegistry) {
+            return {};
+        }
+
+        std::vector<DspNodePtr> nodes;
+        nodes.reserve(defs.size());
+
+        for(const auto& entry : defs) {
+            auto node = m_dspRegistry->create(entry.id);
+            if(!node) {
+                continue;
+            }
+
+            node->setInstanceId(entry.instanceId);
+            node->setEnabled(entry.enabled);
+            if(!entry.settings.isEmpty()) {
+                node->loadSettings(entry.settings);
+            }
+
+            nodes.push_back(std::move(node));
+        }
+
+        return nodes;
+    };
+
+    std::vector<DspNodePtr> masterNodes = buildNodes(chain.masterChain);
+    m_pipeline.setDspChain(std::move(masterNodes), chain.perTrackChain, m_format);
+
+    if(m_format.isValid()) {
+        m_outputController.uninitOutput();
+        const bool initOk = m_outputController.initOutput(m_format, m_volume);
+        if(initOk && wasPlaying) {
+            play();
+        }
+    }
+}
+
 void AudioEngine::setOutputDevice(const QString& device)
 {
     if(device == m_outputController.outputDevice()) {
@@ -4292,7 +4349,23 @@ void AudioEngine::setOutputDevice(const QString& device)
     qCDebug(ENGINE) << "Changing output device to:" << device;
 
     m_outputController.setOutputDevice(device);
-    m_pipeline.setOutputDevice(device);
+
+    if(!m_format.isValid()) {
+        m_pipeline.setOutputDevice(device);
+        return;
+    }
+
+    const bool wasPlaying = m_playbackState.load(std::memory_order_relaxed) == Engine::PlaybackState::Playing;
+    if(wasPlaying) {
+        cancelFadesForReinit();
+        m_outputController.pauseOutputImmediate(true);
+    }
+
+    m_outputController.uninitOutput();
+    const bool initOk = m_outputController.initOutput(m_format, m_volume);
+    if(initOk && wasPlaying) {
+        play();
+    }
 }
 
 void AudioEngine::setDspChain(const Engine::DspChains& chain)

--- a/src/core/engine/audioengine.h
+++ b/src/core/engine/audioengine.h
@@ -165,6 +165,8 @@ public slots:
     void setVolume(double volume);
 
     void setAudioOutput(const Fooyin::OutputCreator& output, const QString& device);
+    void applyOutputProfile(const Fooyin::OutputCreator& output, const QString& device, SampleFormat bitdepth,
+                            bool dither, const Fooyin::Engine::DspChains& chain);
     void setOutputDevice(const QString& device);
     void setAnalysisDataSubscriptions(Fooyin::Engine::AnalysisDataTypes subscriptions);
     void updateLiveDspSettings(const Fooyin::Engine::LiveDspSettingsUpdate& update);

--- a/src/core/engine/dsp/dspchainstore.cpp
+++ b/src/core/engine/dsp/dspchainstore.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<DspNode> DspChainStore::createDsp(const QString& id) const
     return m_registry ? m_registry->create(id) : nullptr;
 }
 
-void DspChainStore::setActiveChain(const Engine::DspChains& chain)
+void DspChainStore::setActiveChain(const DspChains& chain)
 {
     m_activeChain = normaliseChain(chain);
     m_liveRevisionByKey.clear();
@@ -177,19 +177,26 @@ void DspChainStore::setActiveChain(const Engine::DspChains& chain)
     }
 }
 
-bool DspChainStore::updateLiveDspSettings(const Engine::DspChainScope scope, uint64_t instanceId,
-                                          const QByteArray& settings, bool persist)
+void DspChainStore::syncActiveChain(const DspChains& chain)
+{
+    m_activeChain = normaliseChain(chain);
+    m_liveRevisionByKey.clear();
+    persistChain(m_activeChain);
+}
+
+bool DspChainStore::updateLiveDspSettings(const DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
+                                          bool persist)
 {
     if(instanceId == 0) {
         return false;
     }
 
-    auto inChain = [instanceId](const Engine::DspChain& chain) {
+    auto inChain = [instanceId](const DspChain& chain) {
         return std::ranges::any_of(chain, [instanceId](const auto& entry) { return entry.instanceId == instanceId; });
     };
 
     DspChain* targetChain{nullptr};
-    if(scope == Engine::DspChainScope::Master) {
+    if(scope == DspChainScope::Master) {
         targetChain = &m_activeChain.masterChain;
     }
     else {

--- a/src/core/engine/dsp/dspchainstore.h
+++ b/src/core/engine/dsp/dspchainstore.h
@@ -44,6 +44,7 @@ public:
     [[nodiscard]] std::unique_ptr<DspNode> createDsp(const QString& id) const;
 
     void setActiveChain(const Engine::DspChains& chain);
+    void syncActiveChain(const Engine::DspChains& chain);
     bool updateLiveDspSettings(Engine::DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
                                bool persist);
 

--- a/src/core/engine/enginehandler.cpp
+++ b/src/core/engine/enginehandler.cpp
@@ -819,6 +819,22 @@ void EngineHandler::setup()
     changeOutput(m_settings->value<Settings::Core::AudioOutput>());
 }
 
+void EngineHandler::applyOutputProfile(const Engine::OutputProfileRequest& request)
+{
+    if(request.output.isEmpty() || request.device.isEmpty()) {
+        return;
+    }
+
+    if(!m_outputs.contains(request.output)) {
+        qCWarning(ENG_HANDLER) << "Output hasn't been registered:" << request.output;
+        return;
+    }
+
+    m_currentOutput = {.name = request.output, .device = request.device};
+    dispatchCommand(&AudioEngine::applyOutputProfile, m_outputs.at(request.output), request.device, request.bitDepth,
+                    request.dither, request.chain);
+}
+
 void EngineHandler::setDspChain(const Engine::DspChains& chain)
 {
     dispatchCommand(&AudioEngine::setDspChain, chain);
@@ -881,8 +897,7 @@ OutputDevices EngineHandler::getOutputDevices(const QString& output) const
 
     if(auto out = m_outputs.at(output)()) {
         const bool isCurrent
-            = m_engine->playbackState() != Engine::PlaybackState::Stopped
-           && (m_currentOutput.name == output || m_currentOutput.device.compare(output, Qt::CaseInsensitive) == 0);
+            = m_engine->playbackState() != Engine::PlaybackState::Stopped && m_currentOutput.name == output;
         return out->getAllDevices(isCurrent);
     }
 

--- a/src/core/engine/enginehandler.h
+++ b/src/core/engine/enginehandler.h
@@ -83,6 +83,8 @@ public:
     //! Get devices for a specific output
     [[nodiscard]] OutputDevices getOutputDevices(const QString& output) const override;
 
+    void applyOutputProfile(const Engine::OutputProfileRequest& request) override;
+
     //! Register an audio output
     void addOutput(const QString& name, OutputCreator output) override;
 

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -52,6 +52,7 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
     qRegisterMetaType<Engine::FadingValues>("FadingValues");
     qRegisterMetaType<Engine::CrossfadingValues>("CrossfadingValues");
     qRegisterMetaType<Engine::FadeSpec>("FadeSpec");
+    qRegisterMetaType<Engine::OutputDeviceProfiles>("OutputDeviceProfiles");
 
     m_settings->createTempSetting<FirstRun>(true);
     m_settings->createTempSetting<Version>(QString::fromLatin1(VERSION));
@@ -120,6 +121,8 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
     m_settings->createSetting<Internal::DecodeHighWatermarkRatio>(0.95, u"Engine/DecodeHighWatermarkRatio"_s);
     m_settings->createSetting<Internal::CrossfadeSwitchPolicy>(
         static_cast<int>(Engine::CrossfadeSwitchPolicy::OverlapStart), u"Playback/CrossfadeSwitchPolicy"_s);
+    m_settings->createSetting<Internal::OutputDeviceProfiles>(QVariant::fromValue(Engine::OutputDeviceProfiles{}),
+                                                              u"Engine/OutputDeviceProfiles"_s);
 
     m_settings->set<FirstRun>(!QFileInfo::exists(Core::settingsPath()));
 

--- a/src/core/internalcoresettings.h
+++ b/src/core/internalcoresettings.h
@@ -73,6 +73,7 @@ enum CoreInternalSettings : uint32_t
     DecodeLowWatermarkRatio  = 15 | Type::Double,
     DecodeHighWatermarkRatio = 16 | Type::Double,
     CrossfadeSwitchPolicy    = 17 | Type::Int,
+    OutputDeviceProfiles     = 18 | Type::Variant,
 };
 Q_ENUM_NS(CoreInternalSettings)
 } // namespace Settings::Core::Internal

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -96,6 +96,8 @@ set(SOURCES
     controls/commandbuttonconfigdialog.h
     controls/playlistcontrol.cpp
     controls/playlistcontrol.h
+    controls/outputselector.cpp
+    controls/outputselector.h
     controls/seekbar.cpp
     controls/seekbar.h
     controls/volumecontrol.cpp
@@ -293,6 +295,8 @@ set(SOURCES
     search/searchcontroller.h
     search/searchwidget.cpp
     search/searchwidget.h
+    output/outputprofilemanager.cpp
+    output/outputprofilemanager.h
     selectioninfo/infodelegate.cpp
     selectioninfo/infodelegate.h
     selectioninfo/infoitem.cpp
@@ -341,6 +345,12 @@ set(SOURCES
     settings/playback/decodermodel.h
     settings/playback/decoderdelegate.cpp
     settings/playback/decoderdelegate.h
+    settings/playback/devicepage.cpp
+    settings/playback/devicepage.h
+    settings/playback/outputdevicesdelegate.cpp
+    settings/playback/outputdevicesdelegate.h
+    settings/playback/outputdevicesmodel.cpp
+    settings/playback/outputdevicesmodel.h
     settings/playback/decoderpage.cpp
     settings/playback/decoderpage.h
     settings/playback/dspdelegate.cpp

--- a/src/gui/controls/outputselector.cpp
+++ b/src/gui/controls/outputselector.cpp
@@ -1,0 +1,159 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "outputselector.h"
+
+#include "output/outputprofilemanager.h"
+
+#include <gui/guiconstants.h>
+#include <gui/widgets/expandingcombobox.h>
+#include <utils/settings/settingsdialogcontroller.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QAction>
+#include <QContextMenuEvent>
+#include <QHBoxLayout>
+#include <QJsonObject>
+#include <QLabel>
+#include <QMenu>
+#include <QSignalBlocker>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+OutputSelector::OutputSelector(OutputProfileManager* profileManager, SettingsManager* settings, QWidget* parent)
+    : FyWidget{parent}
+    , m_profileManager{profileManager}
+    , m_settings{settings}
+    , m_label{new QLabel(tr("Output") + u": "_s, this)}
+    , m_combo{new ExpandingComboBox(this)}
+    , m_showLabel{true}
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins({});
+    layout->addWidget(m_label);
+    layout->addWidget(m_combo, 1);
+
+    m_combo->setResizeToCurrentEnabled(false);
+    m_label->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_combo->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    QObject::connect(m_combo, &QComboBox::currentIndexChanged, this, [this](int index) {
+        if(index < 0) {
+            return;
+        }
+
+        const QString output = m_combo->currentData(Qt::UserRole).toString();
+        const QString device = m_combo->currentData(Qt::UserRole + 1).toString();
+        m_profileManager->applyProfile(output, device);
+    });
+
+    QObject::connect(m_profileManager, &OutputProfileManager::profilesChanged, this, &OutputSelector::reload);
+    QObject::connect(m_profileManager, &OutputProfileManager::currentOutputChanged, this, &OutputSelector::reload);
+
+    QObject::connect(m_label, &QWidget::customContextMenuRequested, this,
+                     [this](const QPoint& pos) { showContextMenu(m_label->mapToGlobal(pos)); });
+    QObject::connect(m_combo, &QWidget::customContextMenuRequested, this,
+                     [this](const QPoint& pos) { showContextMenu(m_combo->mapToGlobal(pos)); });
+
+    setShowLabel(m_showLabel);
+    reload();
+}
+
+QString OutputSelector::name() const
+{
+    return tr("Output Selector");
+}
+
+QString OutputSelector::layoutName() const
+{
+    return u"OutputSelector"_s;
+}
+
+void OutputSelector::saveLayoutData(QJsonObject& layout)
+{
+    layout["ShowLabel"_L1] = m_showLabel;
+}
+
+void OutputSelector::loadLayoutData(const QJsonObject& layout)
+{
+    setShowLabel(layout.value("ShowLabel"_L1).toBool());
+}
+
+void OutputSelector::contextMenuEvent(QContextMenuEvent* event)
+{
+    showContextMenu(event->globalPos());
+}
+
+void OutputSelector::reload()
+{
+    const QString currentOutput = m_profileManager->currentOutput();
+    const QString currentDevice = m_profileManager->currentDevice();
+    const auto entries          = m_profileManager->deviceEntries(currentOutput);
+
+    const QSignalBlocker blocker{m_combo};
+    m_combo->clear();
+
+    for(const auto& entry : entries) {
+        if(!entry.enabled && entry.device != currentDevice) {
+            continue;
+        }
+
+        m_combo->addItem(entry.description, currentOutput);
+        m_combo->setItemData(m_combo->count() - 1, entry.device, Qt::UserRole + 1);
+        if(entry.device == currentDevice) {
+            m_combo->setCurrentIndex(m_combo->count() - 1);
+        }
+    }
+
+    m_combo->setEnabled(m_combo->count() > 0);
+    m_combo->resizeDropDown();
+}
+
+void OutputSelector::setShowLabel(bool showLabel)
+{
+    m_showLabel = showLabel;
+    m_label->setVisible(m_showLabel);
+    updateGeometry();
+}
+
+void OutputSelector::showContextMenu(const QPoint& globalPos)
+{
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* showLabel = new QAction(tr("Show label"), menu);
+    showLabel->setCheckable(true);
+    showLabel->setChecked(m_showLabel);
+    QObject::connect(showLabel, &QAction::triggered, this, &OutputSelector::setShowLabel);
+    menu->addAction(showLabel);
+
+    auto* configureDevices = new QAction(tr("Configure listed devices…"), menu);
+    QObject::connect(configureDevices, &QAction::triggered, this, [this]() {
+        if(m_settings && m_settings->settingsDialog()) {
+            m_settings->settingsDialog()->openAtPage(Id{Constants::Page::OutputDevices});
+        }
+    });
+    menu->addAction(configureDevices);
+
+    menu->popup(globalPos);
+}
+} // namespace Fooyin
+
+#include "moc_outputselector.cpp"

--- a/src/gui/controls/outputselector.h
+++ b/src/gui/controls/outputselector.h
@@ -1,0 +1,62 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gui/fywidget.h>
+
+class QContextMenuEvent;
+class QLabel;
+class QJsonObject;
+class QMenu;
+class QPoint;
+
+namespace Fooyin {
+class OutputProfileManager;
+class ExpandingComboBox;
+class SettingsManager;
+
+class OutputSelector : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    explicit OutputSelector(OutputProfileManager* profileManager, SettingsManager* settings, QWidget* parent = nullptr);
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+private:
+    void reload();
+    void setShowLabel(bool showLabel);
+    void showContextMenu(const QPoint& globalPos);
+
+    OutputProfileManager* m_profileManager;
+    SettingsManager* m_settings;
+    QLabel* m_label;
+    ExpandingComboBox* m_combo;
+    bool m_showLabel;
+};
+} // namespace Fooyin

--- a/src/gui/output/outputprofilemanager.cpp
+++ b/src/gui/output/outputprofilemanager.cpp
@@ -1,0 +1,233 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "outputprofilemanager.h"
+
+#include "dsp/dsppresetregistry.h"
+
+#include <core/coresettings.h>
+#include <core/engine/dsp/dspchainstore.h>
+#include <core/internalcoresettings.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <algorithm>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+OutputProfileManager::OutputProfileManager(EngineController* engine, DspChainStore* chainStore,
+                                           DspPresetRegistry* presetRegistry, SettingsManager* settings,
+                                           QObject* parent)
+    : QObject{parent}
+    , m_engine{engine}
+    , m_chainStore{chainStore}
+    , m_presetRegistry{presetRegistry}
+    , m_settings{settings}
+{
+    m_settings->subscribe<Settings::Core::AudioOutput>(this, [this](const QString& value) {
+        const QStringList parts = value.split(u'|');
+        if(!parts.empty() && parts.size() >= 2) {
+            emit currentOutputChanged(parts.value(0), parts.value(1));
+            reapplyCurrentProfile();
+        }
+    });
+    m_settings->subscribe<Settings::Core::Internal::OutputDeviceProfiles>(
+        this, [this]() { emit profilesChanged(currentOutput()); });
+}
+
+OutputNames OutputProfileManager::outputs() const
+{
+    return m_engine->getAllOutputs();
+}
+
+QString OutputProfileManager::currentOutput() const
+{
+    return parseCurrentOutput().first;
+}
+
+QString OutputProfileManager::currentDevice() const
+{
+    return parseCurrentOutput().second;
+}
+
+std::vector<OutputProfileManager::DeviceEntry> OutputProfileManager::deviceEntries(const QString& output) const
+{
+    if(output.isEmpty()) {
+        return {};
+    }
+
+    const auto stored  = profiles();
+    const auto devices = m_engine->getOutputDevices(output);
+
+    std::vector<DeviceEntry> entries;
+    entries.reserve(devices.size());
+
+    for(const auto& [device, description] : devices) {
+        DeviceEntry entry{
+            .output      = output,
+            .device      = device,
+            .description = description,
+        };
+
+        const auto it = std::ranges::find_if(stored, [&output, &device](const auto& profile) {
+            return profile.output == output && profile.device == device;
+        });
+        if(it != stored.cend()) {
+            entry.enabled     = it->enabled;
+            entry.bitDepth    = it->bitDepth;
+            entry.dither      = it->dither;
+            entry.dspPresetId = it->dspPresetId;
+        }
+
+        entries.push_back(std::move(entry));
+    }
+
+    return entries;
+}
+
+void OutputProfileManager::setProfiles(const QString& output, const Engine::OutputDeviceProfiles& profilesForOutput)
+{
+    auto merged = profiles();
+    std::erase_if(merged, [&output](const auto& profile) { return profile.output == output; });
+
+    for(const auto& profile : profilesForOutput) {
+        if(profile.isValid()) {
+            merged.push_back(profile);
+        }
+    }
+
+    storeProfiles(merged);
+}
+
+void OutputProfileManager::clearProfiles()
+{
+    m_settings->reset<Settings::Core::Internal::OutputDeviceProfiles>();
+    emit profilesChanged(currentOutput());
+}
+
+bool OutputProfileManager::applyProfile(const QString& output, const QString& device)
+{
+    if(output.isEmpty() || device.isEmpty()) {
+        return false;
+    }
+
+    const auto profile  = profileFor(output, device);
+    const auto bitDepth = (profile && profile->bitDepth != SampleFormat::Unknown)
+                            ? profile->bitDepth
+                            : static_cast<SampleFormat>(m_settings->value<Settings::Core::OutputBitDepth>());
+    const bool dither
+        = bitDepth == SampleFormat::S16
+       && ((profile && profile->bitDepth != SampleFormat::Unknown) ? profile->dither
+                                                                   : m_settings->value<Settings::Core::OutputDither>());
+
+    const int dspPresetId         = profile ? profile->dspPresetId : -1;
+    const Engine::DspChains chain = resolveChain(dspPresetId);
+
+    m_engine->applyOutputProfile({
+        .output   = output,
+        .device   = device,
+        .bitDepth = bitDepth,
+        .dither   = dither,
+        .chain    = chain,
+    });
+
+    if(m_chainStore) {
+        m_chainStore->syncActiveChain(chain);
+    }
+
+    const QString setting = output + u"|"_s + device;
+    m_settings->setSilently<Settings::Core::AudioOutput>(setting);
+    m_settings->setSilently<Settings::Core::OutputBitDepth>(static_cast<int>(bitDepth));
+    m_settings->setSilently<Settings::Core::OutputDither>(dither);
+
+    emit currentOutputChanged(output, device);
+    return true;
+}
+
+void OutputProfileManager::reapplyCurrentProfile()
+{
+    const auto [output, device] = parseCurrentOutput();
+    const auto profile          = profileFor(output, device);
+    if(!profile) {
+        return;
+    }
+
+    if(profile->bitDepth == SampleFormat::Unknown && profile->dspPresetId < 0) {
+        return;
+    }
+
+    applyProfile(output, device);
+}
+
+Engine::OutputDeviceProfiles OutputProfileManager::profiles() const
+{
+    return m_settings->value<Settings::Core::Internal::OutputDeviceProfiles>().value<Engine::OutputDeviceProfiles>();
+}
+
+void OutputProfileManager::storeProfiles(const Engine::OutputDeviceProfiles& profiles)
+{
+    m_settings->set<Settings::Core::Internal::OutputDeviceProfiles>(QVariant::fromValue(profiles));
+}
+
+std::optional<Engine::OutputDeviceProfile> OutputProfileManager::profileFor(const QString& output,
+                                                                            const QString& device) const
+{
+    const auto stored = profiles();
+
+    const auto it = std::ranges::find_if(stored, [&output, &device](const auto& profile) {
+        return profile.output == output && profile.device == device;
+    });
+    if(it != stored.cend()) {
+        return *it;
+    }
+
+    return {};
+}
+
+Engine::DspChains OutputProfileManager::resolveChain(int dspPresetId) const
+{
+    if(dspPresetId >= 0) {
+        if(const auto preset = m_presetRegistry->itemById(dspPresetId)) {
+            return preset->chain;
+        }
+    }
+
+    return m_chainStore->activeChain();
+}
+
+std::pair<QString, QString> OutputProfileManager::parseCurrentOutput() const
+{
+    const QStringList parts = m_settings->value<Settings::Core::AudioOutput>().split(u'|');
+    if(!parts.empty() && parts.size() >= 2) {
+        return {parts.value(0), parts.value(1)};
+    }
+
+    const auto outputs = m_engine->getAllOutputs();
+    if(!outputs.empty()) {
+        const auto devices = m_engine->getOutputDevices(outputs.front());
+        if(!devices.empty()) {
+            return {outputs.front(), devices.front().name};
+        }
+    }
+
+    return {};
+}
+} // namespace Fooyin
+
+#include "moc_outputprofilemanager.cpp"

--- a/src/gui/output/outputprofilemanager.h
+++ b/src/gui/output/outputprofilemanager.h
@@ -1,0 +1,80 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/enginecontroller.h>
+
+#include <QObject>
+
+#include <optional>
+
+namespace Fooyin {
+class DspChainStore;
+class DspPresetRegistry;
+class EngineController;
+class SettingsManager;
+
+class OutputProfileManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    struct DeviceEntry
+    {
+        QString output;
+        QString device;
+        QString description;
+        bool enabled{true};
+        SampleFormat bitDepth{SampleFormat::Unknown};
+        bool dither{false};
+        int dspPresetId{-1};
+    };
+
+    OutputProfileManager(EngineController* engine, DspChainStore* chainStore, DspPresetRegistry* presetRegistry,
+                         SettingsManager* settings, QObject* parent = nullptr);
+
+    [[nodiscard]] OutputNames outputs() const;
+    [[nodiscard]] QString currentOutput() const;
+    [[nodiscard]] QString currentDevice() const;
+    [[nodiscard]] std::vector<DeviceEntry> deviceEntries(const QString& output) const;
+
+    void setProfiles(const QString& output, const Engine::OutputDeviceProfiles& profiles);
+    void clearProfiles();
+    bool applyProfile(const QString& output, const QString& device);
+    void reapplyCurrentProfile();
+
+signals:
+    void profilesChanged(const QString& output);
+    void currentOutputChanged(const QString& output, const QString& device);
+
+private:
+    [[nodiscard]] Engine::OutputDeviceProfiles profiles() const;
+    void storeProfiles(const Engine::OutputDeviceProfiles& profiles);
+    [[nodiscard]] std::optional<Engine::OutputDeviceProfile> profileFor(const QString& output,
+                                                                        const QString& device) const;
+    [[nodiscard]] Engine::DspChains resolveChain(int dspPresetId) const;
+    [[nodiscard]] std::pair<QString, QString> parseCurrentOutput() const;
+
+    EngineController* m_engine;
+    DspChainStore* m_chainStore;
+    DspPresetRegistry* m_presetRegistry;
+    SettingsManager* m_settings;
+};
+} // namespace Fooyin

--- a/src/gui/settings/playback/devicepage.cpp
+++ b/src/gui/settings/playback/devicepage.cpp
@@ -1,0 +1,278 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "devicepage.h"
+
+#include "dsp/dsppresetregistry.h"
+#include "output/outputprofilemanager.h"
+#include "outputdevicesdelegate.h"
+#include "outputdevicesmodel.h"
+
+#include <gui/guiconstants.h>
+#include <gui/widgets/expandingcombobox.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QComboBox>
+#include <QGridLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QResizeEvent>
+#include <QSignalBlocker>
+#include <QTableView>
+
+#include <algorithm>
+#include <map>
+#include <optional>
+
+using namespace Qt::StringLiterals;
+
+namespace {
+std::optional<Fooyin::Engine::OutputDeviceProfile>
+profileForDevice(const Fooyin::Engine::OutputDeviceProfiles& profiles, const QString& device)
+{
+    const auto it = std::ranges::find(profiles, device, &Fooyin::Engine::OutputDeviceProfile::device);
+    if(it != profiles.cend()) {
+        return *it;
+    }
+
+    return {};
+}
+} // namespace
+
+namespace Fooyin {
+class DevicePageWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    DevicePageWidget(OutputProfileManager* profileManager, DspPresetRegistry* presetRegistry);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    void storeCurrentOutput();
+    void loadOutput(const QString& output);
+    void updateColumnWidths();
+
+    OutputProfileManager* m_profileManager;
+    ExpandingComboBox* m_outputBox;
+    QTableView* m_devices;
+    OutputDevicesModel* m_model;
+
+    std::map<QString, Engine::OutputDeviceProfiles> m_profilesByOutput;
+    std::map<QString, Engine::OutputDeviceProfiles> m_loadedProfilesByOutput;
+};
+
+DevicePageWidget::DevicePageWidget(OutputProfileManager* profileManager, DspPresetRegistry* presetRegistry)
+    : m_profileManager{profileManager}
+    , m_outputBox{new ExpandingComboBox(this)}
+    , m_devices{new QTableView(this)}
+    , m_model{new OutputDevicesModel(presetRegistry, this)}
+{
+    m_devices->setModel(m_model);
+    m_devices->setItemDelegateForColumn(OutputDevicesModel::DspColumn,
+                                        new DspPresetDelegate(presetRegistry, m_devices));
+    m_devices->setItemDelegateForColumn(OutputDevicesModel::BitsColumn, new BitdepthDelegate(m_devices));
+    m_devices->horizontalHeader()->setStretchLastSection(false);
+    m_devices->horizontalHeader()->setSectionResizeMode(OutputDevicesModel::DeviceColumn, QHeaderView::Stretch);
+    m_devices->horizontalHeader()->setSectionResizeMode(OutputDevicesModel::DspColumn, QHeaderView::Interactive);
+    m_devices->horizontalHeader()->setSectionResizeMode(OutputDevicesModel::BitsColumn, QHeaderView::Interactive);
+    m_devices->verticalHeader()->hide();
+
+    auto* hint
+        = new QLabel(u"🛈 "_s + tr("Only checked devices will appear in the output device selector widget."), this);
+    hint->setWordWrap(true);
+
+    auto* layout = new QGridLayout(this);
+
+    int row{0};
+    layout->addWidget(new QLabel(tr("Output") + u":"_s, this), row, 0);
+    layout->addWidget(m_outputBox, row++, 1);
+    layout->addWidget(m_devices, row++, 0, 1, 2);
+    layout->addWidget(hint, row++, 0, 1, 2);
+    layout->setColumnStretch(1, 1);
+    layout->setRowStretch(1, 1);
+
+    QObject::connect(m_outputBox, &QComboBox::currentTextChanged, this, [this](const QString& output) {
+        storeCurrentOutput();
+        loadOutput(output);
+    });
+
+    updateColumnWidths();
+}
+
+void DevicePageWidget::load()
+{
+    m_profilesByOutput.clear();
+    m_loadedProfilesByOutput.clear();
+    m_model->setEntries({});
+
+    const QSignalBlocker blocker{m_outputBox};
+    m_outputBox->clear();
+
+    const auto outputs = m_profileManager->outputs();
+    for(const auto& output : outputs) {
+        m_outputBox->addItem(output);
+
+        const auto entries = m_profileManager->deviceEntries(output);
+
+        Engine::OutputDeviceProfiles profiles;
+        profiles.reserve(entries.size());
+
+        for(const auto& entry : entries) {
+            profiles.push_back({
+                .output      = output,
+                .device      = entry.device,
+                .enabled     = entry.enabled,
+                .bitDepth    = entry.bitDepth,
+                .dither      = entry.dither,
+                .dspPresetId = entry.dspPresetId,
+            });
+        }
+
+        m_loadedProfilesByOutput.emplace(output, profiles);
+        m_profilesByOutput.emplace(output, std::move(profiles));
+    }
+
+    if(m_outputBox->count() <= 0) {
+        return;
+    }
+
+    int currentIndex = m_outputBox->findText(m_profileManager->currentOutput());
+    currentIndex     = std::max(currentIndex, 0);
+
+    m_outputBox->setCurrentIndex(currentIndex);
+    loadOutput(m_outputBox->currentText());
+}
+
+void DevicePageWidget::apply()
+{
+    storeCurrentOutput();
+
+    const QString currentOutput = m_profileManager->currentOutput();
+    const QString currentDevice = m_profileManager->currentDevice();
+
+    const auto loadedCurrentProfiles = m_loadedProfilesByOutput.find(currentOutput);
+    const auto currentProfiles       = m_profilesByOutput.find(currentOutput);
+
+    const auto loadedCurrentProfile = (loadedCurrentProfiles != m_loadedProfilesByOutput.cend())
+                                        ? profileForDevice(loadedCurrentProfiles->second, currentDevice)
+                                        : std::optional<Engine::OutputDeviceProfile>{};
+    const auto currentProfile       = (currentProfiles != m_profilesByOutput.cend())
+                                        ? profileForDevice(currentProfiles->second, currentDevice)
+                                        : std::optional<Engine::OutputDeviceProfile>{};
+
+    const auto oldBitDepth = loadedCurrentProfile ? loadedCurrentProfile->bitDepth : SampleFormat::Unknown;
+    const auto newBitDepth = currentProfile ? currentProfile->bitDepth : SampleFormat::Unknown;
+    const bool oldDither   = loadedCurrentProfile ? loadedCurrentProfile->dither : false;
+    const bool newDither   = currentProfile ? currentProfile->dither : false;
+    const int oldPreset    = loadedCurrentProfile ? loadedCurrentProfile->dspPresetId : -1;
+    const int newPreset    = currentProfile ? currentProfile->dspPresetId : -1;
+
+    const bool audioSettingsChanged = oldBitDepth != newBitDepth || oldDither != newDither || oldPreset != newPreset;
+
+    bool profilesChanged{false};
+    for(const auto& [output, profiles] : m_profilesByOutput) {
+        const auto loadedIt = m_loadedProfilesByOutput.find(output);
+        const auto loadedProfiles
+            = (loadedIt != m_loadedProfilesByOutput.cend()) ? loadedIt->second : Engine::OutputDeviceProfiles{};
+
+        if(profiles == loadedProfiles) {
+            continue;
+        }
+
+        m_profileManager->setProfiles(output, profiles);
+        profilesChanged = true;
+    }
+
+    if(profilesChanged) {
+        m_loadedProfilesByOutput = m_profilesByOutput;
+    }
+
+    if(audioSettingsChanged) {
+        m_profileManager->reapplyCurrentProfile();
+    }
+}
+
+void DevicePageWidget::reset()
+{
+    m_profileManager->clearProfiles();
+    load();
+}
+
+void DevicePageWidget::storeCurrentOutput()
+{
+    const QString output = m_outputBox->currentText();
+    if(output.isEmpty()) {
+        return;
+    }
+
+    m_profilesByOutput[output] = m_model->profiles(output);
+}
+
+void DevicePageWidget::loadOutput(const QString& output)
+{
+    if(output.isEmpty()) {
+        m_model->setEntries({});
+        return;
+    }
+
+    auto entries = m_profileManager->deviceEntries(output);
+    if(const auto it = m_profilesByOutput.find(output); it != m_profilesByOutput.end()) {
+        std::map<QString, Engine::OutputDeviceProfile> overrides;
+        for(const auto& profile : it->second) {
+            overrides.emplace(profile.device, profile);
+        }
+
+        for(auto& entry : entries) {
+            if(const auto overrideIt = overrides.find(entry.device); overrideIt != overrides.end()) {
+                const auto& profile = overrideIt->second;
+                entry.enabled       = profile.enabled;
+                entry.bitDepth      = profile.bitDepth;
+                entry.dither        = profile.dither;
+                entry.dspPresetId   = profile.dspPresetId;
+            }
+        }
+    }
+
+    m_model->setEntries(entries);
+    updateColumnWidths();
+}
+
+void DevicePageWidget::updateColumnWidths()
+{
+    m_devices->resizeColumnToContents(OutputDevicesModel::DspColumn);
+    m_devices->resizeColumnToContents(OutputDevicesModel::BitsColumn);
+}
+
+DevicePage::DevicePage(OutputProfileManager* profileManager, DspPresetRegistry* presetRegistry,
+                       SettingsManager* settings, QObject* parent)
+    : SettingsPage{settings->settingsDialog(), parent}
+{
+    setId(Id{Constants::Page::OutputDevices});
+    setName(tr("Devices"));
+    setCategory({tr("Playback"), tr("Output"), tr("Devices")});
+    setWidgetCreator([profileManager, presetRegistry] { return new DevicePageWidget(profileManager, presetRegistry); });
+}
+} // namespace Fooyin
+
+#include "devicepage.moc"
+#include "moc_devicepage.cpp"

--- a/src/gui/settings/playback/devicepage.h
+++ b/src/gui/settings/playback/devicepage.h
@@ -1,0 +1,37 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/settings/settingspage.h>
+
+namespace Fooyin {
+class DspPresetRegistry;
+class OutputProfileManager;
+class SettingsManager;
+
+class DevicePage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    DevicePage(OutputProfileManager* profileManager, DspPresetRegistry* presetRegistry, SettingsManager* settings,
+               QObject* parent = nullptr);
+};
+} // namespace Fooyin

--- a/src/gui/settings/playback/outputdevicesdelegate.cpp
+++ b/src/gui/settings/playback/outputdevicesdelegate.cpp
@@ -1,0 +1,188 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "outputdevicesdelegate.h"
+
+#include "dsp/dsppresetregistry.h"
+#include "outputdevicesmodel.h"
+
+#include <core/engine/audioformat.h>
+#include <gui/widgets/expandingcombobox.h>
+
+#include <QComboBox>
+#include <QCoreApplication>
+
+#include <algorithm>
+
+using namespace Qt::StringLiterals;
+
+namespace {
+int widthForText(const QStyleOptionViewItem& option, const QString& text)
+{
+    return option.fontMetrics.horizontalAdvance(text) + 36; // Padding to account for editor combobox
+}
+
+int findBitdepthIndex(const QComboBox* box, int bitDepth, bool dither)
+{
+    if(!box) {
+        return -1;
+    }
+
+    for(int i{0}; i < box->count(); ++i) {
+        if(box->itemData(i).toInt() == bitDepth && box->itemData(i, Qt::UserRole + 1).toBool() == dither) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+} // namespace
+
+namespace Fooyin {
+DspPresetDelegate::DspPresetDelegate(DspPresetRegistry* presetRegistry, QObject* parent)
+    : QStyledItemDelegate{parent}
+    , m_presetRegistry{presetRegistry}
+{ }
+
+QWidget* DspPresetDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/,
+                                         const QModelIndex& index) const
+{
+    auto* box = new QComboBox(parent);
+    box->addItem(tr("<not set>"), -1);
+
+    const auto presets = m_presetRegistry->items();
+    for(const auto& preset : presets) {
+        box->addItem(preset.name, preset.id);
+    }
+
+    const int dspPresetId = index.data(Qt::EditRole).toInt();
+    const int itemIndex   = std::max(0, box->findData(dspPresetId));
+    box->setCurrentIndex(itemIndex);
+
+    return box;
+}
+
+QSize DspPresetDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    QSize hint = QStyledItemDelegate::sizeHint(option, index);
+    int width  = widthForText(option, tr("<not set>"));
+
+    const auto presets = m_presetRegistry->items();
+    for(const auto& preset : presets) {
+        width = std::max(width, widthForText(option, preset.name));
+    }
+
+    hint.setWidth(std::max(hint.width(), width));
+    return hint;
+}
+
+void DspPresetDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const
+{
+    auto* box = qobject_cast<QComboBox*>(editor);
+    if(!box) {
+        return;
+    }
+
+    const int dspPresetId = index.data(Qt::EditRole).toInt();
+    const int itemIndex   = std::max(0, box->findData(dspPresetId));
+    box->setCurrentIndex(itemIndex);
+}
+
+void DspPresetDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    auto* box = qobject_cast<QComboBox*>(editor);
+    if(!box) {
+        return;
+    }
+
+    model->setData(index, box->currentData(), Qt::EditRole);
+}
+
+BitdepthDelegate::BitdepthDelegate(QObject* parent)
+    : QStyledItemDelegate{parent}
+{ }
+
+QWidget* BitdepthDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/,
+                                        const QModelIndex& index) const
+{
+    auto* box = new ExpandingComboBox(parent);
+    populate(box, index.data(OutputDevicesModel::BitdepthOptionsRole).value<BitdepthOptions>());
+
+    const int bitDepth = index.data(OutputDevicesModel::BitDepthRole).toInt();
+    const bool dither  = index.data(OutputDevicesModel::DitherRole).toBool();
+
+    const int itemIndex = findBitdepthIndex(box, bitDepth, dither);
+    box->setCurrentIndex(itemIndex >= 0 ? itemIndex : 0);
+
+    box->resizeDropDown();
+    return box;
+}
+
+QSize BitdepthDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    QSize hint = QStyledItemDelegate::sizeHint(option, index);
+    int width{0};
+
+    const auto options = index.data(OutputDevicesModel::BitdepthOptionsRole).value<BitdepthOptions>();
+    for(const auto& bitdepthOption : options) {
+        width = std::max(width, widthForText(option, bitdepthOption.text));
+    }
+
+    hint.setWidth(std::max(hint.width(), width));
+    return hint;
+}
+
+void BitdepthDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const
+{
+    auto* box = qobject_cast<QComboBox*>(editor);
+    if(!box) {
+        return;
+    }
+
+    const int bitDepth = index.data(OutputDevicesModel::BitDepthRole).toInt();
+    const bool dither  = index.data(OutputDevicesModel::DitherRole).toBool();
+
+    const int itemIndex = findBitdepthIndex(box, bitDepth, dither);
+    box->setCurrentIndex(itemIndex >= 0 ? itemIndex : 0);
+}
+
+void BitdepthDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    auto* box = qobject_cast<QComboBox*>(editor);
+    if(!box) {
+        return;
+    }
+
+    model->setData(index,
+                   QVariant::fromValue(BitdepthOption{
+                       .text     = box->currentText(),
+                       .bitDepth = static_cast<SampleFormat>(box->currentData().toInt()),
+                       .dither   = box->currentData(Qt::UserRole + 1).toBool(),
+                   }),
+                   OutputDevicesModel::BitdepthSelectionRole);
+}
+
+void BitdepthDelegate::populate(QComboBox* box, const BitdepthOptions& options)
+{
+    for(const auto& option : options) {
+        box->addItem(option.text, static_cast<int>(option.bitDepth));
+        box->setItemData(box->count() - 1, option.dither, Qt::UserRole + 1);
+    }
+}
+} // namespace Fooyin

--- a/src/gui/settings/playback/outputdevicesdelegate.h
+++ b/src/gui/settings/playback/outputdevicesdelegate.h
@@ -1,0 +1,64 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "outputdevicesmodel.h"
+
+#include <QStyledItemDelegate>
+
+class QComboBox;
+
+namespace Fooyin {
+class DspPresetRegistry;
+
+class DspPresetDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit DspPresetDelegate(DspPresetRegistry* presetRegistry, QObject* parent = nullptr);
+
+    [[nodiscard]] QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                                        const QModelIndex& index) const override;
+    [[nodiscard]] QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+    void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+    void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
+
+private:
+    DspPresetRegistry* m_presetRegistry;
+};
+
+class BitdepthDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit BitdepthDelegate(QObject* parent = nullptr);
+
+    [[nodiscard]] QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                                        const QModelIndex& index) const override;
+    [[nodiscard]] QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+    void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+    void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
+
+private:
+    static void populate(QComboBox* box, const BitdepthOptions& options);
+};
+} // namespace Fooyin

--- a/src/gui/settings/playback/outputdevicesmodel.cpp
+++ b/src/gui/settings/playback/outputdevicesmodel.cpp
@@ -1,0 +1,306 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "outputdevicesmodel.h"
+
+#include "dsp/dsppresetregistry.h"
+
+#include <core/engine/audioformat.h>
+
+#include <QCoreApplication>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+OutputDevicesModel::OutputDevicesModel(DspPresetRegistry* presetRegistry, QObject* parent)
+    : QAbstractTableModel{parent}
+    , m_presetRegistry{presetRegistry}
+{ }
+
+int OutputDevicesModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+}
+
+int OutputDevicesModel::columnCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : ColumnCount;
+}
+
+QVariant OutputDevicesModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation != Qt::Horizontal || role != Qt::DisplayRole) {
+        return {};
+    }
+
+    switch(section) {
+        case DeviceColumn:
+            //: Audio output device
+            return tr("Device");
+        case DspColumn:
+            //: DSP chain set for an audio output device
+            return tr("DSP");
+        case BitsColumn:
+            return tr("Bitdepth");
+        default:
+            return {};
+    }
+}
+
+QVariant OutputDevicesModel::data(const QModelIndex& index, int role) const
+{
+    if(!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_rows.size())) {
+        return {};
+    }
+
+    const auto& row = m_rows.at(static_cast<size_t>(index.row()));
+
+    if(role == Qt::TextAlignmentRole) {
+        switch(index.column()) {
+            case DeviceColumn:
+                return {Qt::AlignVCenter | Qt::AlignLeft};
+            case DspColumn:
+            case BitsColumn:
+                return Qt::AlignCenter;
+            default:
+                break;
+        }
+    }
+
+    switch(index.column()) {
+        case DeviceColumn:
+            if(role == Qt::DisplayRole) {
+                return row.description;
+            }
+            if(role == Qt::CheckStateRole) {
+                return row.enabled ? Qt::Checked : Qt::Unchecked;
+            }
+            if(role == DeviceIdRole) {
+                return row.device;
+            }
+            break;
+        case DspColumn:
+            if(role == Qt::DisplayRole) {
+                return presetText(row.dspPresetId);
+            }
+            if(role == Qt::EditRole || role == DspPresetIdRole) {
+                return row.dspPresetId;
+            }
+            break;
+        case BitsColumn:
+            if(role == Qt::DisplayRole) {
+                return bitDepthText(row.bitDepth, row.dither);
+            }
+            if(role == BitdepthSelectionRole) {
+                return QVariant::fromValue(BitdepthOption{
+                    .text     = bitDepthText(row.bitDepth, row.dither),
+                    .bitDepth = row.bitDepth,
+                    .dither   = row.dither,
+                });
+            }
+            if(role == BitDepthRole) {
+                return static_cast<int>(row.bitDepth);
+            }
+            if(role == DitherRole) {
+                return row.dither;
+            }
+            if(role == BitdepthOptionsRole) {
+                return QVariant::fromValue(buildBitdepthOptions());
+            }
+            break;
+        default:
+            break;
+    }
+
+    return {};
+}
+
+bool OutputDevicesModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if(!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_rows.size())) {
+        return false;
+    }
+
+    auto& row = m_rows.at(static_cast<size_t>(index.row()));
+    switch(index.column()) {
+        case DeviceColumn:
+            if(role == Qt::CheckStateRole) {
+                const bool enabled = value.toInt() == Qt::Checked;
+                if(row.enabled == enabled) {
+                    return false;
+                }
+                row.enabled = enabled;
+                emit dataChanged(index, index, {Qt::CheckStateRole});
+                return true;
+            }
+            break;
+        case DspColumn:
+            if(role == Qt::EditRole || role == DspPresetIdRole) {
+                const int dspPresetId = value.toInt();
+                if(row.dspPresetId == dspPresetId) {
+                    return false;
+                }
+                row.dspPresetId = dspPresetId;
+                emit dataChanged(index, index, {Qt::DisplayRole, Qt::EditRole, DspPresetIdRole});
+                return true;
+            }
+            break;
+        case BitsColumn:
+            if(role == BitdepthSelectionRole) {
+                const auto option = value.value<BitdepthOption>();
+                if(row.bitDepth == option.bitDepth && row.dither == option.dither) {
+                    return false;
+                }
+
+                row.bitDepth = option.bitDepth;
+                row.dither   = row.bitDepth == SampleFormat::S16 && option.dither;
+                emit dataChanged(index, index, {Qt::DisplayRole, BitdepthSelectionRole, BitDepthRole, DitherRole});
+                return true;
+            }
+            if(role == BitDepthRole) {
+                const auto bitDepth = static_cast<SampleFormat>(value.toInt());
+                const bool changed  = row.bitDepth != bitDepth;
+                row.bitDepth        = bitDepth;
+                if(row.bitDepth != SampleFormat::S16) {
+                    row.dither = false;
+                }
+                if(changed) {
+                    emit dataChanged(index, index, {Qt::DisplayRole, BitDepthRole, DitherRole});
+                }
+                return changed;
+            }
+            if(role == DitherRole) {
+                const bool dither = row.bitDepth == SampleFormat::S16 && value.toBool();
+                if(row.dither == dither) {
+                    return false;
+                }
+                row.dither = dither;
+                emit dataChanged(index, index, {Qt::DisplayRole, DitherRole});
+                return true;
+            }
+            break;
+        default:
+            break;
+    }
+
+    return false;
+}
+
+Qt::ItemFlags OutputDevicesModel::flags(const QModelIndex& index) const
+{
+    if(!index.isValid()) {
+        return Qt::NoItemFlags;
+    }
+
+    auto itemFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    switch(index.column()) {
+        case DeviceColumn:
+            return itemFlags | Qt::ItemIsUserCheckable;
+        case DspColumn:
+        case BitsColumn:
+            return itemFlags | Qt::ItemIsEditable;
+        default:
+            return itemFlags;
+    }
+}
+
+void OutputDevicesModel::setEntries(const std::vector<OutputProfileManager::DeviceEntry>& entries)
+{
+    beginResetModel();
+    m_rows.clear();
+    m_rows.reserve(entries.size());
+
+    for(const auto& entry : entries) {
+        m_rows.push_back({
+            .device      = entry.device,
+            .description = entry.description,
+            .enabled     = entry.enabled,
+            .bitDepth    = entry.bitDepth,
+            .dither      = entry.dither,
+            .dspPresetId = entry.dspPresetId,
+        });
+    }
+
+    endResetModel();
+}
+
+Engine::OutputDeviceProfiles OutputDevicesModel::profiles(const QString& output) const
+{
+    Engine::OutputDeviceProfiles profiles;
+    profiles.reserve(m_rows.size());
+
+    for(const auto& row : m_rows) {
+        profiles.push_back({
+            .output      = output,
+            .device      = row.device,
+            .enabled     = row.enabled,
+            .bitDepth    = row.bitDepth,
+            .dither      = row.bitDepth == SampleFormat::S16 && row.dither,
+            .dspPresetId = row.dspPresetId,
+        });
+    }
+
+    return profiles;
+}
+QString OutputDevicesModel::presetText(int dspPresetId) const
+{
+    if(dspPresetId < 0) {
+        //: No DSP chain has been set for this output device
+        return tr("<not set>");
+    }
+
+    for(const auto& preset : m_presetRegistry->items()) {
+        if(preset.id == dspPresetId) {
+            return preset.name;
+        }
+    }
+
+    //: The DSP chain set for this output device can no longer be found
+    return tr("<missing>");
+}
+
+QString OutputDevicesModel::bitDepthText(SampleFormat bitDepth, bool dither)
+{
+    switch(bitDepth) {
+        case SampleFormat::S16:
+            return dither ? tr("16-bit (dithered)") : tr("16-bit");
+        case SampleFormat::S24In32:
+            return tr("24-bit");
+        case SampleFormat::S32:
+            return tr("32-bit");
+        case SampleFormat::F32:
+            return tr("32-bit float");
+        case SampleFormat::Unknown:
+        default:
+            return tr("Automatic");
+    }
+}
+
+BitdepthOptions OutputDevicesModel::buildBitdepthOptions()
+{
+    return {
+        {.text = tr("Automatic"), .bitDepth = SampleFormat::Unknown},
+        {.text = tr("16-bit"), .bitDepth = SampleFormat::S16},
+        {.text = tr("16-bit (dithered)"), .bitDepth = SampleFormat::S16, .dither = true},
+        {.text = tr("24-bit"), .bitDepth = SampleFormat::S24In32},
+        {.text = tr("32-bit"), .bitDepth = SampleFormat::S32},
+        {.text = tr("32-bit float"), .bitDepth = SampleFormat::F32},
+    };
+}
+} // namespace Fooyin

--- a/src/gui/settings/playback/outputdevicesmodel.h
+++ b/src/gui/settings/playback/outputdevicesmodel.h
@@ -1,0 +1,95 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "output/outputprofilemanager.h"
+
+#include <QAbstractTableModel>
+
+#include <vector>
+
+namespace Fooyin {
+class DspPresetRegistry;
+
+struct BitdepthOption
+{
+    QString text;
+    SampleFormat bitDepth{SampleFormat::Unknown};
+    bool dither{false};
+};
+using BitdepthOptions = std::vector<BitdepthOption>;
+
+class OutputDevicesModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    enum Column
+    {
+        DeviceColumn = 0,
+        DspColumn,
+        BitsColumn,
+        ColumnCount
+    };
+
+    enum Role
+    {
+        DeviceIdRole = Qt::UserRole + 1,
+        DspPresetIdRole,
+        BitDepthRole,
+        DitherRole,
+        BitdepthOptionsRole,
+        BitdepthSelectionRole
+    };
+
+    explicit OutputDevicesModel(DspPresetRegistry* presetRegistry, QObject* parent = nullptr);
+
+    [[nodiscard]] int rowCount(const QModelIndex& parent) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+    void setEntries(const std::vector<OutputProfileManager::DeviceEntry>& entries);
+    [[nodiscard]] Engine::OutputDeviceProfiles profiles(const QString& output) const;
+
+private:
+    struct Row
+    {
+        QString device;
+        QString description;
+        bool enabled{true};
+        SampleFormat bitDepth{SampleFormat::Unknown};
+        bool dither{false};
+        int dspPresetId{-1};
+    };
+
+    [[nodiscard]] QString presetText(int dspPresetId) const;
+    static QString bitDepthText(SampleFormat bitDepth, bool dither);
+    static BitdepthOptions buildBitdepthOptions();
+
+    DspPresetRegistry* m_presetRegistry;
+    std::vector<Row> m_rows;
+};
+} // namespace Fooyin
+
+Q_DECLARE_METATYPE(Fooyin::BitdepthOptions)
+Q_DECLARE_METATYPE(Fooyin::BitdepthOption)

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -23,6 +23,7 @@
 #include "artwork/artworkfinder.h"
 #include "artwork/artworkproperties.h"
 #include "controls/commandbutton.h"
+#include "controls/outputselector.h"
 #include "controls/playercontrol.h"
 #include "controls/playlistcontrol.h"
 #include "controls/seekbar.h"
@@ -37,6 +38,7 @@
 #include "librarytree/librarytreecontroller.h"
 #include "librarytree/librarytreewidget.h"
 #include "mainwindow.h"
+#include "output/outputprofilemanager.h"
 #include "playlist/organiser/playlistorganiser.h"
 #include "playlist/playlistbox.h"
 #include "playlist/playlistcontroller.h"
@@ -61,6 +63,7 @@
 #include "settings/library/librarysortingpage.h"
 #include "settings/networkpage.h"
 #include "settings/playback/decoderpage.h"
+#include "settings/playback/devicepage.h"
 #include "settings/playback/dspmanagerpage.h"
 #include "settings/playback/fadingpage.h"
 #include "settings/playback/outputpage.h"
@@ -106,10 +109,14 @@ Widgets::Widgets(Application* core, MainWindow* window, GuiApplication* gui, Pla
     , m_playlistController{playlistInteractor->playlistController()}
     , m_libraryTreeController{new LibraryTreeController(m_settings, this)}
     , m_dspPresetRegistry{new DspPresetRegistry(m_settings, this)}
+    , m_outputProfileManager{new OutputProfileManager(m_core->engine(), m_core->dspChainStore(), m_dspPresetRegistry,
+                                                      m_settings, this)}
     , m_dspSettingsRegistry{std::make_unique<DspSettingsRegistry>()}
     , m_pluginSettingsRegistry{std::make_unique<PluginSettingsRegistry>()}
     , m_scriptCommandHandler{scriptCommandHandler}
-{ }
+{
+    m_outputProfileManager->reapplyCurrentProfile();
+}
 
 void Widgets::registerWidgets()
 {
@@ -208,6 +215,11 @@ void Widgets::registerWidgets()
     provider->setSubMenus(u"SeekBar"_s, {tr("Controls")});
 
     provider->registerWidget(
+        u"OutputSelector"_s, [this]() { return new OutputSelector(m_outputProfileManager, m_settings, m_window); },
+        tr("Output Selector"));
+    provider->setSubMenus(u"OutputSelector"_s, {tr("Controls")});
+
+    provider->registerWidget(
         u"SelectionInfo"_s, [this]() { return new InfoWidget(m_core, m_gui->trackSelection(), m_window); },
         tr("Selection Info"));
 
@@ -288,6 +300,7 @@ void Widgets::registerPages()
     new ShellIntegrationPage(m_settings, this);
     new ShortcutsPage(m_gui->actionManager(), m_settings, this);
     new OutputPage(m_core->engine(), m_settings, this);
+    new DevicePage(m_outputProfileManager, m_dspPresetRegistry, m_settings, this);
     new DecoderPage(m_core->audioLoader().get(), m_core->pluginManager(), m_pluginSettingsRegistry.get(), m_settings,
                     this);
     new ReplayGainPage(m_settings, this);

--- a/src/gui/widgets.h
+++ b/src/gui/widgets.h
@@ -37,6 +37,7 @@ class FyWidget;
 class GuiApplication;
 class LibraryTreeController;
 class MainWindow;
+class OutputProfileManager;
 class PlaylistController;
 class PlaylistInteractor;
 class ScriptCommandHandler;
@@ -80,6 +81,7 @@ private:
     PlaylistController* m_playlistController;
     LibraryTreeController* m_libraryTreeController;
     DspPresetRegistry* m_dspPresetRegistry;
+    OutputProfileManager* m_outputProfileManager;
     std::unique_ptr<DspSettingsRegistry> m_dspSettingsRegistry;
     std::unique_ptr<PluginSettingsRegistry> m_pluginSettingsRegistry;
     ScriptCommandHandler* m_scriptCommandHandler;

--- a/tests/core/engine/audioenginetest.cpp
+++ b/tests/core/engine/audioenginetest.cpp
@@ -1264,6 +1264,23 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, SetAudioOutputReinitializesLo
     ASSERT_TRUE(pumpUntil([&newOutputStats]() { return newOutputStats->initCalls.load() >= 1; }, 2000ms));
 }
 
+FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, SetOutputDeviceReinitialisesLoadedOutput)
+{
+    ensureCoreApplication();
+    EngineHarness harness{false};
+
+    const Track track = harness.createTrack(u"switch-device.fyt"_s, 0, 100000);
+    harness.engine.loadTrack(makePlaybackItem(track, 1), false);
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.trackStatus() == Engine::TrackStatus::Loaded; }));
+    ASSERT_EQ(harness.outputStats->initCalls.load(), 1);
+
+    harness.engine.setOutputDevice(u"hw:test"_s);
+
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.outputStats->uninitCalls.load() >= 1; }, 2000ms));
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.outputStats->initCalls.load() >= 2; }, 2000ms));
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.outputStats->device() == u"hw:test"_s; }, 2000ms));
+}
+
 FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, BufferLengthChangeReconfiguresPlaybackWithoutReinitialisingOutput)
 {
     ensureCoreApplication();


### PR DESCRIPTION
This adds a new `Output Selector` layout widget for switching between enabled devices.

<img width="345" height="160" alt="image" src="https://github.com/user-attachments/assets/0f5093aa-f124-442c-b4e6-54ebc5427f72" />

It also adds a new `Playback > Output > Devices` page for configuring per-device output behavior, including whether a device appears in the selector widget, which DSP preset it uses, and which bitdepth it applies. 

<img width="575" height="495" alt="image" src="https://github.com/user-attachments/assets/e237dcbf-2691-45f5-8a7d-017ee7cf3140" />

This change also fixes the output switching path so same-backend device changes fully reapply the selected output profile.