### PR TITLE
[gui] Add "Copy file location" action

### DIFF
--- a/include/core/constants.h
+++ b/include/core/constants.h
@@ -22,11 +22,6 @@
 namespace Fooyin::Constants {
 constexpr auto RecordSeparator = "\036";
 constexpr auto UnitSeparator   = "\037";
-#ifdef Q_OS_WIN32
-constexpr auto NewLine = "\r\n";
-#else
-constexpr auto NewLine = "\n";
-#endif
 
 constexpr auto InvalidGain = -1000;
 constexpr auto InvalidPeak = -1;

--- a/include/core/constants.h
+++ b/include/core/constants.h
@@ -22,6 +22,11 @@
 namespace Fooyin::Constants {
 constexpr auto RecordSeparator = "\036";
 constexpr auto UnitSeparator   = "\037";
+#ifdef Q_OS_WIN32
+constexpr auto NewLine = "\r\n";
+#else
+constexpr auto NewLine = "\n";
+#endif
 
 constexpr auto InvalidGain = -1000;
 constexpr auto InvalidPeak = -1;

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -189,6 +189,7 @@ constexpr auto QueueNext                 = "Tracks.QueueNext";
 constexpr auto SendToQueue               = "Tracks.SendToQueue";
 constexpr auto RemoveFromQueue           = "Tracks.RemoveFromQueue";
 constexpr auto OpenFolder                = "Tracks.OpenFolder";
+constexpr auto CopyLocation              = "Tracks.CopyLocation";
 constexpr auto SearchArtwork             = "Tracks.SearchArtwork";
 constexpr auto SearchArtworkQuick        = "Tracks.SearchArtworkQuick";
 constexpr auto ExportArtwork             = "Tracks.ExportArtwork";

--- a/src/gui/trackselectioncontroller.cpp
+++ b/src/gui/trackselectioncontroller.cpp
@@ -635,7 +635,7 @@ void TrackSelectionControllerPrivate::copyLocation(const TrackSelection& selecti
     for(const auto& track : selection.tracks) {
         paths.append(track.prettyFilepath());
     }
-    QApplication::clipboard()->setText(paths.join(QLatin1String{Constants::NewLine}));
+    QApplication::clipboard()->setText(paths.join("\n"_L1));
 }
 
 void TrackSelectionControllerPrivate::searchArtwork(const TrackSelection& selection, bool quick) const

--- a/src/gui/trackselectioncontroller.cpp
+++ b/src/gui/trackselectioncontroller.cpp
@@ -20,6 +20,7 @@
 #include <gui/trackselectioncontroller.h>
 
 #include "artwork/artworkexporter.h"
+#include "core/constants.h"
 #include "internalguisettings.h"
 #include "playlist/playlistcontroller.h"
 #include "statusevent.h"
@@ -39,6 +40,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QClipboard>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMenuBar>
@@ -89,6 +91,7 @@ public:
     void addToQueue() const;
     void queueNext() const;
     void openFolder(const TrackSelection& selection) const;
+    void copyLocation(const TrackSelection& selection) const;
     void searchArtwork(const TrackSelection& selection, bool quick) const;
     void extractArtwork(const TrackSelection& selection) const;
     void attachArtwork(const TrackSelection& selection, Track::Cover coverType, QWidget* parent) const;
@@ -132,6 +135,7 @@ public:
     QAction* m_queueNext;
     QAction* m_removeFromQueue;
     QAction* m_openFolder;
+    QAction* m_copyLocation;
     QAction* m_searchArtwork;
     QAction* m_searchArtworkQuick;
     QAction* m_extractArtwork;
@@ -164,6 +168,7 @@ TrackSelectionControllerPrivate::TrackSelectionControllerPrivate(TrackSelectionC
     , m_queueNext{new QAction(tr("Queue to play next"), m_tracksMenu)}
     , m_removeFromQueue{new QAction(tr("Remove from playback queue"), m_tracksMenu)}
     , m_openFolder{new QAction(tr("Open containing folder"), m_tracksMenu)}
+    , m_copyLocation{new QAction(tr("Copy file location"), m_tracksMenu)}
     , m_searchArtwork{new QAction(tr("Search for artwork…"), m_tracksMenu)}
     , m_searchArtworkQuick{new QAction(tr("Quicksearch for artwork"), m_tracksMenu)}
     , m_extractArtwork{new QAction(tr("Auto-extract artwork to files"), m_tracksMenu)}
@@ -271,6 +276,16 @@ void TrackSelectionControllerPrivate::setupMenu()
         }
     });
     m_tracksMenu->addAction(openFolderCmd);
+
+    m_copyLocation->setStatusTip(tr("Copy the location of the selected tracks"));
+    auto* copyLocationCmd = m_actionManager->registerAction(m_copyLocation, Constants::Actions::CopyLocation);
+    copyLocationCmd->setCategories(tracksCategory);
+    QObject::connect(m_copyLocation, &QAction::triggered, m_tracksMenu, [this]() {
+        if(hasTracks()) {
+            copyLocation(m_self->selectedSelection());
+        }
+    });
+    m_tracksMenu->addAction(copyLocationCmd);
 
     auto* artworkMenu = m_actionManager->createMenu(Constants::Menus::Context::Artwork);
     artworkMenu->menu()->setTitle(TrackSelectionController::tr("Artwork"));
@@ -608,6 +623,19 @@ void TrackSelectionControllerPrivate::openFolder(const TrackSelection& selection
     else {
         Utils::File::openDirectory(track.path());
     }
+}
+
+void TrackSelectionControllerPrivate::copyLocation(const TrackSelection& selection) const
+{
+    if(selection.tracks.empty()) {
+        return;
+    }
+
+    QStringList paths;
+    for(const auto& track : selection.tracks) {
+        paths.append(track.prettyFilepath());
+    }
+    QApplication::clipboard()->setText(paths.join(QLatin1String{Constants::NewLine}));
 }
 
 void TrackSelectionControllerPrivate::searchArtwork(const TrackSelection& selection, bool quick) const


### PR DESCRIPTION
Addresses #496.

I don't know if we want another action to copy just the directory, the context menu looks pretty long to me as it is. Maybe under a submenu?