### PR TITLE
Fix wavebar option labeling

### DIFF
--- a/src/gui/controls/seekbar.cpp
+++ b/src/gui/controls/seekbar.cpp
@@ -354,7 +354,7 @@ void SeekBar::contextMenuEvent(QContextMenuEvent* event)
                      [this](bool checked) { m_container->setLabelsEnabled(checked); });
     menu->addAction(showLabels);
 
-    auto* showElapsed = new QAction(tr("Show elapsed total"), menu);
+    auto* showElapsed = new QAction(tr("Show remaining time"), menu);
     showElapsed->setCheckable(true);
     showElapsed->setChecked(m_container->elapsedTotal());
     QObject::connect(showElapsed, &QAction::triggered, this,

--- a/src/plugins/wavebar/wavebarconfigwidget.cpp
+++ b/src/plugins/wavebar/wavebarconfigwidget.cpp
@@ -41,7 +41,7 @@ namespace Fooyin::WaveBar {
 WaveBarConfigDialog::WaveBarConfigDialog(WaveBarWidget* waveBar, QWidget* parent)
     : WidgetConfigDialog{waveBar, tr("WaveBar Settings"), parent}
     , m_showLabels{new QCheckBox(tr("Show labels"), this)}
-    , m_elapsedTotal{new QCheckBox(tr("Show elapsed total"), this)}
+    , m_elapsedTotal{new QCheckBox(tr("Show remaining time"), this)}
     , m_minMax{new QCheckBox(tr("Min/Max"), this)}
     , m_rms{new QCheckBox(tr("RMS"), this)}
     , m_silence{new QCheckBox(tr("Silence"), this)}

--- a/src/plugins/wavebar/wavebarwidget.cpp
+++ b/src/plugins/wavebar/wavebarwidget.cpp
@@ -514,7 +514,7 @@ void WaveBarWidget::contextMenuEvent(QContextMenuEvent* event)
         applyConfig(config);
     });
 
-    auto* showElapsed = new QAction(tr("Show elapsed total"), menu);
+    auto* showElapsed = new QAction(tr("Show remaining time"), menu);
     showElapsed->setCheckable(true);
     showElapsed->setChecked(m_config.elapsedTotal);
     QObject::connect(showElapsed, &QAction::triggered, this, [this](bool checked) {


### PR DESCRIPTION
Fixes https://github.com/fooyin/fooyin/issues/1017#issuecomment-4219355607 by renaming all occurances of the wavebar option `Show elapsed total` to `Show remaining time`.