### PR TITLE
Added Tag Editor as UI Element

### DIFF
--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -65,19 +65,7 @@ Fooyin::FyWidget* findSplitterChild(QWidget* widget)
             return {};
         }
     }
-
-    // Walk up past any FyWidget that is embedded inside a non-container FyWidget parent.
-    // A true layout widget has a WidgetContainer (or no FyWidget) as its nearest FyWidget ancestor.
-    auto* fyChild = qobject_cast<Fooyin::FyWidget*>(child);
-    while(fyChild) {
-        auto* fyParent = fyChild->findParent();
-        if(!fyParent || qobject_cast<Fooyin::WidgetContainer*>(fyParent)) {
-            return fyChild;
-        }
-        fyChild = fyParent;
-    }
-
-    return {};
+    return qobject_cast<Fooyin::FyWidget*>(child);
 }
 } // namespace
 

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -65,7 +65,19 @@ Fooyin::FyWidget* findSplitterChild(QWidget* widget)
             return {};
         }
     }
-    return qobject_cast<Fooyin::FyWidget*>(child);
+
+    // Walk up past any FyWidget that is embedded inside a non-container FyWidget parent.
+    // A true layout widget has a WidgetContainer (or no FyWidget) as its nearest FyWidget ancestor.
+    auto* fyChild = qobject_cast<Fooyin::FyWidget*>(child);
+    while(fyChild) {
+        auto* fyParent = fyChild->findParent();
+        if(!fyParent || qobject_cast<Fooyin::WidgetContainer*>(fyParent)) {
+            return fyChild;
+        }
+        fyChild = fyParent;
+    }
+
+    return {};
 }
 } // namespace
 

--- a/src/plugins/tageditor/CMakeLists.txt
+++ b/src/plugins/tageditor/CMakeLists.txt
@@ -33,6 +33,4 @@ create_fooyin_plugin_internal(
             tageditorpropertiestab.h
             tageditorview.cpp
             tageditorview.h
-            tageditorwidget.cpp
-            tageditorwidget.h
 )

--- a/src/plugins/tageditor/CMakeLists.txt
+++ b/src/plugins/tageditor/CMakeLists.txt
@@ -21,6 +21,8 @@ create_fooyin_plugin_internal(
             tagfilloperation.h
             tagfilldialog.cpp
             tagfilldialog.h
+            tageditorpanel.cpp
+            tageditorpanel.h
             tagfillpreviewmodel.cpp
             tagfillpreviewmodel.h
             tageditorplugin.cpp
@@ -31,4 +33,6 @@ create_fooyin_plugin_internal(
             tageditorpropertiestab.h
             tageditorview.cpp
             tageditorview.h
+            tageditorwidget.cpp
+            tageditorwidget.h
 )

--- a/src/plugins/tageditor/tageditoreditor.cpp
+++ b/src/plugins/tageditor/tageditoreditor.cpp
@@ -27,6 +27,7 @@
 
 #include <core/constants.h>
 #include <core/coresettings.h>
+#include <gui/widgets/autoheaderview.h>
 #include <gui/widgets/multilinedelegate.h>
 #include <gui/widgets/toolbutton.h>
 #include <utils/actions/actionmanager.h>
@@ -36,13 +37,10 @@
 
 #include <QHeaderView>
 #include <QMenu>
+#include <QTimer>
 #include <QVBoxLayout>
 
-#include <ranges>
-
 using namespace Qt::StringLiterals;
-
-constexpr auto NameColumnWidth = "TagEditor/NameColumnWidth";
 
 namespace Fooyin::TagEditor {
 TagEditorEditor::TagEditorEditor(ActionManager* actionManager, TagEditorFieldRegistry* registry,
@@ -51,8 +49,10 @@ TagEditorEditor::TagEditorEditor(ActionManager* actionManager, TagEditorFieldReg
     , m_registry{registry}
     , m_settings{settings}
     , m_readOnly{false}
+    , m_firstReset{true}
     , m_view{new TagEditorView(actionManager, this)}
     , m_model{new TagEditorModel(settings, this)}
+    , m_header{new AutoHeaderView(Qt::Horizontal, this)}
     , m_autocompleteDelegate{new TagEditorAutocompleteDelegate(this)}
     , m_multilineDelegate{nullptr}
     , m_starDelegate{nullptr}
@@ -67,9 +67,10 @@ TagEditorEditor::TagEditorEditor(ActionManager* actionManager, TagEditorFieldReg
     layout->setContentsMargins({});
     layout->addWidget(m_view);
 
+    m_header->setStretchEnabled(true);
+    m_header->setStretchLastSection(true);
+    m_view->setHorizontalHeader(m_header);
     m_view->setExtendableModel(m_model);
-    m_view->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
-    m_view->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
     m_view->setItemDelegateForColumn(1, m_autocompleteDelegate);
     m_view->setupActions();
 
@@ -83,18 +84,22 @@ TagEditorEditor::TagEditorEditor(ActionManager* actionManager, TagEditorFieldReg
     m_toolsButton->setMenu(toolsMenu);
     m_view->addCustomTool(m_toolsButton);
 
+    QObject::connect(m_header, &AutoHeaderView::stateRestored, this, [this]() { m_firstReset = false; });
     QObject::connect(m_model, &QAbstractItemModel::rowsInserted, m_view, &QTableView::resizeRowsToContents);
     QObject::connect(
         m_model, &QAbstractItemModel::modelReset, this,
         [this]() {
-            m_view->resizeColumnsForContents();
             m_view->resizeRowsToContents();
-            restoreState();
+
+            if(m_firstReset) {
+                m_firstReset = false;
+                QTimer::singleShot(0, this, [this]() { m_header->resizeColumnToContents(0); });
+            }
         },
         Qt::QueuedConnection);
-    QObject::connect(m_model, &QAbstractItemModel::dataChanged, this, [this]() { updatePendingScopeState(); });
-    QObject::connect(m_model, &QAbstractItemModel::rowsInserted, this, [this]() { updatePendingScopeState(); });
-    QObject::connect(m_model, &QAbstractItemModel::rowsRemoved, this, [this]() { updatePendingScopeState(); });
+    QObject::connect(m_model, &QAbstractItemModel::dataChanged, this, &TagEditorEditor::updatePendingScopeState);
+    QObject::connect(m_model, &QAbstractItemModel::rowsInserted, this, &TagEditorEditor::updatePendingScopeState);
+    QObject::connect(m_model, &QAbstractItemModel::rowsRemoved, this, &TagEditorEditor::updatePendingScopeState);
     QObject::connect(m_view->selectionModel(), &QItemSelectionModel::selectionChanged, this, [this]() {
         const QModelIndexList selected = m_view->selectionModel()->selectedIndexes();
         m_view->removeRowAction()->setEnabled(!m_readOnly && !selected.empty());
@@ -103,11 +108,6 @@ TagEditorEditor::TagEditorEditor(ActionManager* actionManager, TagEditorFieldReg
     QObject::connect(m_autoFillValuesAction, &QAction::triggered, this, &TagEditorEditor::autoFillValuesRequested);
     QObject::connect(m_changeFields, &QAction::triggered, this,
                      [this]() { m_settings->settingsDialog()->openAtPage(Constants::Page::TagEditorFields); });
-}
-
-TagEditorEditor::~TagEditorEditor()
-{
-    saveState();
 }
 
 void TagEditorEditor::setTracks(const TrackList& tracks)
@@ -209,28 +209,19 @@ TrackList TagEditorEditor::applyChanges()
     return m_model->tracks();
 }
 
+void TagEditorEditor::addTool(QWidget* widget)
+{
+    m_view->addCustomTool(widget);
+}
+
+AutoHeaderView* TagEditorEditor::header() const
+{
+    return m_header;
+}
+
 void TagEditorEditor::updatePendingScopeState()
 {
     Q_EMIT pendingChangesStateChanged();
-}
-
-void TagEditorEditor::saveState() const
-{
-    FyStateSettings stateSettings;
-    stateSettings.setValue(NameColumnWidth, m_view->horizontalHeader()->sectionSize(0));
-}
-
-void TagEditorEditor::restoreState() const
-{
-    const FyStateSettings stateSettings;
-    const int nameColumnWidth        = stateSettings.value(NameColumnWidth).toInt();
-    const int minimumRestorableWidth = m_view->horizontalHeader()->sectionSizeHint(0);
-
-    if(nameColumnWidth > minimumRestorableWidth) {
-        m_view->horizontalHeader()->resizeSection(0, nameColumnWidth);
-    }
-
-    m_view->normaliseColumnWidths();
 }
 } // namespace Fooyin::TagEditor
 

--- a/src/plugins/tageditor/tageditoreditor.h
+++ b/src/plugins/tageditor/tageditoreditor.h
@@ -23,10 +23,12 @@
 
 #include <core/track.h>
 
+#include <QString>
 #include <QWidget>
 
 namespace Fooyin {
 class ActionManager;
+class AutoHeaderView;
 class MultiLineEditDelegate;
 class SettingsManager;
 class StarDelegate;
@@ -46,7 +48,6 @@ class TagEditorEditor : public QWidget
 public:
     explicit TagEditorEditor(ActionManager* actionManager, TagEditorFieldRegistry* registry, SettingsManager* settings,
                              QWidget* parent = nullptr);
-    ~TagEditorEditor() override;
 
     void setTracks(const TrackList& tracks);
     void setReadOnly(bool readOnly);
@@ -54,6 +55,10 @@ public:
     [[nodiscard]] bool hasOnlyStatChanges() const;
     [[nodiscard]] TrackList tracks() const;
     TrackList applyChanges();
+
+    void addTool(QWidget* widget);
+
+    [[nodiscard]] AutoHeaderView* header() const;
 
 Q_SIGNALS:
     void pendingChangesStateChanged();
@@ -64,15 +69,14 @@ private:
     void refreshModel();
     void updatePendingScopeState();
 
-    void saveState() const;
-    void restoreState() const;
-
     TagEditorFieldRegistry* m_registry;
     SettingsManager* m_settings;
 
     bool m_readOnly;
+    bool m_firstReset;
     TagEditorView* m_view;
     TagEditorModel* m_model;
+    AutoHeaderView* m_header;
 
     TrackList m_tracks;
 

--- a/src/plugins/tageditor/tageditorpanel.cpp
+++ b/src/plugins/tageditor/tageditorpanel.cpp
@@ -1,0 +1,126 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "tageditorpanel.h"
+
+#include "tageditorwidget.h"
+
+#include <core/engine/audioloader.h>
+#include <core/library/musiclibrary.h>
+#include <core/track.h>
+#include <gui/trackselectioncontroller.h>
+
+#include <QMessageBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::TagEditor {
+
+TagEditorPanel::TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry,
+                               MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
+                               TrackSelectionController* selectionController,
+                               SettingsManager* settings, QWidget* parent)
+    : FyWidget{parent}
+    , m_library{library}
+    , m_audioLoader{std::move(audioLoader)}
+    , m_selectionController{selectionController}
+    , m_editor{new TagEditorWidget(actionManager, registry, settings, this)}
+{
+    setObjectName(TagEditorPanel::name());
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins({});
+    layout->addWidget(m_editor);
+
+    auto* applyButton = new QPushButton(tr("Apply"), this);
+    layout->addWidget(applyButton);
+
+    QObject::connect(applyButton, &QPushButton::clicked, m_editor, &TagEditorWidget::apply);
+    QObject::connect(m_editor, &TagEditorWidget::trackMetadataChanged,
+                     m_library, &MusicLibrary::writeTrackMetadata);
+    QObject::connect(m_editor, &TagEditorWidget::trackStatsChanged, m_library,
+                     [this](const TrackList& tracks) { m_library->updateTrackStats(tracks); });
+    QObject::connect(m_selectionController, &TrackSelectionController::selectionChanged,
+                     this, &TagEditorPanel::selectionChanged);
+
+    selectionChanged();
+}
+
+QString TagEditorPanel::name() const
+{
+    return u"Tag Editor"_s;
+}
+
+QString TagEditorPanel::layoutName() const
+{
+    return u"TagEditorPanel"_s;
+}
+
+void TagEditorPanel::selectionChanged()
+{
+    const TrackList newTracks = m_selectionController->selectedTracks();
+
+    // Ignore empty selections: focus moving to a widget with no registered track context
+    // (e.g. the Apply button) makes selectedTracks() return empty. Keep displaying the
+    // current tracks in that case rather than clearing the editor or showing a save dialog.
+    if(newTracks.empty() && !m_currentTracks.empty()) {
+        return;
+    }
+
+    const bool tracksActuallyChanged
+        = newTracks.size() != m_currentTracks.size()
+          || !std::ranges::equal(newTracks, m_currentTracks,
+                                 [](const Track& a, const Track& b) { return a.id() == b.id(); });
+
+    if(tracksActuallyChanged && m_editor->hasPendingScopeChanges()) {
+        const int result = QMessageBox::question(
+            this, tr("Unsaved Changes"),
+            tr("There are unsaved tag changes. Save before switching tracks?"),
+            QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel,
+            QMessageBox::Save);
+
+        if(result == QMessageBox::Cancel) {
+            return;
+        }
+        if(result == QMessageBox::Save) {
+            m_editor->apply();
+        }
+    }
+
+    updateForTracks(newTracks);
+}
+
+void TagEditorPanel::updateForTracks(const TrackList& tracks)
+{
+    m_currentTracks = tracks;
+
+    const bool canWrite = !tracks.empty()
+                          && std::ranges::all_of(tracks, [this](const Track& track) {
+                                 return !track.hasCue() && !track.isInArchive()
+                                        && m_audioLoader->canWriteMetadata(track);
+                             });
+    m_editor->setReadOnly(!canWrite);
+    m_editor->setTracks(tracks);
+}
+
+} // namespace Fooyin::TagEditor
+
+#include "moc_tageditorpanel.cpp"

--- a/src/plugins/tageditor/tageditorpanel.cpp
+++ b/src/plugins/tageditor/tageditorpanel.cpp
@@ -19,47 +19,47 @@
 
 #include "tageditorpanel.h"
 
-#include "tageditorwidget.h"
+#include "tageditoreditor.h"
 
 #include <core/engine/audioloader.h>
 #include <core/library/musiclibrary.h>
 #include <core/track.h>
 #include <gui/trackselectioncontroller.h>
+#include <gui/widgets/autoheaderview.h>
+#include <utils/settings/settingsmanager.h>
 
+#include <QCheckBox>
+#include <QJsonObject>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QVBoxLayout>
 
 using namespace Qt::StringLiterals;
 
-namespace Fooyin::TagEditor {
+constexpr auto DontAskAgain = "TagEditor/DontAskAgain";
 
-TagEditorPanel::TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry,
-                               MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
-                               TrackSelectionController* selectionController,
+namespace Fooyin::TagEditor {
+TagEditorPanel::TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry, MusicLibrary* library,
+                               std::shared_ptr<AudioLoader> audioLoader, TrackSelectionController* selectionController,
                                SettingsManager* settings, QWidget* parent)
     : FyWidget{parent}
     , m_library{library}
     , m_audioLoader{std::move(audioLoader)}
     , m_selectionController{selectionController}
-    , m_editor{new TagEditorWidget(actionManager, registry, settings, this)}
+    , m_settings{settings}
+    , m_editor{new TagEditorEditor(actionManager, registry, settings, this)}
+    , m_applyButton{new QPushButton(tr("Apply"), this)}
 {
     setObjectName(TagEditorPanel::name());
 
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins({});
     layout->addWidget(m_editor);
+    m_editor->addTool(m_applyButton);
 
-    auto* applyButton = new QPushButton(tr("Apply"), this);
-    layout->addWidget(applyButton);
-
-    QObject::connect(applyButton, &QPushButton::clicked, m_editor, &TagEditorWidget::apply);
-    QObject::connect(m_editor, &TagEditorWidget::trackMetadataChanged,
-                     m_library, &MusicLibrary::writeTrackMetadata);
-    QObject::connect(m_editor, &TagEditorWidget::trackStatsChanged, m_library,
-                     [this](const TrackList& tracks) { m_library->updateTrackStats(tracks); });
-    QObject::connect(m_selectionController, &TrackSelectionController::selectionChanged,
-                     this, &TagEditorPanel::selectionChanged);
+    QObject::connect(m_applyButton, &QPushButton::clicked, this, &TagEditorPanel::apply);
+    QObject::connect(m_selectionController, &TrackSelectionController::selectionChanged, this,
+                     &TagEditorPanel::selectionChanged);
 
     selectionChanged();
 }
@@ -72,6 +72,26 @@ QString TagEditorPanel::name() const
 QString TagEditorPanel::layoutName() const
 {
     return u"TagEditorPanel"_s;
+}
+
+void TagEditorPanel::saveLayoutData(QJsonObject& layout)
+{
+    QByteArray state         = m_editor->header()->saveHeaderState();
+    state                    = qCompress(state, 9);
+    layout["HeaderState"_L1] = QString::fromUtf8(state.toBase64());
+}
+
+void TagEditorPanel::loadLayoutData(const QJsonObject& layout)
+{
+    if(layout.contains("HeaderState"_L1)) {
+        const auto headerState = layout.value("HeaderState"_L1).toString().toUtf8();
+
+        if(!headerState.isEmpty() && headerState.isValidUtf8()) {
+            auto state = QByteArray::fromBase64(headerState);
+            state      = qUncompress(state);
+            m_editor->header()->restoreHeaderState(state);
+        }
+    }
 }
 
 void TagEditorPanel::selectionChanged()
@@ -87,36 +107,73 @@ void TagEditorPanel::selectionChanged()
 
     const bool tracksActuallyChanged
         = newTracks.size() != m_currentTracks.size()
-          || !std::ranges::equal(newTracks, m_currentTracks,
-                                 [](const Track& a, const Track& b) { return a.id() == b.id(); });
+       || !std::ranges::equal(newTracks, m_currentTracks,
+                              [](const Track& a, const Track& b) { return a.id() == b.id(); });
 
-    if(tracksActuallyChanged && m_editor->hasPendingScopeChanges()) {
-        const int result = QMessageBox::question(
-            this, tr("Unsaved Changes"),
-            tr("There are unsaved tag changes. Save before switching tracks?"),
-            QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel,
-            QMessageBox::Save);
+    if(tracksActuallyChanged && m_editor->hasChanges()) {
+        const int result = QMessageBox::question(this, tr("Unsaved Changes"),
+                                                 tr("There are unsaved tag changes. Save before switching tracks?"),
+                                                 QMessageBox::Save | QMessageBox::Discard, QMessageBox::Save);
 
-        if(result == QMessageBox::Cancel) {
+        if(result == QMessageBox::Save && !apply()) {
             return;
-        }
-        if(result == QMessageBox::Save) {
-            m_editor->apply();
         }
     }
 
     updateForTracks(newTracks);
 }
 
+bool TagEditorPanel::apply()
+{
+    if(!m_editor->hasChanges()) {
+        return true;
+    }
+
+    const bool statOnly = m_editor->hasOnlyStatChanges();
+    if(!statOnly && !m_settings->fileValue(DontAskAgain).toBool()) {
+        QMessageBox message;
+        message.setIcon(QMessageBox::Warning);
+        message.setText(tr("Are you sure?"));
+        message.setInformativeText(tr("Metadata in the associated files will be overwritten."));
+
+        auto* dontAskAgain = new QCheckBox(tr("Don't ask again"), &message);
+        message.setCheckBox(dontAskAgain);
+
+        message.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        message.setDefaultButton(QMessageBox::No);
+
+        if(message.exec() != QMessageBox::Yes) {
+            return false;
+        }
+        if(dontAskAgain->isChecked()) {
+            m_settings->fileSet(DontAskAgain, true);
+        }
+    }
+
+    const TrackList changedTracks = m_editor->applyChanges();
+    if(changedTracks.empty()) {
+        return true;
+    }
+
+    if(statOnly) {
+        m_library->updateTrackStats(changedTracks);
+    }
+    else {
+        m_library->writeTrackMetadata(changedTracks);
+    }
+
+    return true;
+}
+
 void TagEditorPanel::updateForTracks(const TrackList& tracks)
 {
     m_currentTracks = tracks;
 
-    const bool canWrite = !tracks.empty()
-                          && std::ranges::all_of(tracks, [this](const Track& track) {
-                                 return !track.hasCue() && !track.isInArchive()
-                                        && m_audioLoader->canWriteMetadata(track);
-                             });
+    const bool hasTracks = !tracks.empty();
+    const bool canWrite  = hasTracks && std::ranges::all_of(tracks, [this](const Track& track) {
+                              return !track.hasCue() && !track.isInArchive() && m_audioLoader->canWriteMetadata(track);
+                           });
+    m_applyButton->setEnabled(canWrite);
     m_editor->setReadOnly(!canWrite);
     m_editor->setTracks(tracks);
 }

--- a/src/plugins/tageditor/tageditorpanel.h
+++ b/src/plugins/tageditor/tageditorpanel.h
@@ -24,6 +24,9 @@
 
 #include <memory>
 
+class QJsonObject;
+class QPushButton;
+
 namespace Fooyin {
 class ActionManager;
 class AudioLoader;
@@ -33,29 +36,33 @@ class TrackSelectionController;
 
 namespace TagEditor {
 class TagEditorFieldRegistry;
-class TagEditorWidget;
+class TagEditorEditor;
 
 class TagEditorPanel : public FyWidget
 {
     Q_OBJECT
 
 public:
-    explicit TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry,
-                            MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
-                            TrackSelectionController* selectionController,
+    explicit TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry, MusicLibrary* library,
+                            std::shared_ptr<AudioLoader> audioLoader, TrackSelectionController* selectionController,
                             SettingsManager* settings, QWidget* parent = nullptr);
 
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
 private:
+    bool apply();
     void selectionChanged();
     void updateForTracks(const TrackList& tracks);
 
     MusicLibrary* m_library;
     std::shared_ptr<AudioLoader> m_audioLoader;
     TrackSelectionController* m_selectionController;
-    TagEditorWidget* m_editor;
+    SettingsManager* m_settings;
+    TagEditorEditor* m_editor;
+    QPushButton* m_applyButton;
     TrackList m_currentTracks;
 };
 } // namespace TagEditor

--- a/src/plugins/tageditor/tageditorpanel.h
+++ b/src/plugins/tageditor/tageditorpanel.h
@@ -1,0 +1,62 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/track.h>
+#include <gui/fywidget.h>
+
+#include <memory>
+
+namespace Fooyin {
+class ActionManager;
+class AudioLoader;
+class MusicLibrary;
+class SettingsManager;
+class TrackSelectionController;
+
+namespace TagEditor {
+class TagEditorFieldRegistry;
+class TagEditorWidget;
+
+class TagEditorPanel : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TagEditorPanel(ActionManager* actionManager, TagEditorFieldRegistry* registry,
+                            MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
+                            TrackSelectionController* selectionController,
+                            SettingsManager* settings, QWidget* parent = nullptr);
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+
+private:
+    void selectionChanged();
+    void updateForTracks(const TrackList& tracks);
+
+    MusicLibrary* m_library;
+    std::shared_ptr<AudioLoader> m_audioLoader;
+    TrackSelectionController* m_selectionController;
+    TagEditorWidget* m_editor;
+    TrackList m_currentTracks;
+};
+} // namespace TagEditor
+} // namespace Fooyin

--- a/src/plugins/tageditor/tageditorplugin.cpp
+++ b/src/plugins/tageditor/tageditorplugin.cpp
@@ -23,6 +23,7 @@
 #include "settings/tageditorpage.h"
 #include "tageditorpropertiestab.h"
 #include "tagfilldialog.h"
+#include "tageditorpanel.h"
 
 #include <core/engine/audioloader.h>
 #include <core/library/musiclibrary.h>
@@ -70,8 +71,8 @@ void TagEditorPlugin::initialise(const GuiPluginContext& context)
 
     m_fieldsPage = new TagEditorFieldsPage(m_registry, m_settings, this);
 
-    // m_widgetProvider->registerWidget(
-    //     u"TagEditor"_s, [this]() { return createEditor(); }, u"Tag Editor"_s);
+    m_widgetProvider->registerWidget(
+        u"TagEditorPanel"_s, [this]() { return createPanel(); }, tr("Tag Editor"));
 
     m_propertiesDialog->insertTab(0, u"Metadata"_s, [this](const TrackList& tracks) { return createEditor(tracks); });
 
@@ -113,6 +114,12 @@ TagEditorPropertiesTab* TagEditorPlugin::createEditor(const TrackList& tracks)
     QObject::connect(tagEditor, &TagEditorPropertiesTab::trackStatsChanged, m_library,
                      [this](const TrackList& changedTracks) { m_library->updateTrackStats(changedTracks); });
     return tagEditor;
+}
+
+TagEditorPanel* TagEditorPlugin::createPanel()
+{
+    return new TagEditorPanel(m_actionManager, m_registry, m_library, m_audioLoader,
+                              m_trackSelection, m_settings);
 }
 } // namespace Fooyin::TagEditor
 

--- a/src/plugins/tageditor/tageditorplugin.cpp
+++ b/src/plugins/tageditor/tageditorplugin.cpp
@@ -21,9 +21,9 @@
 
 #include "settings/tageditorfieldregistry.h"
 #include "settings/tageditorpage.h"
+#include "tageditorpanel.h"
 #include "tageditorpropertiestab.h"
 #include "tagfilldialog.h"
-#include "tageditorpanel.h"
 
 #include <core/engine/audioloader.h>
 #include <core/library/musiclibrary.h>
@@ -71,8 +71,7 @@ void TagEditorPlugin::initialise(const GuiPluginContext& context)
 
     m_fieldsPage = new TagEditorFieldsPage(m_registry, m_settings, this);
 
-    m_widgetProvider->registerWidget(
-        u"TagEditorPanel"_s, [this]() { return createPanel(); }, tr("Tag Editor"));
+    m_widgetProvider->registerWidget(u"TagEditor"_s, [this]() { return createPanel(); }, tr("Tag Editor"));
 
     m_propertiesDialog->insertTab(0, u"Metadata"_s, [this](const TrackList& tracks) { return createEditor(tracks); });
 
@@ -118,8 +117,7 @@ TagEditorPropertiesTab* TagEditorPlugin::createEditor(const TrackList& tracks)
 
 TagEditorPanel* TagEditorPlugin::createPanel()
 {
-    return new TagEditorPanel(m_actionManager, m_registry, m_library, m_audioLoader,
-                              m_trackSelection, m_settings);
+    return new TagEditorPanel(m_actionManager, m_registry, m_library, m_audioLoader, m_trackSelection, m_settings);
 }
 } // namespace Fooyin::TagEditor
 

--- a/src/plugins/tageditor/tageditorplugin.h
+++ b/src/plugins/tageditor/tageditorplugin.h
@@ -28,6 +28,7 @@ namespace Fooyin::TagEditor {
 class TagEditorFieldRegistry;
 class TagEditorFieldsPage;
 class TagEditorPropertiesTab;
+class TagEditorPanel;
 
 class TagEditorPlugin : public QObject,
                         public Plugin,
@@ -44,6 +45,7 @@ public:
 
 private:
     TagEditorPropertiesTab* createEditor(const TrackList& tracks);
+    TagEditorPanel* createPanel();
 
     ActionManager* m_actionManager;
     MusicLibrary* m_library;

--- a/src/plugins/tageditor/tageditorpropertiestab.cpp
+++ b/src/plugins/tageditor/tageditorpropertiestab.cpp
@@ -19,9 +19,11 @@
 
 #include "tageditorpropertiestab.h"
 
+#include "core/coresettings.h"
 #include "tageditoreditor.h"
 #include "tagfilldialog.h"
 
+#include <gui/widgets/autoheaderview.h>
 #include <utils/settings/settingsmanager.h>
 
 #include <QCheckBox>
@@ -31,9 +33,10 @@
 
 using namespace Qt::StringLiterals;
 
-namespace Fooyin::TagEditor {
 constexpr auto DontAskAgain = "TagEditor/DontAskAgain";
+constexpr auto HeaderState  = "TagEditor/HeaderState";
 
+namespace Fooyin::TagEditor {
 TagEditorPropertiesTab::TagEditorPropertiesTab(ActionManager* actionManager, TagEditorFieldRegistry* registry,
                                                SettingsManager* settings, QWidget* parent)
     : PropertiesTabWidget{parent}
@@ -55,9 +58,14 @@ TagEditorPropertiesTab::TagEditorPropertiesTab(ActionManager* actionManager, Tag
                      &TagEditorPropertiesTab::pendingChangesStateChanged);
     QObject::connect(m_editor, &TagEditorEditor::autoFillValuesRequested, this,
                      &TagEditorPropertiesTab::autoFillValues);
+
+    restoreState();
 }
 
-TagEditorPropertiesTab::~TagEditorPropertiesTab() = default;
+TagEditorPropertiesTab::~TagEditorPropertiesTab()
+{
+    saveState();
+}
 
 void TagEditorPropertiesTab::setTracks(const TrackList& tracks)
 {
@@ -271,6 +279,30 @@ void TagEditorPropertiesTab::mergeTracks(TrackList& destination, const TrackList
         }
 
         destination.emplace_back(updatedTrack);
+    }
+}
+
+void TagEditorPropertiesTab::saveState() const
+{
+    FyStateSettings settings;
+    QByteArray state = m_editor->header()->saveHeaderState();
+    state            = qCompress(state, 9);
+    settings.setValue(HeaderState, state.toBase64());
+}
+
+void TagEditorPropertiesTab::restoreState() const
+{
+    const FyStateSettings settings;
+
+    if(settings.contains(HeaderState)) {
+        const auto headerState = settings.value(HeaderState).toString().toUtf8();
+
+        if(!headerState.isEmpty() && headerState.isValidUtf8()) {
+            auto state = QByteArray::fromBase64(headerState);
+            state      = qUncompress(state);
+            m_editor->header()->restoreHeaderState(state);
+            return;
+        }
     }
 }
 } // namespace Fooyin::TagEditor

--- a/src/plugins/tageditor/tageditorpropertiestab.h
+++ b/src/plugins/tageditor/tageditorpropertiestab.h
@@ -66,6 +66,9 @@ private:
     [[nodiscard]] TrackList activeTracks() const;
     static void mergeTracks(TrackList& destination, const TrackList& source);
 
+    void saveState() const;
+    void restoreState() const;
+
     SettingsManager* m_settings;
     PropertiesDialogSession* m_session;
     TrackList m_tracks;

--- a/src/plugins/tageditor/tageditorview.cpp
+++ b/src/plugins/tageditor/tageditorview.cpp
@@ -41,8 +41,6 @@
 
 using namespace Qt::StringLiterals;
 
-constexpr auto MinimumValueColumnWidth = 150;
-
 namespace Fooyin::TagEditor {
 TagEditorView::TagEditorView(ActionManager* actionManager, QWidget* parent)
     : ExtendableTableView{parent}
@@ -110,38 +108,6 @@ void TagEditorView::setRatingRow(int row)
     }
 }
 
-void TagEditorView::resizeColumnsForContents()
-{
-    if(!model() || model()->columnCount() < 2) {
-        return;
-    }
-
-    resizeColumnToContents(0);
-    normaliseColumnWidths();
-}
-
-void TagEditorView::normaliseColumnWidths()
-{
-    if(!model() || model()->columnCount() < 2) {
-        return;
-    }
-
-    const int viewportWidth = viewport()->width();
-    if(viewportWidth <= 0) {
-        return;
-    }
-
-    auto* header             = horizontalHeader();
-    const int minWidth       = header->minimumSectionSize();
-    const int minValueCol    = std::max(minWidth, MinimumValueColumnWidth);
-    const int maxFieldCol    = std::max(minWidth, viewportWidth - minValueCol);
-    const int targetFieldCol = std::clamp(columnWidth(0), minWidth, maxFieldCol);
-
-    if(columnWidth(0) != targetFieldCol) {
-        header->resizeSection(0, targetFieldCol);
-    }
-}
-
 int TagEditorView::sizeHintForRow(int row) const
 {
     if(!model()->hasIndex(row, 0, {})) {
@@ -160,12 +126,6 @@ void TagEditorView::setupContextActions(QMenu* menu, const QPoint& /*pos*/)
     menu->addSeparator();
     m_capitaliseAction->setEnabled(canCapitaliseSelection());
     menu->addAction(m_capitaliseAction);
-}
-
-void TagEditorView::resizeEvent(QResizeEvent* event)
-{
-    ExtendableTableView::resizeEvent(event);
-    normaliseColumnWidths();
 }
 
 void TagEditorView::mouseMoveEvent(QMouseEvent* event)

--- a/src/plugins/tageditor/tageditorview.h
+++ b/src/plugins/tageditor/tageditorview.h
@@ -37,14 +37,11 @@ public:
     void setTagEditTriggers(EditTriggers triggers);
     void setupActions();
     void setRatingRow(int row);
-    void resizeColumnsForContents();
-    void normaliseColumnWidths();
-
-    [[nodiscard]] int sizeHintForRow(int row) const override;
 
 protected:
+    [[nodiscard]] int sizeHintForRow(int row) const override;
+
     void setupContextActions(QMenu* menu, const QPoint& pos) override;
-    void resizeEvent(QResizeEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;


### PR DESCRIPTION
Hey :) Thanks for adding my other pull request with the delete functionality. Awesome.

Here I tried to add the Tag Editor as a UI Element. This allows editing tags for one or multiple selected tracks. It uses the already established tag editor available under Right Click -> Properties ->  Metadata.
The UI Element can be added, removed and replaced. When a new track is selected (either manually or automatically) it asked if pending changes should be saved or discarded.

Please give me feedback and I will try to improve it.

Thanks again for your work on this. Coming from foobar2k myself, this is one of the last features I really need to feel right at home with fooyin.