### PR TITLE
[core,gui,rgscanner] Handle Opus header gain/ReplayGain

### DIFF
--- a/include/core/constants.h
+++ b/include/core/constants.h
@@ -23,8 +23,9 @@ namespace Fooyin::Constants {
 constexpr auto RecordSeparator = "\036";
 constexpr auto UnitSeparator   = "\037";
 
-constexpr auto InvalidGain = -1000;
-constexpr auto InvalidPeak = -1;
+constexpr auto InvalidGain       = -1000;
+constexpr auto InvalidPeak       = -1;
+constexpr auto OpusHeaderGainQ78 = "_OPUS_HEADER_GAIN_Q78";
 
 namespace MetaData {
 constexpr auto Title             = "TITLE";
@@ -81,6 +82,7 @@ constexpr auto RGTrackPeakDB     = "REPLAYGAIN_TRACK_PEAK_DB";
 constexpr auto RGAlbumGain       = "REPLAYGAIN_ALBUM_GAIN";
 constexpr auto RGAlbumPeak       = "REPLAYGAIN_ALBUM_PEAK";
 constexpr auto RGAlbumPeakDB     = "REPLAYGAIN_ALBUM_PEAK_DB";
+constexpr auto OpusHeaderGain    = "OPUS_HEADER_GAIN";
 } // namespace MetaData
 
 constexpr auto FrontCover    = "%frontcover%";

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -38,6 +38,13 @@ class Track;
 class TrackPrivate;
 class TrackMetadataStore;
 
+enum class OpusRGWriteMode : uint8_t
+{
+    LeaveNull = 0,
+    Track,
+    Album,
+};
+
 using TrackList = std::vector<Track>;
 using TrackIds  = std::vector<int>;
 
@@ -159,6 +166,18 @@ public:
     [[nodiscard]] float rgAlbumGain() const;
     [[nodiscard]] float rgTrackPeak() const;
     [[nodiscard]] float rgAlbumPeak() const;
+    [[nodiscard]] std::optional<int16_t> opusHeaderGainQ78() const;
+    [[nodiscard]] bool hasOpusHeaderGain() const;
+    [[nodiscard]] float opusHeaderGainDb() const;
+    [[nodiscard]] bool hasEffectiveTrackGain() const;
+    [[nodiscard]] bool hasEffectiveAlbumGain() const;
+    [[nodiscard]] bool hasEffectiveTrackPeak() const;
+    [[nodiscard]] bool hasEffectiveAlbumPeak() const;
+    [[nodiscard]] float effectiveRGTrackGain() const;
+    [[nodiscard]] float effectiveRGAlbumGain() const;
+    [[nodiscard]] float effectiveRGTrackPeak() const;
+    [[nodiscard]] float effectiveRGAlbumPeak() const;
+    [[nodiscard]] bool isOpus() const;
 
     [[nodiscard]] bool hasCue() const;
     [[nodiscard]] bool hasEmbeddedCue() const;
@@ -235,6 +254,8 @@ public:
     void setRGAlbumGain(float gain);
     void setRGTrackPeak(float peak);
     void setRGAlbumPeak(float peak);
+    void setOpusHeaderGainQ78(int16_t gainQ78);
+    void clearOpusHeaderGain();
     void clearRGInfo();
 
     [[nodiscard]] QString metaValue(const QString& name) const;
@@ -253,6 +274,7 @@ public:
 
     void setExtraProperty(const QString& prop, const QString& value);
     void removeExtraProperty(const QString& prop);
+    void normaliseExtraProperties();
     void clearExtraProperties();
     void storeExtraProperties(const QByteArray& props);
 
@@ -302,6 +324,8 @@ struct TrackCoverData
     TrackList tracks;
     TrackCovers coverData;
 };
+
+[[nodiscard]] FYCORE_EXPORT Track prepareOpusRGWriteTrack(const Track& track, OpusRGWriteMode mode);
 } // namespace Fooyin
 
 Q_DECLARE_METATYPE(Fooyin::TrackList)

--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -67,11 +67,18 @@
 #include <QMimeDatabase>
 #include <QPixmap>
 
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <optional>
 #include <set>
 
 Q_LOGGING_CATEGORY(TAGLIB, "fy.taglib")
 
 using namespace Qt::StringLiterals;
+
+constexpr auto OpusR128Scale     = 256.0;
+constexpr auto RGReferenceOffset = 5.0;
 
 constexpr auto BufferSize = 1024;
 
@@ -556,6 +563,185 @@ float gainStringToFloat(const TagLib::String& gainString)
     return ok ? gain : Fooyin::Constants::InvalidGain;
 };
 
+std::optional<float> opusR128ToReplayGain(const TagLib::String& gainString)
+{
+    bool ok{false};
+    const int gainQ78 = convertString(gainString).trimmed().toInt(&ok);
+    if(!ok) {
+        return {};
+    }
+
+    return static_cast<float>((static_cast<double>(gainQ78) / OpusR128Scale) + RGReferenceOffset);
+}
+
+std::optional<int16_t> replayGainToOpusR128Q78(float gainDb)
+{
+    if(!std::isfinite(gainDb)) {
+        return {};
+    }
+
+    const auto gainQ78 = std::lround((static_cast<double>(gainDb) - RGReferenceOffset) * OpusR128Scale);
+
+    if(gainQ78 < std::numeric_limits<int16_t>::min() || gainQ78 > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+
+    return static_cast<int16_t>(gainQ78);
+}
+
+struct OpusHeadPage
+{
+    QByteArray page;
+    qsizetype packetOffset{0};
+    qsizetype gainOffset{0};
+};
+
+uint32_t oggPageCrc(QByteArray page)
+{
+    page[22] = 0;
+    page[23] = 0;
+    page[24] = 0;
+    page[25] = 0;
+
+    uint32_t crc{0};
+    for(const char byte : std::as_const(page)) {
+        crc ^= static_cast<uint32_t>(static_cast<unsigned char>(byte)) << 24;
+        for(int bit{0}; bit < 8; ++bit) {
+            crc = (crc & 0x80000000) != 0 ? (crc << 1) ^ 0x04C11DB7 : (crc << 1);
+        }
+    }
+
+    return crc;
+}
+
+std::optional<OpusHeadPage> readOpusHeadPage(QIODevice* device)
+{
+    if(!device || !device->isOpen() || !device->isReadable() || device->isSequential()) {
+        return {};
+    }
+
+    const qint64 originalPos = device->pos();
+
+    if(!device->seek(0)) {
+        return {};
+    }
+
+    struct RestorePos
+    {
+        QIODevice* device;
+        qint64 pos;
+
+        ~RestorePos()
+        {
+            if(device) {
+                device->seek(pos);
+            }
+        }
+    };
+
+    const RestorePos restore{.device = device, .pos = originalPos};
+
+    QByteArray header(27, Qt::Uninitialized);
+    if(device->read(header.data(), header.size()) != header.size()) {
+        return {};
+    }
+
+    if(std::memcmp(header.constData(), "OggS", 4) != 0) {
+        return {};
+    }
+
+    const int segmentCount = static_cast<unsigned char>(header[26]);
+    QByteArray segmentTable(segmentCount, Qt::Uninitialized);
+    if(device->read(segmentTable.data(), segmentTable.size()) != segmentTable.size()) {
+        return {};
+    }
+
+    int packetSize{0};
+    for(const char laceValue : std::as_const(segmentTable)) {
+        packetSize += static_cast<unsigned char>(laceValue);
+    }
+
+    const auto packetOffset = header.size() + segmentTable.size();
+    if(packetSize < 19) {
+        return {};
+    }
+
+    QByteArray page(packetOffset + packetSize, Qt::Uninitialized);
+    std::memcpy(page.data(), header.constData(), static_cast<size_t>(header.size()));
+    std::memcpy(page.data() + header.size(), segmentTable.constData(), static_cast<size_t>(segmentTable.size()));
+
+    if(device->read(page.data() + packetOffset, packetSize) != packetSize) {
+        return {};
+    }
+
+    const auto storedCrc = static_cast<uint32_t>(static_cast<unsigned char>(page[22]))
+                         | (static_cast<uint32_t>(static_cast<unsigned char>(page[23])) << 8)
+                         | (static_cast<uint32_t>(static_cast<unsigned char>(page[24])) << 16)
+                         | (static_cast<uint32_t>(static_cast<unsigned char>(page[25])) << 24);
+    if(oggPageCrc(page) != storedCrc) {
+        return {};
+    }
+
+    if(std::memcmp(page.constData() + packetOffset, "OpusHead", 8) != 0) {
+        return {};
+    }
+
+    return OpusHeadPage{
+        .page         = std::move(page),
+        .packetOffset = packetOffset,
+        .gainOffset   = packetOffset + 16,
+    };
+}
+} // namespace
+
+namespace Fooyin {
+std::optional<int16_t> readOpusHeaderGainQ78(QIODevice* device)
+{
+    const auto page = readOpusHeadPage(device);
+    if(!page.has_value()) {
+        return {};
+    }
+
+    const auto gainLo = static_cast<unsigned char>(page->page[page->gainOffset]);
+    const auto gainHi = static_cast<unsigned char>(page->page[page->gainOffset + 1]);
+    const auto gain   = static_cast<uint16_t>(gainLo | (gainHi << 8));
+    return static_cast<int16_t>(gain);
+}
+
+bool writeOpusHeaderGainQ78(QIODevice* device, int16_t gain)
+{
+    if(!device || !device->isOpen() || !device->isWritable() || device->isSequential()) {
+        return false;
+    }
+
+    const auto page = readOpusHeadPage(device);
+    if(!page.has_value()) {
+        return false;
+    }
+
+    QByteArray updatedPage            = page->page;
+    updatedPage[page->gainOffset]     = static_cast<char>(gain & 0xFF);
+    updatedPage[page->gainOffset + 1] = static_cast<char>((static_cast<uint16_t>(gain) >> 8) & 0xFF);
+
+    const uint32_t crc = oggPageCrc(updatedPage);
+    updatedPage[22]    = static_cast<char>(crc & 0xFF);
+    updatedPage[23]    = static_cast<char>((crc >> 8) & 0xFF);
+    updatedPage[24]    = static_cast<char>((crc >> 16) & 0xFF);
+    updatedPage[25]    = static_cast<char>((crc >> 24) & 0xFF);
+
+    if(!device->seek(0) || device->write(updatedPage.constData(), updatedPage.size()) != updatedPage.size()) {
+        return false;
+    }
+
+    if(auto* file = qobject_cast<QFile*>(device)) {
+        return file->flush();
+    }
+
+    return true;
+}
+} // namespace Fooyin
+
+namespace {
 QString codecForMime(const QString& mimeType)
 {
     if(mimeType == "audio/mpeg"_L1 || mimeType == "audio/mpeg3"_L1 || mimeType == "audio/x-mpeg"_L1) {
@@ -1783,6 +1969,37 @@ void readXiphComment(const TagLib::Ogg::XiphComment* xiphTags, Fooyin::Track& tr
     }
 }
 
+void readOpusReplayGain(const TagLib::Ogg::XiphComment* xiphTags, Fooyin::Track& track)
+{
+    if(xiphTags->isEmpty()) {
+        return;
+    }
+
+    const TagLib::Ogg::FieldListMap& fields = xiphTags->fieldListMap();
+    track.setRGTrackGain(Fooyin::Constants::InvalidGain);
+    track.setRGAlbumGain(Fooyin::Constants::InvalidGain);
+    track.removeExtraTag(u"R128_TRACK_GAIN"_s);
+    track.removeExtraTag(u"R128_ALBUM_GAIN"_s);
+
+    if(fields.contains("R128_TRACK_GAIN")) {
+        const TagLib::StringList& gains = fields["R128_TRACK_GAIN"];
+        if(!gains.isEmpty()) {
+            if(const auto gain = opusR128ToReplayGain(gains.front()); gain.has_value()) {
+                track.setRGTrackGain(*gain);
+            }
+        }
+    }
+
+    if(fields.contains("R128_ALBUM_GAIN")) {
+        const TagLib::StringList& gains = fields["R128_ALBUM_GAIN"];
+        if(!gains.isEmpty()) {
+            if(const auto gain = opusR128ToReplayGain(gains.front()); gain.has_value()) {
+                track.setRGAlbumGain(*gain);
+            }
+        }
+    }
+}
+
 QByteArray readFlacCover(const TagLib::List<TagLib::FLAC::Picture*>& pictures, Fooyin::Track::Cover cover)
 {
     if(pictures.isEmpty()) {
@@ -1859,6 +2076,50 @@ void writeXiphComment(TagLib::Ogg::XiphComment* xiphTags, const Fooyin::Track& t
         }
         else {
             xiphTags->addField("FMPS_PLAYCOUNT", convertString(QString::number(track.playCount())));
+        }
+    }
+}
+
+void writeOpusReplayGain(TagLib::Ogg::XiphComment* xiphTags, const Fooyin::Track& track,
+                         Fooyin::AudioReader::WriteOptions options)
+{
+    if(!(options & Fooyin::AudioReader::Metadata)) {
+        return;
+    }
+
+    using namespace Fooyin::Tag::ReplayGain;
+
+    const auto removeField = [xiphTags](QStringView fieldName) {
+        QStringList fieldsToRemove;
+        const auto& fields = xiphTags->fieldListMap();
+
+        for(const auto& field : fields) {
+            if(convertString(field.first).compare(fieldName, Qt::CaseInsensitive) == 0) {
+                fieldsToRemove.emplace_back(convertString(field.first));
+            }
+        }
+
+        for(const QString& field : fieldsToRemove) {
+            xiphTags->removeFields(convertString(field));
+        }
+    };
+
+    removeField(QString::fromLatin1(TrackGain));
+    removeField(QString::fromLatin1(TrackGainAlt));
+    removeField(QString::fromLatin1(AlbumGain));
+    removeField(QString::fromLatin1(AlbumGainAlt));
+    removeField(u"R128_TRACK_GAIN"_s);
+    removeField(u"R128_ALBUM_GAIN"_s);
+
+    if(track.hasTrackGain()) {
+        if(const auto gainQ78 = replayGainToOpusR128Q78(track.rgTrackGain()); gainQ78.has_value()) {
+            xiphTags->addField("R128_TRACK_GAIN", convertString(QString::number(*gainQ78)), true);
+        }
+    }
+
+    if(track.hasAlbumGain()) {
+        if(const auto gainQ78 = replayGainToOpusR128Q78(track.rgAlbumGain()); gainQ78.has_value()) {
+            xiphTags->addField("R128_ALBUM_GAIN", convertString(QString::number(*gainQ78)), true);
         }
     }
 }
@@ -2553,8 +2814,14 @@ bool TagLibReader::readTrack(const AudioSource& source, Track& track)
             readProperties(file);
             track.setEncoding(u"Lossy"_s);
 
+            if(const auto headerGain = readOpusHeaderGainQ78(source.device);
+               headerGain.has_value() && *headerGain != 0) {
+                track.setOpusHeaderGainQ78(*headerGain);
+            }
+
             if(file.tag()) {
                 readXiphComment(file.tag(), track);
+                readOpusReplayGain(file.tag(), track);
                 track.setTagTypes({u"XiphComment"_s});
             }
         }
@@ -2920,10 +3187,18 @@ bool TagLibReader::writeTrack(const AudioSource& source, const Track& track, Wri
             writeProperties(file);
             if(file.tag()) {
                 writeXiphComment(file.tag(), track, options);
+                writeOpusReplayGain(file.tag(), track, options);
             }
             else {
                 logWriteFailure(u"write metadata"_s, source.filepath, mimeType, u"file has no Xiph comment block"_s);
                 failureLogged = true;
+            }
+
+            if(const auto headerGain = track.opusHeaderGainQ78(); headerGain.has_value()) {
+                if(!writeOpusHeaderGainQ78(source.device, *headerGain)) {
+                    logWriteFailure(u"write opus header gain"_s, source.filepath, mimeType, u"failed"_s);
+                    failureLogged = true;
+                }
             }
 
             success = failureLogged

--- a/src/core/engine/input/taglibparser.h
+++ b/src/core/engine/input/taglibparser.h
@@ -23,7 +23,13 @@
 
 #include <core/engine/audioinput.h>
 
+#include <cstdint>
+#include <optional>
+
 namespace Fooyin {
+[[nodiscard]] FYCORE_EXPORT std::optional<int16_t> readOpusHeaderGainQ78(QIODevice* device);
+[[nodiscard]] FYCORE_EXPORT bool writeOpusHeaderGainQ78(QIODevice* device, int16_t gain);
+
 class FYCORE_EXPORT TagLibReader : public AudioReader
 {
 public:

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -123,6 +123,8 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
         static_cast<int>(Engine::CrossfadeSwitchPolicy::OverlapStart), u"Playback/CrossfadeSwitchPolicy"_s);
     m_settings->createSetting<Internal::OutputDeviceProfiles>(QVariant::fromValue(Engine::OutputDeviceProfiles{}),
                                                               u"Engine/OutputDeviceProfiles"_s);
+    m_settings->createSetting<Internal::OpusHeaderWriteMode>(static_cast<int>(OpusRGWriteMode::Album),
+                                                             u"ReplayGain/OpusHeaderWriteMode"_s);
 
     m_settings->set<FirstRun>(!QFileInfo::exists(Core::settingsPath()));
 

--- a/src/core/internalcoresettings.h
+++ b/src/core/internalcoresettings.h
@@ -74,6 +74,7 @@ enum CoreInternalSettings : uint32_t
     DecodeHighWatermarkRatio = 16 | Type::Double,
     CrossfadeSwitchPolicy    = 17 | Type::Int,
     OutputDeviceProfiles     = 18 | Type::Variant,
+    OpusHeaderWriteMode      = 19 | Type::Int,
 };
 Q_ENUM_NS(CoreInternalSettings)
 } // namespace Settings::Core::Internal

--- a/src/core/library/trackdatabasemanager.cpp
+++ b/src/core/library/trackdatabasemanager.cpp
@@ -141,6 +141,7 @@ void TrackDatabaseManager::updateTracks(const TrackList& tracks, bool write, int
             if(m_audioLoader->writeTrackMetadata(updatedTrack, options)) {
                 const QDateTime modifiedTime = QFileInfo{updatedTrack.filepath()}.lastModified();
                 updatedTrack.setModifiedTime(modifiedTime.isValid() ? modifiedTime.toMSecsSinceEpoch() : 0);
+                updatedTrack.normaliseExtraProperties();
             }
             else {
                 qCWarning(TRK_DBMAN) << "Failed to write metadata to file:" << updatedTrack.filepath();
@@ -200,6 +201,7 @@ void TrackDatabaseManager::updateTrackStats(const TrackList& tracks, AudioReader
             const QDateTime modifiedTime   = QFileInfo{updatedTrack.filepath()}.lastModified();
             const uint64_t newModifiedTime = modifiedTime.isValid() ? modifiedTime.toMSecsSinceEpoch() : 0;
             updatedTrack.setModifiedTime(newModifiedTime);
+            updatedTrack.normaliseExtraProperties();
             needsTrackUpdate = newModifiedTime != track.modifiedTime();
         }
         if(success && (!needsTrackUpdate || m_trackDatabase.updateTrack(updatedTrack))

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -357,17 +357,17 @@ std::optional<ScriptRegistry::FuncRet> trackMetadataValue(const VariableKind kin
         case VariableKind::Subsong:
             return track.subsong();
         case VariableKind::RGTrackGain:
-            return formatGain(track.rgTrackGain());
+            return formatGain(track.effectiveRGTrackGain());
         case VariableKind::RGTrackPeak:
-            return track.rgTrackPeak();
+            return track.effectiveRGTrackPeak();
         case VariableKind::RGTrackPeakDB:
-            return formatPeak(track.rgTrackPeak());
+            return formatPeak(track.effectiveRGTrackPeak());
         case VariableKind::RGAlbumGain:
-            return formatGain(track.rgAlbumGain());
+            return formatGain(track.effectiveRGAlbumGain());
         case VariableKind::RGAlbumPeak:
-            return track.rgAlbumPeak();
+            return track.effectiveRGAlbumPeak();
         case VariableKind::RGAlbumPeakDB:
-            return formatPeak(track.rgAlbumPeak());
+            return formatPeak(track.effectiveRGAlbumPeak());
         default:
             return {};
     }

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -32,6 +32,8 @@
 #include <QRegularExpression>
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <utility>
 
 using namespace Qt::StringLiterals;
@@ -96,6 +98,81 @@ const MetaMap& metaMap()
     };
     // clang-format on
     return metaMap;
+}
+
+std::optional<int> opusHeaderGainQ78(const Fooyin::Track& track)
+{
+    const auto& props         = track.extraProperties();
+    const QString* opusHeader = props.find(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+    if(!opusHeader) {
+        return {};
+    }
+
+    bool ok{false};
+    const int gain = opusHeader->toInt(&ok);
+    return ok ? std::optional{gain} : std::nullopt;
+}
+
+float opusHeaderGainDb(const Fooyin::Track& track)
+{
+    if(const auto gainQ78 = opusHeaderGainQ78(track); gainQ78.has_value()) {
+        return static_cast<float>(*gainQ78) / 256.0F;
+    }
+    return 0.0F;
+}
+
+float q78ToDb(int gainQ78)
+{
+    return static_cast<float>(gainQ78) / 256.0F;
+}
+
+std::optional<int16_t> replayGainToOpusR128Q78(float gainDb)
+{
+    const auto gainQ78 = std::lround((static_cast<double>(gainDb) - 5.0) * 256.0);
+    if(gainQ78 < std::numeric_limits<int16_t>::min() || gainQ78 > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+
+    return static_cast<int16_t>(gainQ78);
+}
+
+std::optional<int16_t> adjustCommentGain(std::optional<int16_t> currentGain, int commentDeltaQ78)
+{
+    if(!currentGain.has_value()) {
+        return {};
+    }
+
+    const auto adjustedGain = static_cast<long long>(*currentGain) - commentDeltaQ78;
+    if(adjustedGain < std::numeric_limits<int16_t>::min() || adjustedGain > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+
+    return static_cast<int16_t>(adjustedGain);
+}
+
+struct OpusGainState
+{
+    int16_t headerGain{0};
+    std::optional<int16_t> trackGain;
+    std::optional<int16_t> albumGain;
+};
+
+float opusHeaderLinearGain(const Fooyin::Track& track)
+{
+    return std::pow(10.0F, opusHeaderGainDb(track) / 20.0F);
+}
+
+void normaliseExtraProperties(Fooyin::Track::ExtraProperties& props)
+{
+    const QString* opusHeader = props.find(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+    if(!opusHeader) {
+        return;
+    }
+
+    bool ok{false};
+    if(const int gain = opusHeader->toInt(&ok); ok && gain == 0) {
+        props.erase(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+    }
 }
 
 template <typename Value, typename KeyFn>
@@ -830,6 +907,97 @@ float Track::rgAlbumPeak() const
     return p->rgAlbumPeak;
 }
 
+std::optional<int16_t> Track::opusHeaderGainQ78() const
+{
+    if(const auto gainQ78 = ::opusHeaderGainQ78(*this); gainQ78.has_value()
+                                                        && *gainQ78 >= std::numeric_limits<int16_t>::min()
+                                                        && *gainQ78 <= std::numeric_limits<int16_t>::max()) {
+        return static_cast<int16_t>(*gainQ78);
+    }
+
+    return {};
+}
+
+bool Track::hasOpusHeaderGain() const
+{
+    if(const auto gainQ78 = opusHeaderGainQ78(); gainQ78.has_value()) {
+        return *gainQ78 != 0;
+    }
+
+    return false;
+}
+
+float Track::opusHeaderGainDb() const
+{
+    if(const auto gainQ78 = opusHeaderGainQ78(); gainQ78.has_value()) {
+        return static_cast<float>(*gainQ78) / 256.0F;
+    }
+
+    return 0.0F;
+}
+
+bool Track::hasEffectiveTrackGain() const
+{
+    return hasTrackGain() || hasOpusHeaderGain();
+}
+
+bool Track::hasEffectiveAlbumGain() const
+{
+    return hasAlbumGain() || hasOpusHeaderGain();
+}
+
+bool Track::hasEffectiveTrackPeak() const
+{
+    return hasTrackPeak();
+}
+
+bool Track::hasEffectiveAlbumPeak() const
+{
+    return hasAlbumPeak();
+}
+
+float Track::effectiveRGTrackGain() const
+{
+    if(!hasEffectiveTrackGain()) {
+        return Constants::InvalidGain;
+    }
+
+    return (hasTrackGain() ? rgTrackGain() : 0.0F) + opusHeaderGainDb();
+}
+
+float Track::effectiveRGAlbumGain() const
+{
+    if(!hasEffectiveAlbumGain()) {
+        return Constants::InvalidGain;
+    }
+
+    return (hasAlbumGain() ? rgAlbumGain() : 0.0F) + opusHeaderGainDb();
+}
+
+float Track::effectiveRGTrackPeak() const
+{
+    if(!hasTrackPeak()) {
+        return Constants::InvalidPeak;
+    }
+
+    return rgTrackPeak() / opusHeaderLinearGain(*this);
+}
+
+float Track::effectiveRGAlbumPeak() const
+{
+    if(!hasAlbumPeak()) {
+        return Constants::InvalidPeak;
+    }
+
+    return rgAlbumPeak() / opusHeaderLinearGain(*this);
+}
+
+bool Track::isOpus() const
+{
+    return extension().compare(u"opus"_s, Qt::CaseInsensitive) == 0
+        || codec().compare(u"Opus"_s, Qt::CaseInsensitive) == 0;
+}
+
 bool Track::hasCue() const
 {
     return !p->cuePath.isEmpty();
@@ -969,11 +1137,17 @@ QByteArray Track::serialiseExtraProperties() const
         return {};
     }
 
+    ExtraProperties props{p->extraProps};
+    ::normaliseExtraProperties(props);
+    if(props.empty()) {
+        return {};
+    }
+
     QByteArray out;
     QDataStream stream(&out, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Qt_6_0);
 
-    DataStream::writeContainer(stream, p->extraProps);
+    DataStream::writeContainer(stream, props);
 
     return out;
 }
@@ -1440,6 +1614,16 @@ void Track::setRGAlbumPeak(float peak)
     p->rgAlbumPeak = peak;
 }
 
+void Track::setOpusHeaderGainQ78(int16_t gainQ78)
+{
+    p->extraProps.insertOrAssign(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78), QString::number(gainQ78));
+}
+
+void Track::clearOpusHeaderGain()
+{
+    removeExtraProperty(QString::fromLatin1(Fooyin::Constants::OpusHeaderGainQ78));
+}
+
 void Track::clearRGInfo()
 {
     p->rgTrackGain = Constants::InvalidGain;
@@ -1485,10 +1669,11 @@ QString Track::techInfo(const QString& name) const
         {QString::fromLatin1(Channels),     [validNum](const Track& track) { return validNum(track.channels()); }},
         {QString::fromLatin1(BitDepth),     [validNum](const Track& track) { return validNum(track.bitDepth()); }},
         {QString::fromLatin1(Duration),     [validNum](const Track& track) { return validNum(track.duration()); }},
-        {QString::fromLatin1(RGTrackGain),  [](const Track& track) { return track.hasTrackGain() ? QString::number(track.rgTrackGain()) : QString{}; }},
-        {QString::fromLatin1(RGTrackPeak),  [](const Track& track) { return track.hasTrackPeak() ? QString::number(track.rgTrackPeak()) : QString{}; }},
-        {QString::fromLatin1(RGAlbumGain),  [](const Track& track) { return track.hasAlbumGain() ? QString::number(track.rgAlbumGain()) : QString{}; }},
-        {QString::fromLatin1(RGAlbumPeak),  [](const Track& track) { return track.hasAlbumPeak() ? QString::number(track.rgAlbumPeak()) : QString{}; }}
+        {QString::fromLatin1(RGTrackGain),  [](const Track& track) { return track.hasEffectiveTrackGain() ? QString::number(track.effectiveRGTrackGain()) : QString{}; }},
+        {QString::fromLatin1(RGTrackPeak),  [](const Track& track) { return track.hasEffectiveTrackPeak() ? QString::number(track.effectiveRGTrackPeak()) : QString{}; }},
+        {QString::fromLatin1(RGAlbumGain),  [](const Track& track) { return track.hasEffectiveAlbumGain() ? QString::number(track.effectiveRGAlbumGain()) : QString{}; }},
+        {QString::fromLatin1(RGAlbumPeak),  [](const Track& track) { return track.hasEffectiveAlbumPeak() ? QString::number(track.effectiveRGAlbumPeak()) : QString{}; }},
+        {QString::fromLatin1(OpusHeaderGain), [](const Track& track) { return track.hasOpusHeaderGain() ? QString::number(track.opusHeaderGainDb()) : QString{}; }}
     };
     // clang-format on
 
@@ -1627,6 +1812,11 @@ void Track::removeExtraProperty(const QString& prop)
     p->extraProps.erase(prop);
 }
 
+void Track::normaliseExtraProperties()
+{
+    ::normaliseExtraProperties(p->extraProps);
+}
+
 void Track::clearExtraProperties()
 {
     p->extraProps.clear();
@@ -1646,6 +1836,7 @@ void Track::storeExtraProperties(const QByteArray& props)
 
     Track::ExtraProperties loaded;
     if(p->readPropsToVector(stream, loaded)) {
+        ::normaliseExtraProperties(loaded);
         p->extraProps = std::move(loaded);
     }
 }
@@ -1839,6 +2030,75 @@ QStringList Track::supportedMimeTypes()
            u"application/ogg"_s, u"audio/opus"_s,         u"audio/x-opus+ogg"_s,
            u"audio/x-ms-wma"_s,  u"video/x-ms-asf"_s,     u"application/vnd.ms-asf"_s};
     return supportedTypes;
+}
+
+Track prepareOpusRGWriteTrack(const Track& track, OpusRGWriteMode mode)
+{
+    if(!track.isOpus()) {
+        return track;
+    }
+
+    OpusGainState currentState{
+        .headerGain = static_cast<int16_t>(opusHeaderGainQ78(track).value_or(0)),
+        .trackGain  = track.hasTrackGain() ? replayGainToOpusR128Q78(track.rgTrackGain()) : std::optional<int16_t>{},
+        .albumGain  = track.hasAlbumGain() ? replayGainToOpusR128Q78(track.rgAlbumGain()) : std::optional<int16_t>{},
+    };
+
+    int headerDeltaQ78{0};
+    int commentDeltaQ78{0};
+
+    switch(mode) {
+        case OpusRGWriteMode::Track:
+            if(!currentState.trackGain.has_value()) {
+                return track;
+            }
+
+            commentDeltaQ78 = *currentState.trackGain;
+            headerDeltaQ78  = commentDeltaQ78;
+            break;
+        case OpusRGWriteMode::Album:
+            if(!currentState.albumGain.has_value()) {
+                return track;
+            }
+
+            commentDeltaQ78 = *currentState.albumGain;
+            headerDeltaQ78  = commentDeltaQ78;
+            break;
+        case OpusRGWriteMode::LeaveNull:
+            headerDeltaQ78  = -currentState.headerGain;
+            commentDeltaQ78 = headerDeltaQ78;
+            break;
+    }
+
+    const auto newHeader = static_cast<long long>(currentState.headerGain) + headerDeltaQ78;
+    if(newHeader < std::numeric_limits<int16_t>::min() || newHeader > std::numeric_limits<int16_t>::max()) {
+        return track;
+    }
+
+    Track updatedTrack{track};
+    updatedTrack.setRGTrackGain(Constants::InvalidGain);
+    updatedTrack.setRGAlbumGain(Constants::InvalidGain);
+    updatedTrack.clearOpusHeaderGain();
+
+    if(const auto newTrackGain = adjustCommentGain(currentState.trackGain, commentDeltaQ78); currentState.trackGain) {
+        if(!newTrackGain.has_value()) {
+            return track;
+        }
+        updatedTrack.setRGTrackGain(q78ToDb(*newTrackGain) + 5.0F);
+    }
+
+    if(const auto newAlbumGain = adjustCommentGain(currentState.albumGain, commentDeltaQ78); currentState.albumGain) {
+        if(!newAlbumGain.has_value()) {
+            return track;
+        }
+        updatedTrack.setRGAlbumGain(q78ToDb(*newAlbumGain) + 5.0F);
+    }
+
+    if(newHeader != 0) {
+        updatedTrack.setOpusHeaderGainQ78(static_cast<int16_t>(newHeader));
+    }
+
+    return updatedTrack;
 }
 
 size_t qHash(const Track& track)

--- a/src/gui/replaygain/replaygainitem.cpp
+++ b/src/gui/replaygain/replaygainitem.cpp
@@ -22,6 +22,38 @@
 #include <core/constants.h>
 
 namespace Fooyin {
+namespace {
+float rawGainFromDisplay(const Track& track, float value)
+{
+    return value - track.opusHeaderGainDb();
+}
+
+float rawPeakFromDisplay(const Track& track, float value)
+{
+    return value * std::pow(10.0F, track.opusHeaderGainDb() / 20.0F);
+}
+
+float displayedTrackGain(const Track& track)
+{
+    return track.hasTrackGain() ? track.effectiveRGTrackGain() : Constants::InvalidGain;
+}
+
+float displayedTrackPeak(const Track& track)
+{
+    return track.hasTrackPeak() ? track.effectiveRGTrackPeak() : Constants::InvalidPeak;
+}
+
+float displayedAlbumGain(const Track& track)
+{
+    return track.hasAlbumGain() ? track.effectiveRGAlbumGain() : Constants::InvalidGain;
+}
+
+float displayedAlbumPeak(const Track& track)
+{
+    return track.hasAlbumPeak() ? track.effectiveRGAlbumPeak() : Constants::InvalidPeak;
+}
+} // namespace
+
 ReplayGainItem::ReplayGainItem()
     : ReplayGainItem{Entry, {}, nullptr}
 { }
@@ -94,22 +126,22 @@ Track ReplayGainItem::track() const
 
 float ReplayGainItem::trackGain() const
 {
-    return m_trackGain ? m_trackGain.value() : m_track.rgTrackGain();
+    return m_trackGain ? m_trackGain.value() : displayedTrackGain(m_track);
 }
 
 float ReplayGainItem::trackPeak() const
 {
-    return m_trackPeak ? m_trackPeak.value() : m_track.rgTrackPeak();
+    return m_trackPeak ? m_trackPeak.value() : displayedTrackPeak(m_track);
 }
 
 float ReplayGainItem::albumGain() const
 {
-    return m_albumGain ? m_albumGain.value() : m_track.rgAlbumGain();
+    return m_albumGain ? m_albumGain.value() : displayedAlbumGain(m_track);
 }
 
 float ReplayGainItem::albumPeak() const
 {
-    return m_albumPeak ? m_albumPeak.value() : m_track.rgAlbumPeak();
+    return m_albumPeak ? m_albumPeak.value() : displayedAlbumPeak(m_track);
 }
 
 bool ReplayGainItem::isSummary() const
@@ -139,22 +171,22 @@ void ReplayGainItem::setTrack(const Track& track)
 
 bool ReplayGainItem::setTrackGain(float value)
 {
-    return setGainOrPeak(m_trackGain, value, m_track.rgTrackGain(), Constants::InvalidGain, 2);
+    return setGainOrPeak(m_trackGain, value, displayedTrackGain(m_track), Constants::InvalidGain, 2);
 }
 
 bool ReplayGainItem::setTrackPeak(float value)
 {
-    return setGainOrPeak(m_trackPeak, value, m_track.rgTrackPeak(), Constants::InvalidPeak, 6);
+    return setGainOrPeak(m_trackPeak, value, displayedTrackPeak(m_track), Constants::InvalidPeak, 6);
 }
 
 bool ReplayGainItem::setAlbumGain(float value)
 {
-    return setGainOrPeak(m_albumGain, value, m_track.rgAlbumGain(), Constants::InvalidGain, 2);
+    return setGainOrPeak(m_albumGain, value, displayedAlbumGain(m_track), Constants::InvalidGain, 2);
 }
 
 bool ReplayGainItem::setAlbumPeak(float value)
 {
-    return setGainOrPeak(m_albumPeak, value, m_track.rgAlbumPeak(), Constants::InvalidPeak, 6);
+    return setGainOrPeak(m_albumPeak, value, displayedAlbumPeak(m_track), Constants::InvalidPeak, 6);
 }
 
 void ReplayGainItem::setIsEditable(bool isEditable)
@@ -179,19 +211,19 @@ bool ReplayGainItem::applyChanges()
     }
 
     if(m_trackGain) {
-        m_track.setRGTrackGain(m_trackGain.value());
+        m_track.setRGTrackGain(rawGainFromDisplay(m_track, m_trackGain.value()));
         m_trackGain = {};
     }
     if(m_trackPeak) {
-        m_track.setRGTrackPeak(m_trackPeak.value());
+        m_track.setRGTrackPeak(rawPeakFromDisplay(m_track, m_trackPeak.value()));
         m_trackPeak = {};
     }
     if(m_albumGain) {
-        m_track.setRGAlbumGain(m_albumGain.value());
+        m_track.setRGAlbumGain(rawGainFromDisplay(m_track, m_albumGain.value()));
         m_albumGain = {};
     }
     if(m_albumPeak) {
-        m_track.setRGAlbumPeak(m_albumPeak.value());
+        m_track.setRGAlbumPeak(rawPeakFromDisplay(m_track, m_albumPeak.value()));
         m_albumPeak = {};
     }
 

--- a/src/gui/replaygain/replaygainmodel.cpp
+++ b/src/gui/replaygain/replaygainmodel.cpp
@@ -81,7 +81,33 @@ TrackList ReplayGainModel::applyChanges()
 
     for(auto& item : m_nodes | std::views::values) {
         if(item.applyChanges()) {
-            tracks.emplace_back(item.track());
+            const Track changedTrack = item.track();
+            auto trackIt             = std::ranges::find_if(
+                tracks, [&changedTrack](const Track& track) { return track.sameIdentityAs(changedTrack); });
+
+            if(trackIt == tracks.end()) {
+                tracks.emplace_back(changedTrack);
+                trackIt = std::prev(tracks.end());
+            }
+
+            switch(item.type()) {
+                case ReplayGainItem::TrackGain:
+                    trackIt->setRGTrackGain(changedTrack.rgTrackGain());
+                    break;
+                case ReplayGainItem::TrackPeak:
+                    trackIt->setRGTrackPeak(changedTrack.rgTrackPeak());
+                    break;
+                case ReplayGainItem::AlbumGain:
+                    trackIt->setRGAlbumGain(changedTrack.rgAlbumGain());
+                    break;
+                case ReplayGainItem::AlbumPeak:
+                    trackIt->setRGAlbumPeak(changedTrack.rgAlbumPeak());
+                    break;
+                case ReplayGainItem::Header:
+                case ReplayGainItem::Entry:
+                    *trackIt = changedTrack;
+                    break;
+            }
         }
     }
 

--- a/src/gui/replaygain/replaygainpopulator.cpp
+++ b/src/gui/replaygain/replaygainpopulator.cpp
@@ -120,14 +120,18 @@ void ReplayGainPopulator::run(const TrackList& tracks)
 
     if(tracks.size() == 1) {
         const Track& track = tracks.front();
-        p->addNodeIfNew(u"TrackGain"_s, tr("Track Gain"), track.rgTrackGain(), ReplayGainModel::ItemParent::Root,
-                        ReplayGainItem::TrackGain, track);
-        p->addNodeIfNew(u"TrackPeak"_s, tr("Track Peak"), track.rgTrackPeak(), ReplayGainModel::ItemParent::Root,
-                        ReplayGainItem::TrackPeak, track);
-        p->addNodeIfNew(u"AlbumGain"_s, tr("Album Gain"), track.rgAlbumGain(), ReplayGainModel::ItemParent::Root,
-                        ReplayGainItem::AlbumGain, track);
-        p->addNodeIfNew(u"AlbumPeak"_s, tr("Album Peak"), track.rgAlbumPeak(), ReplayGainModel::ItemParent::Root,
-                        ReplayGainItem::AlbumPeak, track);
+        p->addNodeIfNew(u"TrackGain"_s, tr("Track Gain"),
+                        track.hasTrackGain() ? track.effectiveRGTrackGain() : Constants::InvalidGain,
+                        ReplayGainModel::ItemParent::Root, ReplayGainItem::TrackGain, track);
+        p->addNodeIfNew(u"TrackPeak"_s, tr("Track Peak"),
+                        track.hasTrackPeak() ? track.effectiveRGTrackPeak() : Constants::InvalidPeak,
+                        ReplayGainModel::ItemParent::Root, ReplayGainItem::TrackPeak, track);
+        p->addNodeIfNew(u"AlbumGain"_s, tr("Album Gain"),
+                        track.hasAlbumGain() ? track.effectiveRGAlbumGain() : Constants::InvalidGain,
+                        ReplayGainModel::ItemParent::Root, ReplayGainItem::AlbumGain, track);
+        p->addNodeIfNew(u"AlbumPeak"_s, tr("Album Peak"),
+                        track.hasAlbumPeak() ? track.effectiveRGAlbumPeak() : Constants::InvalidPeak,
+                        ReplayGainModel::ItemParent::Root, ReplayGainItem::AlbumPeak, track);
     }
     else {
         if(auto* gain

--- a/src/gui/replaygain/replaygainwidget.cpp
+++ b/src/gui/replaygain/replaygainwidget.cpp
@@ -23,9 +23,11 @@
 #include "replaygainmodel.h"
 #include "replaygainview.h"
 
+#include <core/internalcoresettings.h>
 #include <core/library/libraryutils.h>
 #include <core/library/musiclibrary.h>
 #include <utils/actions/actionmanager.h>
+#include <utils/settings/settingsmanager.h>
 
 #include <QHeaderView>
 #include <QVBoxLayout>
@@ -35,7 +37,18 @@ using namespace Qt::StringLiterals;
 namespace {
 void mergeTracks(Fooyin::TrackList& destination, const Fooyin::TrackList& source)
 {
-    updateCommonTracks(destination, source, Fooyin::Utils::CommonOperation::Update);
+    for(const Fooyin::Track& track : source) {
+        const auto trackIt = std::ranges::find_if(destination, [&track](const Fooyin::Track& destinationTrack) {
+            return destinationTrack.sameIdentityAs(track);
+        });
+
+        if(trackIt != destination.end()) {
+            *trackIt = track;
+        }
+        else {
+            destination.emplace_back(track);
+        }
+    }
 }
 
 int replayGainColumnWidth(const Fooyin::ReplayGainView* view, const QString& headerText, const QString& sampleText)
@@ -47,11 +60,14 @@ int replayGainColumnWidth(const Fooyin::ReplayGainView* view, const QString& hea
 } // namespace
 
 namespace Fooyin {
-ReplayGainWidget::ReplayGainWidget(MusicLibrary* library, const TrackList& tracks, bool readOnly, QWidget* parent)
+ReplayGainWidget::ReplayGainWidget(MusicLibrary* library, const TrackList& tracks, bool readOnly,
+                                   SettingsManager* settings, QWidget* parent)
     : PropertiesTabWidget{parent}
     , m_library{library}
+    , m_settings{settings}
     , m_view{new ReplayGainView(this)}
     , m_model{new ReplayGainModel(readOnly, this)}
+    , m_opusWriteMode{static_cast<OpusRGWriteMode>(m_settings->value<Settings::Core::Internal::OpusHeaderWriteMode>())}
 {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins({});
@@ -82,8 +98,14 @@ void ReplayGainWidget::apply()
     commitPendingChanges();
 
     if(!m_pendingTracks.empty()) {
+        TrackList tracksToWrite;
+        tracksToWrite.reserve(m_pendingTracks.size());
+        for(const Track& track : std::as_const(m_pendingTracks)) {
+            tracksToWrite.emplace_back(prepareOpusRGWriteTrack(track, m_opusWriteMode));
+        }
+
         emit tracksChanged(m_pendingTracks);
-        m_library->writeTrackMetadata(m_pendingTracks);
+        m_library->writeTrackMetadata(tracksToWrite);
         m_pendingTracks.clear();
     }
 }

--- a/src/gui/replaygain/replaygainwidget.h
+++ b/src/gui/replaygain/replaygainwidget.h
@@ -31,7 +31,8 @@ class ReplayGainWidget : public PropertiesTabWidget
     Q_OBJECT
 
 public:
-    ReplayGainWidget(MusicLibrary* library, const TrackList& tracks, bool readOnly, QWidget* parent = nullptr);
+    ReplayGainWidget(MusicLibrary* library, const TrackList& tracks, bool readOnly, SettingsManager* settings,
+                     QWidget* parent = nullptr);
 
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
@@ -45,8 +46,11 @@ private:
     void updateHeaderModes() const;
 
     MusicLibrary* m_library;
+    SettingsManager* m_settings;
+
     ReplayGainView* m_view;
     ReplayGainModel* m_model;
+    OpusRGWriteMode m_opusWriteMode;
 
     TrackList m_pendingTracks;
 };

--- a/src/gui/selectioninfo/infopopulator.cpp
+++ b/src/gui/selectioninfo/infopopulator.cpp
@@ -21,6 +21,7 @@
 
 #include "infomodel.h"
 
+#include <core/constants.h>
 #include <core/library/librarymanager.h>
 #include <core/track.h>
 #include <utils/enum.h>
@@ -91,6 +92,8 @@ public:
     std::set<float> m_trackPeak;
     std::set<float> m_albumGain;
     std::set<float> m_albumPeak;
+    std::set<float> m_opusHeaderGain;
+    int m_opusTrackCount{0};
 };
 
 void InfoPopulatorPrivate::reset()
@@ -100,6 +103,8 @@ void InfoPopulatorPrivate::reset()
     m_trackPeak.clear();
     m_albumGain.clear();
     m_albumPeak.clear();
+    m_opusHeaderGain.clear();
+    m_opusTrackCount = 0;
 }
 
 InfoItem* InfoPopulatorPrivate::getOrAddNode(const QString& key, const QString& name, ItemParent parent,
@@ -229,6 +234,31 @@ void InfoPopulatorPrivate::addTrackGeneral(int total, const Track& track)
     }
     checkAddEntryNode(u"SampleRate"_s, InfoPopulator::tr("Sample Rate"), ItemParent::General,
                       u"%1 Hz"_s.arg(track.sampleRate()), InfoItem::Percentage);
+
+    if(track.hasEffectiveTrackGain()) {
+        m_trackGain.emplace(track.effectiveRGTrackGain());
+    }
+    if(track.hasEffectiveTrackPeak()) {
+        m_trackPeak.emplace(track.effectiveRGTrackPeak());
+    }
+    if(track.hasEffectiveAlbumGain()) {
+        m_albumGain.emplace(track.effectiveRGAlbumGain());
+    }
+    if(track.hasEffectiveAlbumPeak()) {
+        m_albumPeak.emplace(track.effectiveRGAlbumPeak());
+    }
+    if(track.isOpus()) {
+        ++m_opusTrackCount;
+        m_opusHeaderGain.emplace(track.opusHeaderGainDb());
+    }
+
+    if(m_opusTrackCount == total && m_opusHeaderGain.size() == 1) {
+        checkAddEntryNode(
+            u"OpusHeaderGain"_s, InfoPopulator::tr("Opus header gain"), ItemParent::General,
+            QString::number(*m_opusHeaderGain.cbegin()), InfoItem::Total,
+            InfoItem::FormatFloatFunc{[](double gain) { return u"%1 dB"_s.arg(QString::number(gain, 'f', 2)); }}, true);
+    }
+
     checkAddEntryNode(u"Codec"_s, InfoPopulator::tr("Codec"), ItemParent::General,
                       !track.codec().isEmpty() ? track.codec() : track.extension().toUpper(), InfoItem::Percentage);
     checkAddEntryNode(u"CodecProfile"_s, InfoPopulator::tr("Codec Profile"), ItemParent::General, track.codecProfile(),
@@ -294,6 +324,9 @@ void InfoPopulatorPrivate::addTrackOther(const Track& track)
 {
     const auto props = track.extraProperties();
     for(const auto& [prop, value] : props) {
+        if(prop.startsWith("_"_L1)) {
+            continue;
+        }
         const auto extraProp = u"<%1>"_s.arg(prop);
         checkAddEntryNode(extraProp, extraProp, ItemParent::Other, value, InfoItem::Percentage);
     }
@@ -322,19 +355,6 @@ void InfoPopulatorPrivate::addTrackNodes(InfoItem::Options options, const TrackL
         }
         if(options & InfoItem::Other) {
             addTrackOther(track);
-        }
-
-        if(track.hasTrackGain()) {
-            m_trackGain.emplace(track.rgTrackGain());
-        }
-        if(track.hasTrackPeak()) {
-            m_trackPeak.emplace(track.rgTrackPeak());
-        }
-        if(track.hasAlbumGain()) {
-            m_albumGain.emplace(track.rgAlbumGain());
-        }
-        if(track.hasAlbumPeak()) {
-            m_albumPeak.emplace(track.rgAlbumPeak());
         }
     }
 

--- a/src/gui/settings/playback/replaygainpage.cpp
+++ b/src/gui/settings/playback/replaygainpage.cpp
@@ -22,6 +22,7 @@
 #include <core/coresettings.h>
 #include <core/engine/enginecontroller.h>
 #include <core/internalcoresettings.h>
+#include <core/track.h>
 #include <gui/guiconstants.h>
 #include <gui/widgets/doubleslidereditor.h>
 #include <gui/widgets/scriptlineedit.h>
@@ -58,6 +59,9 @@ private:
     QRadioButton* m_trackGain;
     QRadioButton* m_albumGain;
     QRadioButton* m_orderGain;
+    QRadioButton* m_leaveHeaderNull;
+    QRadioButton* m_useTrackHeader;
+    QRadioButton* m_useAlbumHeader;
     DoubleSliderEditor* m_rgPreAmp;
     DoubleSliderEditor* m_preAmp;
 };
@@ -71,6 +75,9 @@ ReplayGainPageWidget::ReplayGainPageWidget(SettingsManager* settings)
     , m_trackGain{new QRadioButton(tr("Use track-based gain"), this)}
     , m_albumGain{new QRadioButton(tr("Use album-based gain"), this)}
     , m_orderGain{new QRadioButton(tr("Use gain based on playback order"), this)}
+    , m_leaveHeaderNull{new QRadioButton(tr("Leave null"), this)}
+    , m_useTrackHeader{new QRadioButton(tr("Use Track Gain"), this)}
+    , m_useAlbumHeader{new QRadioButton(tr("Use Album Gain"), this)}
     , m_rgPreAmp{new DoubleSliderEditor(this)}
     , m_preAmp{new DoubleSliderEditor(this)}
 {
@@ -106,6 +113,25 @@ ReplayGainPageWidget::ReplayGainPageWidget(SettingsManager* settings)
     typeBoxLayout->addWidget(m_albumGain);
     typeBoxLayout->addWidget(m_orderGain);
 
+    auto* opusGroupBox    = new QGroupBox(tr("Opus Header Gain"), this);
+    auto* opusButtonGroup = new QButtonGroup(this);
+    auto* opusBoxLayout   = new QVBoxLayout(opusGroupBox);
+
+    opusButtonGroup->addButton(m_leaveHeaderNull);
+    opusButtonGroup->addButton(m_useTrackHeader);
+    opusButtonGroup->addButton(m_useAlbumHeader);
+
+    m_useTrackHeader->setToolTip(
+        tr("Write track gain to the Opus header and keep album gain in the R128 comment field"));
+    m_useAlbumHeader->setToolTip(
+        tr("Write album gain to the Opus header and keep track gain in the R128 comment field"));
+    m_leaveHeaderNull->setToolTip(
+        tr("Do not write ReplayGain values to the Opus header unless changed explicitly elsewhere"));
+
+    opusBoxLayout->addWidget(m_useTrackHeader);
+    opusBoxLayout->addWidget(m_useAlbumHeader);
+    opusBoxLayout->addWidget(m_leaveHeaderNull);
+
     auto* preAmpGroup  = new QGroupBox(tr("Pre-amplification"), this);
     auto* preAmpLayout = new QGridLayout(preAmpGroup);
 
@@ -127,15 +153,18 @@ ReplayGainPageWidget::ReplayGainPageWidget(SettingsManager* settings)
     m_preAmp->setToolTip(preAmpToolTip);
     preAmpLabel->setToolTip(preAmpToolTip);
 
-    preAmpLayout->addWidget(rgPreAmpLabel, 0, 0);
-    preAmpLayout->addWidget(m_rgPreAmp, 0, 1);
-    preAmpLayout->addWidget(preAmpLabel, 1, 0);
-    preAmpLayout->addWidget(m_preAmp, 1, 1);
+    int row{0};
+    preAmpLayout->addWidget(rgPreAmpLabel, row, 0);
+    preAmpLayout->addWidget(m_rgPreAmp, row++, 1);
+    preAmpLayout->addWidget(preAmpLabel, row, 0);
+    preAmpLayout->addWidget(m_preAmp, row++, 1);
     preAmpLayout->setColumnStretch(1, 1);
 
-    layout->addWidget(modeGroupBox, 0, 0);
-    layout->addWidget(typeGroupBox, 1, 0);
-    layout->addWidget(preAmpGroup, 2, 0);
+    row = 0;
+    layout->addWidget(modeGroupBox, row++, 0);
+    layout->addWidget(typeGroupBox, row++, 0);
+    layout->addWidget(preAmpGroup, row++, 0);
+    layout->addWidget(opusGroupBox, row++, 0);
 
     layout->setRowStretch(layout->rowCount(), 1);
 }
@@ -153,6 +182,12 @@ void ReplayGainPageWidget::load()
     m_trackGain->setChecked(gainType == ReplayGainType::Track);
     m_albumGain->setChecked(gainType == ReplayGainType::Album);
     m_orderGain->setChecked(gainType == ReplayGainType::PlaybackOrder);
+
+    const auto opusMode
+        = static_cast<OpusRGWriteMode>(m_settings->value<Settings::Core::Internal::OpusHeaderWriteMode>());
+    m_useTrackHeader->setChecked(opusMode == OpusRGWriteMode::Track);
+    m_useAlbumHeader->setChecked(opusMode == OpusRGWriteMode::Album);
+    m_leaveHeaderNull->setChecked(opusMode == OpusRGWriteMode::LeaveNull);
 
     const auto rgPreAmp = static_cast<double>(m_settings->value<Settings::Core::RGPreAmp>());
     m_rgPreAmp->setValue(rgPreAmp);
@@ -189,6 +224,11 @@ void ReplayGainPageWidget::apply()
         m_settings->set<Settings::Core::RGType>(static_cast<int>(ReplayGainType::PlaybackOrder));
     }
 
+    const auto opusMode = m_useTrackHeader->isChecked() ? OpusRGWriteMode::Track
+                        : m_useAlbumHeader->isChecked() ? OpusRGWriteMode::Album
+                                                        : OpusRGWriteMode::LeaveNull;
+    m_settings->set<Settings::Core::Internal::OpusHeaderWriteMode>(static_cast<int>(opusMode));
+
     m_settings->set<Settings::Core::RGPreAmp>(static_cast<float>(m_rgPreAmp->value()));
     m_settings->set<Settings::Core::NonRGPreAmp>(static_cast<float>(m_preAmp->value()));
 }
@@ -197,6 +237,7 @@ void ReplayGainPageWidget::reset()
 {
     m_settings->reset<Settings::Core::RGMode>();
     m_settings->reset<Settings::Core::RGType>();
+    m_settings->reset<Settings::Core::Internal::OpusHeaderWriteMode>();
     m_settings->reset<Settings::Core::RGPreAmp>();
     m_settings->reset<Settings::Core::NonRGPreAmp>();
 }

--- a/src/gui/trackselectioncontroller.cpp
+++ b/src/gui/trackselectioncontroller.cpp
@@ -947,16 +947,24 @@ void TrackSelectionController::executeAction(TrackAction action, PlaylistAction:
 
 void TrackSelectionController::tracksUpdated(const TrackList& tracks)
 {
+    Utils::updateCommonTracks(p->m_tracks.tracks, tracks, Utils::CommonOperation::Update);
     for(auto& [_, selection] : p->m_contextSelection) {
         Utils::updateCommonTracks(selection.tracks, tracks, Utils::CommonOperation::Update);
     }
+
+    p->updateActionState();
+    emit selectionChanged();
 }
 
 void TrackSelectionController::tracksRemoved(const TrackList& tracks)
 {
+    Utils::updateCommonTracks(p->m_tracks.tracks, tracks, Utils::CommonOperation::Remove);
     for(auto& [_, selection] : p->m_contextSelection) {
         Utils::updateCommonTracks(selection.tracks, tracks, Utils::CommonOperation::Remove);
     }
+
+    p->updateActionState();
+    emit selectionChanged();
 }
 } // namespace Fooyin
 

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -79,7 +79,6 @@
 #include "settings/widgets/statuswidgetpage.h"
 #include "splitters/splitterwidget.h"
 #include "splitters/tabstackwidget.h"
-#include "statusevent.h"
 #include "widgets/coverwidget.h"
 #include "widgets/dummy.h"
 #include "widgets/spacer.h"
@@ -324,7 +323,7 @@ void Widgets::registerPropertiesTabs()
         const bool canWrite = std::ranges::all_of(tracks, [this](const Track& track) {
             return !track.hasCue() && !track.isInArchive() && m_core->audioLoader()->canWriteMetadata(track);
         });
-        return new ReplayGainWidget(m_core->library(), tracks, !canWrite, m_window);
+        return new ReplayGainWidget(m_core->library(), tracks, !canWrite, m_settings, m_window);
     });
     m_gui->propertiesDialog()->addTab(tr("Artwork"), [this](const TrackList& tracks) {
         const bool canWrite = std::ranges::all_of(tracks, [this](const Track& track) {

--- a/src/plugins/rgscanner/CMakeLists.txt
+++ b/src/plugins/rgscanner/CMakeLists.txt
@@ -13,17 +13,21 @@ create_fooyin_plugin_internal(
             ${FFMPEG_LIBRARIES}
     SOURCES ffmpegscanner.cpp
             ffmpegscanner.h
+            opusheadergaindialog.cpp
+            opusheadergaindialog.h
+            opusreplaygainutils.cpp
+            opusreplaygainutils.h
             rgscanner.cpp
             rgscanner.h
-        rgscannerdefs.h
+            rgscannerdefs.h
             rgscannerpage.cpp
             rgscannerpage.h
             rgscannerplugin.cpp
             rgscannerplugin.h
-        rgscanresults.cpp
-        rgscanresults.h
-        rgscanresultsmodel.cpp
-        rgscanresultsmodel.h
+            rgscanresults.cpp
+            rgscanresults.h
+            rgscanresultsmodel.cpp
+            rgscanresultsmodel.h
 )
 
 target_include_directories(rgscanner PRIVATE ${FFMPEG_INCLUDE_DIRS})
@@ -33,4 +37,3 @@ if(HAVE_EBUR128)
     target_sources(rgscanner PRIVATE ebur128scanner.cpp ebur128scanner.h)
     target_compile_definitions(rgscanner PRIVATE HAVE_EBUR128)
 endif()
-

--- a/src/plugins/rgscanner/ebur128scanner.cpp
+++ b/src/plugins/rgscanner/ebur128scanner.cpp
@@ -31,11 +31,27 @@
 
 Q_LOGGING_CATEGORY(EBUR128, "fy.ebur128")
 
+using namespace Qt::StringLiterals;
+
 constexpr auto ReferenceLUFS  = -18;
 constexpr auto BufferSize     = 10240;
 constexpr auto SingleAlbumKey = "Album";
 
 namespace Fooyin::RGScanner {
+namespace {
+bool storesReplayGainPeak(const Track& track)
+{
+    return !track.isOpus();
+}
+
+void clearReplayGain(TrackList& tracks)
+{
+    for(Track& track : tracks) {
+        track.clearRGInfo();
+    }
+}
+} // namespace
+
 Ebur128Scanner::Ebur128Scanner(std::shared_ptr<AudioLoader> audioLoader, QObject* parent)
     : RGWorker{parent}
     , m_audioLoader{std::move(audioLoader)}
@@ -74,6 +90,7 @@ void Ebur128Scanner::calculatePerTrack(const TrackList& tracks, bool truePeak)
     m_watcher       = new QFutureWatcher<void>(this);
     m_tracks        = tracks;
     m_scannedTracks = tracks;
+    clearReplayGain(m_scannedTracks);
 
     QObject::connect(m_watcher, &QFutureWatcher<void>::progressValueChanged, this, [this](const int val) {
         if(val >= 0 && std::cmp_less(val, m_tracks.size())) {
@@ -107,6 +124,7 @@ void Ebur128Scanner::calculateAsAlbum(const TrackList& tracks, bool truePeak)
     m_watcher       = new QFutureWatcher<void>(this);
     m_tracks        = tracks;
     m_scannedTracks = tracks;
+    clearReplayGain(m_scannedTracks);
 
     QObject::connect(m_watcher, &QFutureWatcher<void>::progressValueChanged, this, [this](const int val) {
         if(val >= 0 && std::cmp_less(val, m_tracks.size())) {
@@ -139,7 +157,9 @@ void Ebur128Scanner::calculateAsAlbum(const TrackList& tracks, bool truePeak)
 
             for(Track& track : m_scannedTracks) {
                 track.setRGAlbumGain(static_cast<float>(albumGain));
-                track.setRGAlbumPeak(albumPeak);
+                if(storesReplayGainPeak(track)) {
+                    track.setRGAlbumPeak(albumPeak);
+                }
             }
         }
 
@@ -162,7 +182,9 @@ void Ebur128Scanner::calculateByAlbumTags(const TrackList& tracks, const QString
 
     for(const auto& track : tracks) {
         const QString album = m_parser.evaluate(groupScript, track);
-        m_albums[album].push_back(track);
+        auto scannedTrack   = track;
+        scannedTrack.clearRGInfo();
+        m_albums[album].push_back(std::move(scannedTrack));
     }
 
     m_currentAlbum = m_albums.begin();
@@ -234,7 +256,9 @@ void Ebur128Scanner::scanTrack(Track& track, bool truePeak, const QString& album
         }
     }
 
-    track.setRGTrackPeak(static_cast<float>(trackPeak));
+    if(storesReplayGainPeak(track)) {
+        track.setRGTrackPeak(static_cast<float>(trackPeak));
+    }
 
     if(!album.isEmpty()) {
         const std::scoped_lock lock{m_mutex};
@@ -289,12 +313,18 @@ void Ebur128Scanner::scanAlbum(bool truePeak)
 
             auto& albumTracks = m_currentAlbum->second;
 
-            const float albumPeak
-                = std::ranges::max_element(albumTracks, std::ranges::less{}, &Track::rgTrackPeak)->rgTrackPeak();
+            float albumPeak{Constants::InvalidPeak};
+            for(const Track& track : std::as_const(albumTracks)) {
+                if(storesReplayGainPeak(track) && track.hasTrackPeak()) {
+                    albumPeak = std::max(albumPeak, track.rgTrackPeak());
+                }
+            }
 
             for(Track& track : albumTracks) {
                 track.setRGAlbumGain(static_cast<float>(albumGain));
-                track.setRGAlbumPeak(albumPeak);
+                if(storesReplayGainPeak(track) && albumPeak != Constants::InvalidPeak) {
+                    track.setRGAlbumPeak(albumPeak);
+                }
             }
 
             albumState->second.clear();

--- a/src/plugins/rgscanner/ffmpegscanner.cpp
+++ b/src/plugins/rgscanner/ffmpegscanner.cpp
@@ -60,6 +60,18 @@ constexpr auto FrameFlags   = AV_BUFFERSRC_FLAG_KEEP_REF | AV_BUFFERSRC_FLAG_NO_
 constexpr auto DecoderFlags = Fooyin::AudioDecoder::NoSeeking | Fooyin::AudioDecoder::NoLooping;
 
 namespace {
+bool storesReplayGainPeak(const Fooyin::Track& track)
+{
+    return !track.isOpus();
+}
+
+void clearReplayGain(Fooyin::TrackList& tracks)
+{
+    for(Fooyin::Track& track : tracks) {
+        track.clearRGInfo();
+    }
+}
+
 struct FilterGraphDeleter
 {
     void operator()(AVFilterGraph* graph) const
@@ -294,7 +306,9 @@ void FFmpegReplayGainPrivate::scanAlbum(FFmpegContext& context, TrackList& track
         if(setupTrack(context, track, context.trackFilter)) {
             const ReplayGainResult trackResult = handleTrack(context, true);
             track.setRGTrackGain(static_cast<float>(trackResult.gain));
-            track.setRGTrackPeak(static_cast<float>(trackResult.peak));
+            if(storesReplayGainPeak(track)) {
+                track.setRGTrackPeak(static_cast<float>(trackResult.peak));
+            }
         }
     }
 
@@ -305,8 +319,10 @@ void FFmpegReplayGainPrivate::scanAlbum(FFmpegContext& context, TrackList& track
     const auto albumResult = extractRGValues(context.albumFilter.filterGraph.get(), context.truePeak);
 
     for(Track& track : tracks) {
-        track.setRGAlbumPeak(static_cast<float>(albumResult.peak));
         track.setRGAlbumGain(static_cast<float>(albumResult.gain));
+        if(storesReplayGainPeak(track)) {
+            track.setRGAlbumPeak(static_cast<float>(albumResult.peak));
+        }
     }
 }
 
@@ -343,6 +359,7 @@ void FFmpegScanner::calculatePerTrack(const TrackList& tracks, bool truePeak)
 
     p->m_tracks        = tracks;
     p->m_scannedTracks = tracks;
+    clearReplayGain(p->m_scannedTracks);
 
     QObject::connect(p->m_future, &QFutureWatcher<void>::progressValueChanged, this, [this](const int val) {
         if(val >= 0 && std::cmp_less(val, p->m_tracks.size())) {
@@ -356,7 +373,9 @@ void FFmpegScanner::calculatePerTrack(const TrackList& tracks, bool truePeak)
         if(setupTrack(context, track, context.trackFilter)) {
             const ReplayGainResult result = handleTrack(context, false);
             track.setRGTrackGain(static_cast<float>(result.gain));
-            track.setRGTrackPeak(static_cast<float>(result.peak));
+            if(storesReplayGainPeak(track)) {
+                track.setRGTrackPeak(static_cast<float>(result.peak));
+            }
         }
     });
 
@@ -382,6 +401,7 @@ void FFmpegScanner::calculateAsAlbum(const TrackList& tracks, bool truePeak)
     FFmpegContext context{truePeak};
 
     TrackList scannedTracks{tracks};
+    clearReplayGain(scannedTracks);
     p->scanAlbum(context, scannedTracks);
 
     if(mayRun()) {
@@ -400,10 +420,14 @@ void FFmpegScanner::calculateByAlbumTags(const TrackList& tracks, const QString&
     qCDebug(FFMPEG) << "Calculating RG using ffmpeg for" << tracks.size() << "tracks";
 
     p->m_future = new QFutureWatcher<void>(this);
+    p->m_scannedTracks.clear();
+    p->m_albums.clear();
 
     for(const auto& track : tracks) {
         const QString album = p->m_parser.evaluate(groupScript, track);
-        p->m_albums[album].push_back(track);
+        auto scannedTrack   = track;
+        scannedTrack.clearRGInfo();
+        p->m_albums[album].push_back(std::move(scannedTrack));
     }
 
     auto future = QtConcurrent::map(p->m_albums, [this, truePeak](auto& album) {

--- a/src/plugins/rgscanner/opusheadergaindialog.cpp
+++ b/src/plugins/rgscanner/opusheadergaindialog.cpp
@@ -1,0 +1,470 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "opusheadergaindialog.h"
+
+#include "opusreplaygainutils.h"
+#include "rgscannerdefs.h"
+
+#include <core/constants.h>
+#include <core/coresettings.h>
+#include <core/engine/audioloader.h>
+#include <core/library/musiclibrary.h>
+#include <gui/widgets/slidereditor.h>
+#include <utils/settings/settingsmanager.h>
+#include <utils/utils.h>
+
+#include <QButtonGroup>
+#include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QFileInfo>
+#include <QFutureWatcher>
+#include <QGridLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSpacerItem>
+#include <QtConcurrentRun>
+
+#include <atomic>
+#include <limits>
+#include <optional>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto MinTargetVolumeDb = 70;
+constexpr auto MaxTargetVolumeDb = 110;
+
+namespace Fooyin::RGScanner {
+namespace {
+struct OpusHeaderGainBatchResult
+{
+    TrackList updatedTracks;
+    QStringList failedFiles;
+    int unchanged{0};
+    bool cancelled{false};
+};
+
+struct OpusHeaderGainAvailability
+{
+    int missingTrackGain{0};
+    int missingAlbumGain{0};
+
+    [[nodiscard]] bool hasTrackGainForAll() const
+    {
+        return missingTrackGain == 0;
+    }
+
+    [[nodiscard]] bool hasAlbumGainForAll() const
+    {
+        return missingAlbumGain == 0;
+    }
+};
+
+QString dialogText(const char* sourceText)
+{
+    return QCoreApplication::translate("OpusHeaderGainDialog", sourceText);
+}
+
+OpusHeaderGainAvailability analyseSelection(const TrackList& tracks)
+{
+    OpusHeaderGainAvailability availability;
+
+    for(const Track& track : tracks) {
+        if(!track.hasTrackGain()) {
+            ++availability.missingTrackGain;
+        }
+        if(!track.hasAlbumGain()) {
+            ++availability.missingAlbumGain;
+        }
+    }
+
+    return availability;
+}
+
+Track updatedTrackFromState(const Track& originalTrack, const OpusGainState& state, bool storeZeroHeaderGain = false)
+{
+    Track updatedTrack{originalTrack};
+    removeReplayGainTags(updatedTrack);
+    updatedTrack.clearOpusHeaderGain();
+
+    if(state.trackGain.has_value()) {
+        updatedTrack.setRGTrackGain(q78ToDb(*state.trackGain) + 5.0F);
+    }
+    if(state.albumGain.has_value()) {
+        updatedTrack.setRGAlbumGain(q78ToDb(*state.albumGain) + 5.0F);
+    }
+    if(storeZeroHeaderGain || state.headerGain != 0) {
+        updatedTrack.setOpusHeaderGainQ78(state.headerGain);
+    }
+
+    const QDateTime modifiedTime = QFileInfo{updatedTrack.filepath()}.lastModified();
+    updatedTrack.setModifiedTime(modifiedTime.isValid() ? modifiedTime.toMSecsSinceEpoch() : 0);
+    return updatedTrack;
+}
+
+bool updateOpusHeaderGainForTrack(AudioLoader* audioLoader, const Track& track, OpusHeaderGainMode mode,
+                                  std::optional<int16_t> explicitGain, const OpusHeaderGainOptions& headerOptions,
+                                  bool preserveTimestamps, Track& updatedTrack)
+{
+    if(!audioLoader) {
+        return false;
+    }
+
+    const OpusGainState currentState{
+        .headerGain = track.opusHeaderGainQ78().value_or(0),
+        .trackGain  = track.hasTrackGain() ? replayGainToOpusR128Q78(track.rgTrackGain()) : std::optional<int16_t>{},
+        .albumGain  = track.hasAlbumGain() ? replayGainToOpusR128Q78(track.rgAlbumGain()) : std::optional<int16_t>{},
+    };
+
+    const auto updatedState = applyHeaderGainMode(currentState, mode, explicitGain, headerOptions);
+    if(!updatedState.has_value()) {
+        return false;
+    }
+    if(*updatedState == currentState) {
+        updatedTrack = Track{};
+        return true;
+    }
+
+    const Track trackToWrite = updatedTrackFromState(track, *updatedState, true);
+
+    AudioReader::WriteOptions options{AudioReader::Metadata};
+    if(preserveTimestamps) {
+        options |= AudioReader::PreserveTimestamps;
+    }
+
+    if(!audioLoader->writeTrackMetadata(trackToWrite, options)) {
+        return false;
+    }
+
+    updatedTrack                 = updatedTrackFromState(track, *updatedState);
+    const QDateTime modifiedTime = QFileInfo{updatedTrack.filepath()}.lastModified();
+    updatedTrack.setModifiedTime(modifiedTime.isValid() ? modifiedTime.toMSecsSinceEpoch() : 0);
+    return true;
+}
+
+class OpusHeaderGainDialog : public QDialog
+{
+public:
+    OpusHeaderGainDialog(std::shared_ptr<AudioLoader> audioLoader, MusicLibrary* library, SettingsManager* settings,
+                         TrackList tracks, QWidget* parent = nullptr)
+        : QDialog(parent)
+        , m_audioLoader(std::move(audioLoader))
+        , m_library(library)
+        , m_settings(settings)
+        , m_tracks(std::move(tracks))
+        , m_availability(analyseSelection(m_tracks))
+        , m_applyTrack(new QRadioButton(dialogText("Apply track ReplayGain"), this))
+        , m_applyAlbum(new QRadioButton(dialogText("Apply album ReplayGain"), this))
+        , m_setExplicit(new QRadioButton(dialogText("Specify header gain"), this))
+        , m_clearHeader(new QRadioButton(dialogText("Clear header gain"), this))
+        , m_explicitGain(new QDoubleSpinBox(this))
+        , m_targetVolume(new SliderEditor(dialogText("Target volume"), this))
+        , m_adjustLouderOrQuieter(new QRadioButton(dialogText("Make files louder or quieter"), this))
+        , m_adjustLouderOnly(new QRadioButton(dialogText("Make files louder only, do not change if too loud"), this))
+        , m_summary(new QLabel(this))
+        , m_currentFile(new QLabel(this))
+        , m_progress(new QProgressBar(this))
+        , m_buttonBox(new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this))
+        , m_watcher(new QFutureWatcher<OpusHeaderGainBatchResult>(this))
+        , m_cancelled(std::make_shared<std::atomic_bool>(false))
+    {
+        setModal(true);
+        setWindowTitle(dialogText("Opus Header Gain"));
+
+        auto* modeGroup = new QButtonGroup(this);
+        modeGroup->addButton(m_applyTrack);
+        modeGroup->addButton(m_applyAlbum);
+        modeGroup->addButton(m_setExplicit);
+        modeGroup->addButton(m_clearHeader);
+
+        auto* adjustmentGroup = new QButtonGroup(this);
+        m_adjustLouderOrQuieter->setAutoExclusive(false);
+        m_adjustLouderOnly->setAutoExclusive(false);
+        adjustmentGroup->addButton(m_adjustLouderOrQuieter);
+        adjustmentGroup->addButton(m_adjustLouderOnly);
+
+        m_explicitGain->setRange(-128.0, 127.99);
+        m_explicitGain->setDecimals(2);
+        m_explicitGain->setSingleStep(0.10);
+
+        m_targetVolume->setRange(MinTargetVolumeDb, MaxTargetVolumeDb);
+        m_targetVolume->setSingleStep(1);
+        m_targetVolume->setSuffix(u" dB"_s);
+        m_targetVolume->setValue(
+            m_settings->fileValue(OpusHeaderTargetVolumeSetting, static_cast<int>(ReplayGainReferenceDb)).toInt());
+        m_adjustLouderOnly->setChecked(m_settings->fileValue(OpusHeaderLouderOnlySetting, false).toBool());
+        m_adjustLouderOrQuieter->setChecked(!m_adjustLouderOnly->isChecked());
+
+        m_summary->setText(dialogText("%1 writable Opus file(s) selected").arg(m_tracks.size()));
+        m_currentFile->setText(dialogText("Ready"));
+        m_progress->setRange(0, static_cast<int>(m_tracks.size()));
+        m_progress->setValue(0);
+
+        if(m_availability.hasTrackGainForAll()) {
+            m_applyTrack->setChecked(true);
+        }
+        else if(m_availability.hasAlbumGainForAll()) {
+            m_applyAlbum->setChecked(true);
+        }
+        else {
+            m_setExplicit->setChecked(true);
+        }
+
+        auto* layout = new QGridLayout(this);
+
+        int row{0};
+        layout->addWidget(m_applyTrack, row++, 0, 1, 4);
+        layout->addWidget(m_applyAlbum, row++, 0, 1, 4);
+        layout->addWidget(m_setExplicit, row, 0);
+        layout->addWidget(m_explicitGain, row, 1);
+        layout->addWidget(new QLabel(u"dB"_s, this), row++, 2);
+        layout->addWidget(m_clearHeader, row++, 0, 1, 4);
+        layout->addItem(new QSpacerItem(0, 16), row++, 0);
+        layout->addWidget(m_targetVolume, row++, 0, 1, 4);
+        layout->addWidget(m_adjustLouderOrQuieter, row++, 0, 1, 4);
+        layout->addWidget(m_adjustLouderOnly, row++, 0, 1, 4);
+        layout->addItem(new QSpacerItem(0, 16), row++, 0);
+        layout->addWidget(m_summary, row++, 0, 1, 4);
+        layout->addWidget(m_currentFile, row++, 0, 1, 4);
+        layout->addWidget(m_progress, row++, 0, 1, 4);
+        layout->addWidget(m_buttonBox, row++, 0, 1, 4);
+        layout->setColumnStretch(1, 0);
+        layout->setColumnStretch(2, 0);
+        layout->setColumnStretch(3, 1);
+
+        m_buttonBox->button(QDialogButtonBox::Ok)->setText(dialogText("Start"));
+        m_buttonBox->button(QDialogButtonBox::Cancel)->setText(dialogText("Cancel"));
+
+        QObject::connect(m_applyTrack, &QRadioButton::toggled, this, [this]() { refreshControls(); });
+        QObject::connect(m_applyAlbum, &QRadioButton::toggled, this, [this]() { refreshControls(); });
+        QObject::connect(m_setExplicit, &QRadioButton::toggled, this, [this]() { refreshControls(); });
+        QObject::connect(m_clearHeader, &QRadioButton::toggled, this, [this]() { refreshControls(); });
+
+        QObject::connect(m_buttonBox, &QDialogButtonBox::accepted, this, [this]() {
+            if(!m_running) {
+                start();
+            }
+        });
+        QObject::connect(m_buttonBox, &QDialogButtonBox::rejected, this, [this]() {
+            if(m_running) {
+                m_cancelled->store(true, std::memory_order_release);
+                m_summary->setText(dialogText("Cancelling after the current file…"));
+            }
+            else {
+                reject();
+            }
+        });
+
+        QObject::connect(m_watcher, &QFutureWatcher<OpusHeaderGainBatchResult>::finished, this, [this]() {
+            m_running = false;
+
+            const auto result = m_watcher->result();
+            if(!result.failedFiles.isEmpty()) {
+                QMessageBox::warning(this, windowTitle(),
+                                     dialogText("Failed to update %1 file(s).\n\n%2")
+                                         .arg(result.failedFiles.size())
+                                         .arg(result.failedFiles.join(u'\n')));
+            }
+
+            if(!result.updatedTracks.empty()) {
+                m_summary->setText(dialogText("Updating library metadata…"));
+                QObject::connect(m_library, &MusicLibrary::tracksMetadataChanged, this, &QDialog::accept,
+                                 Qt::SingleShotConnection);
+                m_library->updateTrackMetadata(result.updatedTracks);
+                return;
+            }
+
+            if(result.cancelled) {
+                m_summary->setText(dialogText("Cancelled"));
+            }
+            else if(result.unchanged > 0) {
+                m_summary->setText(dialogText("No Opus header gain changes were needed"));
+            }
+            else {
+                m_summary->setText(dialogText("No files were updated"));
+            }
+
+            m_buttonBox->button(QDialogButtonBox::Cancel)->setText(dialogText("Close"));
+        });
+
+        refreshControls();
+    }
+
+private:
+    [[nodiscard]] OpusHeaderGainMode selectedMode() const
+    {
+        return m_applyAlbum->isChecked()  ? OpusHeaderGainMode::Album
+             : m_setExplicit->isChecked() ? OpusHeaderGainMode::Explicit
+             : m_clearHeader->isChecked() ? OpusHeaderGainMode::Clear
+                                          : OpusHeaderGainMode::Track;
+    }
+
+    void refreshControls()
+    {
+        if(m_running) {
+            return;
+        }
+
+        const bool canApplyTrack = m_availability.hasTrackGainForAll();
+        const bool canApplyAlbum = m_availability.hasAlbumGainForAll();
+
+        if(m_applyTrack->isChecked() && !canApplyTrack) {
+            if(canApplyAlbum) {
+                m_applyAlbum->setChecked(true);
+            }
+            else {
+                m_setExplicit->setChecked(true);
+            }
+        }
+        if(m_applyAlbum->isChecked() && !canApplyAlbum) {
+            if(canApplyTrack) {
+                m_applyTrack->setChecked(true);
+            }
+            else {
+                m_setExplicit->setChecked(true);
+            }
+        }
+
+        m_applyTrack->setEnabled(canApplyTrack);
+        m_applyAlbum->setEnabled(canApplyAlbum);
+
+        const bool applyReplayGainMode
+            = selectedMode() == OpusHeaderGainMode::Track || selectedMode() == OpusHeaderGainMode::Album;
+
+        m_explicitGain->setEnabled(m_setExplicit->isChecked());
+
+        m_targetVolume->setEnabled(applyReplayGainMode);
+        m_adjustLouderOrQuieter->setEnabled(applyReplayGainMode);
+        m_adjustLouderOnly->setEnabled(applyReplayGainMode);
+    }
+
+    void persistOptions() const
+    {
+        m_settings->fileSet(OpusHeaderTargetVolumeSetting, m_targetVolume->value());
+        m_settings->fileSet(OpusHeaderLouderOnlySetting, m_adjustLouderOnly->isChecked());
+    }
+
+    void start()
+    {
+        m_cancelled->store(false, std::memory_order_release);
+
+        const OpusHeaderGainMode mode = selectedMode();
+
+        const auto explicitGain
+            = mode == OpusHeaderGainMode::Explicit ? dbToQ78(m_explicitGain->value()) : std::optional<int16_t>{};
+        if(mode == OpusHeaderGainMode::Explicit && !explicitGain.has_value()) {
+            QMessageBox::warning(this, windowTitle(), dialogText("The requested header gain is out of range."));
+            return;
+        }
+
+        const OpusHeaderGainOptions headerOptions{
+            .targetVolumeDb = static_cast<double>(m_targetVolume->value()),
+            .louderOnly     = m_adjustLouderOnly->isChecked(),
+        };
+        persistOptions();
+
+        m_running = true;
+        m_progress->setValue(0);
+        m_summary->setText(dialogText("Updating Opus header gain…"));
+        m_buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        m_applyTrack->setEnabled(false);
+        m_applyAlbum->setEnabled(false);
+        m_setExplicit->setEnabled(false);
+        m_clearHeader->setEnabled(false);
+        m_explicitGain->setEnabled(false);
+        m_targetVolume->setEnabled(false);
+        m_adjustLouderOrQuieter->setEnabled(false);
+        m_adjustLouderOnly->setEnabled(false);
+
+        const bool preserveTimestamps = m_settings->value<Settings::Core::PreserveTimestamps>();
+        const auto tracks             = m_tracks;
+        const auto cancel             = m_cancelled;
+
+        m_watcher->setFuture(
+            QtConcurrent::run([this, tracks, cancel, mode, explicitGain, headerOptions, preserveTimestamps]() {
+                OpusHeaderGainBatchResult result;
+
+                for(size_t i{0}; i < tracks.size(); ++i) {
+                    if(cancel->load(std::memory_order_acquire)) {
+                        result.cancelled = true;
+                        break;
+                    }
+
+                    const Track& track = tracks.at(i);
+                    QMetaObject::invokeMethod(this, [this, i, filepath = track.prettyFilepath()]() {
+                        m_progress->setValue(static_cast<int>(i));
+                        m_currentFile->setText(filepath);
+                    });
+
+                    Track updatedTrack;
+                    if(!updateOpusHeaderGainForTrack(m_audioLoader.get(), track, mode, explicitGain, headerOptions,
+                                                     preserveTimestamps, updatedTrack)) {
+                        result.failedFiles.emplace_back(track.prettyFilepath());
+                        continue;
+                    }
+
+                    if(updatedTrack.filepath().isEmpty()) {
+                        ++result.unchanged;
+                        continue;
+                    }
+
+                    result.updatedTracks.emplace_back(std::move(updatedTrack));
+                }
+
+                QMetaObject::invokeMethod(
+                    this, [this]() { m_progress->setValue(m_progress->maximum()); }, Qt::QueuedConnection);
+                return result;
+            }));
+    }
+
+    std::shared_ptr<AudioLoader> m_audioLoader;
+    MusicLibrary* m_library;
+    SettingsManager* m_settings;
+    TrackList m_tracks;
+    OpusHeaderGainAvailability m_availability;
+
+    QRadioButton* m_applyTrack;
+    QRadioButton* m_applyAlbum;
+    QRadioButton* m_setExplicit;
+    QRadioButton* m_clearHeader;
+    QDoubleSpinBox* m_explicitGain;
+    SliderEditor* m_targetVolume;
+    QRadioButton* m_adjustLouderOrQuieter;
+    QRadioButton* m_adjustLouderOnly;
+    QLabel* m_summary;
+    QLabel* m_currentFile;
+    QProgressBar* m_progress;
+    QDialogButtonBox* m_buttonBox;
+    QFutureWatcher<OpusHeaderGainBatchResult>* m_watcher;
+    std::shared_ptr<std::atomic_bool> m_cancelled;
+    bool m_running{false};
+};
+} // namespace
+
+QDialog* createOpusHeaderGainDialog(std::shared_ptr<AudioLoader> audioLoader, MusicLibrary* library,
+                                    SettingsManager* settings, TrackList tracks, QWidget* parent)
+{
+    return new OpusHeaderGainDialog(std::move(audioLoader), library, settings, std::move(tracks), parent);
+}
+} // namespace Fooyin::RGScanner

--- a/src/plugins/rgscanner/opusheadergaindialog.h
+++ b/src/plugins/rgscanner/opusheadergaindialog.h
@@ -1,6 +1,6 @@
 /*
  * Fooyin
- * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
  *
  * Fooyin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,13 +19,21 @@
 
 #pragma once
 
-namespace Fooyin::RGScanner {
-constexpr auto ScannerPage = "Fooyin.Page.Playback.ReplayGain.Calculating";
+#include <core/track.h>
 
-constexpr auto ScannerOption                 = "RGScanner/Scanner";
-constexpr auto TruePeakSetting               = "RGScanner/TruePeak";
-constexpr auto AlbumGroupScriptSetting       = "RGScanner/AlbumGroupScript";
-constexpr auto OpusHeaderTargetVolumeSetting = "RGScanner/OpusHeaderTargetVolume";
-constexpr auto OpusHeaderLouderOnlySetting   = "RGScanner/OpusHeaderLouderOnly";
-constexpr auto DefaultAlbumGroupScript       = "%albumartist% - %date% - %album%";
+#include <memory>
+
+class QDialog;
+class QWidget;
+
+namespace Fooyin {
+class AudioLoader;
+class MusicLibrary;
+class SettingsManager;
+} // namespace Fooyin
+
+namespace Fooyin::RGScanner {
+[[nodiscard]] QDialog* createOpusHeaderGainDialog(std::shared_ptr<AudioLoader> audioLoader, MusicLibrary* library,
+                                                  SettingsManager* settings, TrackList tracks,
+                                                  QWidget* parent = nullptr);
 } // namespace Fooyin::RGScanner

--- a/src/plugins/rgscanner/opusreplaygainutils.cpp
+++ b/src/plugins/rgscanner/opusreplaygainutils.cpp
@@ -1,0 +1,185 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "opusreplaygainutils.h"
+
+#include <core/constants.h>
+
+#include <cmath>
+#include <limits>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto OpusReplayGainOffsetDb = 5.0;
+
+namespace Fooyin::RGScanner {
+namespace {
+std::optional<int16_t> adjustCommentGain(std::optional<int16_t> gain, int deltaQ78)
+{
+    if(!gain.has_value()) {
+        return {};
+    }
+
+    const auto newGain = static_cast<long long>(*gain) - deltaQ78;
+    if(newGain < std::numeric_limits<int16_t>::min() || newGain > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+
+    return static_cast<int16_t>(newGain);
+}
+
+int headerDeltaFromReplayGain(int16_t commentGainQ78, double targetVolumeDb)
+{
+    return commentGainQ78 + q78FromDb(OpusReplayGainOffsetDb + (targetVolumeDb - ReplayGainReferenceDb));
+}
+} // namespace
+
+bool isWritableOpusTrack(const Track& track)
+{
+    return !track.isInArchive() && track.isOpus();
+}
+
+void removeReplayGainTags(Track& track)
+{
+    track.setRGTrackGain(Constants::InvalidGain);
+    track.setRGAlbumGain(Constants::InvalidGain);
+
+    static const QStringList replayGainTags = {
+        QStringLiteral("REPLAYGAIN_TRACK_GAIN"),
+        QStringLiteral("REPLAYGAIN_ALBUM_GAIN"),
+        QStringLiteral("----:COM.APPLE.ITUNES:REPLAYGAIN_TRACK_GAIN"),
+        QStringLiteral("----:COM.APPLE.ITUNES:REPLAYGAIN_ALBUM_GAIN"),
+        QStringLiteral("R128_TRACK_GAIN"),
+        QStringLiteral("R128_ALBUM_GAIN"),
+    };
+
+    for(const QString& tag : replayGainTags) {
+        track.removeExtraTag(tag);
+    }
+}
+
+void removeReplayGainInfoFromFile(Track& track)
+{
+    removeReplayGainTags(track);
+    track.setRGTrackPeak(Constants::InvalidPeak);
+    track.setRGAlbumPeak(Constants::InvalidPeak);
+    track.removeExtraTag(QStringLiteral("REPLAYGAIN_TRACK_PEAK"));
+    track.removeExtraTag(QStringLiteral("REPLAYGAIN_ALBUM_PEAK"));
+    track.removeExtraTag(QStringLiteral("----:COM.APPLE.ITUNES:REPLAYGAIN_TRACK_PEAK"));
+    track.removeExtraTag(QStringLiteral("----:COM.APPLE.ITUNES:REPLAYGAIN_ALBUM_PEAK"));
+
+    if(isWritableOpusTrack(track)) {
+        track.setOpusHeaderGainQ78(0);
+    }
+}
+
+float q78ToDb(int16_t gainQ78)
+{
+    return static_cast<float>(gainQ78) / 256.0F;
+}
+
+int q78FromDb(double gainDb)
+{
+    return static_cast<int>(std::lround(gainDb * 256.0));
+}
+
+std::optional<int16_t> dbToQ78(double gainDb)
+{
+    const auto gainQ78 = std::lround(gainDb * 256.0);
+    if(gainQ78 < std::numeric_limits<int16_t>::min() || gainQ78 > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+
+    return static_cast<int16_t>(gainQ78);
+}
+
+std::optional<int16_t> replayGainToOpusR128Q78(float gainDb)
+{
+    return dbToQ78(static_cast<double>(gainDb) - OpusReplayGainOffsetDb);
+}
+
+std::optional<OpusGainState> applyHeaderGainMode(const OpusGainState& current, OpusHeaderGainMode mode,
+                                                 std::optional<int16_t> explicitHeaderGain,
+                                                 const OpusHeaderGainOptions& options)
+{
+    OpusGainState updated{current};
+    int headerDeltaQ78{0};
+    int commentDeltaQ78{0};
+
+    switch(mode) {
+        case OpusHeaderGainMode::Track:
+            if(!current.trackGain.has_value()) {
+                return current;
+            }
+
+            headerDeltaQ78  = headerDeltaFromReplayGain(*current.trackGain, options.targetVolumeDb);
+            commentDeltaQ78 = headerDeltaQ78;
+
+            if(options.louderOnly && headerDeltaQ78 <= 0) {
+                return current;
+            }
+            break;
+        case OpusHeaderGainMode::Album:
+            if(!current.albumGain.has_value()) {
+                return current;
+            }
+
+            headerDeltaQ78  = headerDeltaFromReplayGain(*current.albumGain, options.targetVolumeDb);
+            commentDeltaQ78 = headerDeltaQ78;
+
+            if(options.louderOnly && headerDeltaQ78 <= 0) {
+                return current;
+            }
+            break;
+        case OpusHeaderGainMode::Explicit:
+            if(!explicitHeaderGain.has_value()) {
+                return {};
+            }
+            headerDeltaQ78  = *explicitHeaderGain - current.headerGain;
+            commentDeltaQ78 = headerDeltaQ78;
+            break;
+        case OpusHeaderGainMode::Clear:
+            headerDeltaQ78  = -current.headerGain;
+            commentDeltaQ78 = headerDeltaQ78;
+            break;
+    }
+
+    const auto newHeader = static_cast<long long>(current.headerGain) + headerDeltaQ78;
+    if(newHeader < std::numeric_limits<int16_t>::min() || newHeader > std::numeric_limits<int16_t>::max()) {
+        return {};
+    }
+    updated.headerGain = static_cast<int16_t>(newHeader);
+
+    if(const auto newTrackGain = adjustCommentGain(current.trackGain, commentDeltaQ78); current.trackGain.has_value()) {
+        if(!newTrackGain.has_value()) {
+            return {};
+        }
+        updated.trackGain = newTrackGain;
+    }
+
+    if(const auto newAlbumGain = adjustCommentGain(current.albumGain, commentDeltaQ78); current.albumGain.has_value()) {
+        if(!newAlbumGain.has_value()) {
+            return {};
+        }
+        updated.albumGain = newAlbumGain;
+    }
+
+    return updated;
+}
+} // namespace Fooyin::RGScanner

--- a/src/plugins/rgscanner/opusreplaygainutils.h
+++ b/src/plugins/rgscanner/opusreplaygainutils.h
@@ -1,0 +1,66 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/track.h>
+
+namespace Fooyin {
+class SettingsManager;
+
+namespace RGScanner {
+inline constexpr auto ReplayGainReferenceDb = 89.0;
+
+enum class OpusHeaderGainMode : uint8_t
+{
+    Track = 0,
+    Album,
+    Explicit,
+    Clear,
+};
+
+struct OpusGainState
+{
+    int16_t headerGain{0};
+    std::optional<int16_t> trackGain;
+    std::optional<int16_t> albumGain;
+
+    [[nodiscard]] bool operator==(const OpusGainState& other) const = default;
+};
+
+struct OpusHeaderGainOptions
+{
+    double targetVolumeDb{ReplayGainReferenceDb};
+    bool louderOnly{false};
+};
+
+[[nodiscard]] bool isWritableOpusTrack(const Track& track);
+void removeReplayGainTags(Track& track);
+void removeReplayGainInfoFromFile(Track& track);
+
+[[nodiscard]] float q78ToDb(int16_t gainQ78);
+[[nodiscard]] int q78FromDb(double gainDb);
+[[nodiscard]] std::optional<int16_t> dbToQ78(double gainDb);
+[[nodiscard]] std::optional<int16_t> replayGainToOpusR128Q78(float gainDb);
+
+[[nodiscard]] std::optional<OpusGainState> applyHeaderGainMode(const OpusGainState& current, OpusHeaderGainMode mode,
+                                                               std::optional<int16_t> explicitHeaderGain,
+                                                               const OpusHeaderGainOptions& options);
+} // namespace RGScanner
+} // namespace Fooyin

--- a/src/plugins/rgscanner/rgscannerpage.cpp
+++ b/src/plugins/rgscanner/rgscannerpage.cpp
@@ -133,6 +133,8 @@ void RGScannerPageWidget::reset()
     m_settings->fileRemove(ScannerOption);
     m_settings->fileRemove(TruePeakSetting);
     m_settings->fileRemove(AlbumGroupScriptSetting);
+    m_settings->fileRemove(OpusHeaderTargetVolumeSetting);
+    m_settings->fileRemove(OpusHeaderLouderOnlySetting);
 }
 
 RGScannerPage::RGScannerPage(SettingsManager* settings, QObject* parent)

--- a/src/plugins/rgscanner/rgscannerplugin.cpp
+++ b/src/plugins/rgscanner/rgscannerplugin.cpp
@@ -19,6 +19,8 @@
 
 #include "rgscannerplugin.h"
 
+#include "opusheadergaindialog.h"
+#include "opusreplaygainutils.h"
 #include "rgscanner.h"
 #include "rgscannerpage.h"
 #include "rgscanresults.h"
@@ -74,12 +76,13 @@ void RGScannerPlugin::calculateReplayGain(RGScanType type)
 
     auto* scanner = new RGScanner(m_audioLoader, this);
     QObject::connect(scanner, &RGScanner::calculationFinished, this,
-                     [this, scanner, progress](const TrackList& tracks) {
+                     [this, scanner, progress, tracksToScan, type](const TrackList& tracks) {
                          const auto finishTime = progress->elapsedTime();
                          scanner->close();
                          progress->deleteLater();
 
-                         auto* rgResults = new RGScanResults(m_library, tracks, finishTime, Utils::getMainWindow());
+                         auto* rgResults = new RGScanResults(m_library, m_settings, tracksToScan, tracks, type,
+                                                             finishTime, Utils::getMainWindow());
                          rgResults->setAttribute(Qt::WA_DeleteOnClose);
                          rgResults->show();
                      });
@@ -95,13 +98,13 @@ void RGScannerPlugin::calculateReplayGain(RGScanType type)
     });
 
     switch(type) {
-        case(RGScanType::Track):
+        case RGScanType::Track:
             scanner->calculatePerTrack(tracksToScan);
             break;
-        case(RGScanType::SingleAlbum):
+        case RGScanType::SingleAlbum:
             scanner->calculateAsAlbum(tracksToScan);
             break;
-        case(RGScanType::Album):
+        case RGScanType::Album:
             scanner->calculateByAlbumTags(tracksToScan);
             break;
     }
@@ -118,21 +121,23 @@ void RGScannerPlugin::setupReplayGainMenu()
 
     auto* window = Utils::getMainWindow();
 
-    auto* rgTrackAction       = new QAction(tr("Calculate ReplayGain values per-file"), window);
-    auto* rgSingleAlbumAction = new QAction(tr("Calculate ReplayGain values as a single album"), window);
-    auto* rgAlbumAction       = new QAction(tr("Calculate ReplayGain values as albums (by tags)"), window);
-    auto* rgRemoveAction      = new QAction(tr("Remove ReplayGain information from files"), window);
+    auto* rgTrackAction        = new QAction(tr("Calculate ReplayGain values per-file"), window);
+    auto* rgSingleAlbumAction  = new QAction(tr("Calculate ReplayGain values as a single album"), window);
+    auto* rgAlbumAction        = new QAction(tr("Calculate ReplayGain values as albums (by tags)"), window);
+    auto* opusHeaderGainAction = new QAction(tr("Edit Opus header gain"), window);
+    auto* rgRemoveAction       = new QAction(tr("Remove ReplayGain information from files"), window);
     rgTrackAction->setStatusTip(
         tr("Calculate ReplayGain values for selected files, considering each file individually"));
     rgSingleAlbumAction->setStatusTip(
         tr("Calculate ReplayGain values for selected files, considering all files as part of one album"));
     rgAlbumAction->setStatusTip(tr("Calculate ReplayGain values for selected files, dividing into albums by tags"));
+    opusHeaderGainAction->setStatusTip(tr("Manipulate the Opus header gain field"));
     rgRemoveAction->setStatusTip(tr("Remove ReplayGain values from the selected files"));
 
     const auto removeInfo = [this]() {
         TrackList tracks = m_selectionController->selectedTracks();
         for(Track& track : tracks) {
-            track.clearRGInfo();
+            removeReplayGainInfoFromFile(track);
         }
 
         auto* removeDialog = createRemoveDialog();
@@ -158,28 +163,51 @@ void RGScannerPlugin::setupReplayGainMenu()
         return std::ranges::any_of(m_selectionController->selectedTracks(),
                                    [](const Track& track) { return !track.isInArchive(); });
     };
+    const auto hasWritableOpus = [this]() -> bool {
+        return std::ranges::any_of(m_selectionController->selectedTracks(), isWritableOpusTrack);
+    };
 
     QObject::connect(rgTrackAction, &QAction::triggered, this, [this] { calculateReplayGain(RGScanType::Track); });
     QObject::connect(rgSingleAlbumAction, &QAction::triggered, this,
                      [this] { calculateReplayGain(RGScanType::SingleAlbum); });
     QObject::connect(rgAlbumAction, &QAction::triggered, this, [this] { calculateReplayGain(RGScanType::Album); });
+    QObject::connect(opusHeaderGainAction, &QAction::triggered, this, [this]() {
+        TrackList tracks;
+        for(const Track& track : m_selectionController->selectedTracks()) {
+            if(isWritableOpusTrack(track)) {
+                tracks.emplace_back(track);
+            }
+        }
+
+        if(tracks.empty()) {
+            return;
+        }
+
+        auto* dialog = createOpusHeaderGainDialog(m_audioLoader, m_library, m_settings, tracks, Utils::getMainWindow());
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->show();
+    });
     QObject::connect(rgRemoveAction, &QAction::triggered, this, removeInfo);
 
-    QObject::connect(
-        m_selectionController, &TrackSelectionController::selectionChanged, this,
-        [this, replayGainMenu, rgSingleAlbumAction, rgAlbumAction, rgRemoveAction, canWriteInfo] {
-            const bool tracksWritable = canWriteInfo();
-            replayGainMenu->menu()->setEnabled(tracksWritable);
-            rgAlbumAction->setEnabled(tracksWritable && m_selectionController->selectedTrackCount() > 1);
-            rgSingleAlbumAction->setEnabled(tracksWritable && m_selectionController->selectedTrackCount() > 1);
-            rgRemoveAction->setEnabled(tracksWritable
-                                       && std::ranges::any_of(m_selectionController->selectedTracks(),
-                                                              [](const Track& track) { return track.hasRGInfo(); }));
-        });
+    QObject::connect(m_selectionController, &TrackSelectionController::selectionChanged, this,
+                     [this, replayGainMenu, rgSingleAlbumAction, rgAlbumAction, opusHeaderGainAction, rgRemoveAction,
+                      canWriteInfo, hasWritableOpus] {
+                         const bool tracksWritable = canWriteInfo();
+                         replayGainMenu->menu()->setEnabled(tracksWritable);
+                         rgAlbumAction->setEnabled(tracksWritable && m_selectionController->selectedTrackCount() > 1);
+                         rgSingleAlbumAction->setEnabled(tracksWritable);
+                         opusHeaderGainAction->setEnabled(hasWritableOpus());
+                         rgRemoveAction->setEnabled(
+                             tracksWritable
+                             && std::ranges::any_of(m_selectionController->selectedTracks(), [](const Track& track) {
+                                    return track.hasRGInfo() || track.hasOpusHeaderGain();
+                                }));
+                     });
 
     replayGainMenu->menu()->addAction(rgTrackAction);
     replayGainMenu->menu()->addAction(rgSingleAlbumAction);
     replayGainMenu->menu()->addAction(rgAlbumAction);
+    replayGainMenu->menu()->addAction(opusHeaderGainAction);
     replayGainMenu->menu()->addAction(rgRemoveAction);
 }
 

--- a/src/plugins/rgscanner/rgscannerplugin.h
+++ b/src/plugins/rgscanner/rgscannerplugin.h
@@ -23,6 +23,8 @@
 #include <core/plugins/plugin.h>
 #include <gui/plugins/guiplugin.h>
 
+#include "rgscanresults.h"
+
 class QDialog;
 
 namespace Fooyin::RGScanner {
@@ -40,12 +42,6 @@ public:
     void initialise(const GuiPluginContext& context) override;
 
 private:
-    enum class RGScanType : uint8_t
-    {
-        Track = 0,
-        SingleAlbum,
-        Album
-    };
     void calculateReplayGain(RGScanType type);
     void setupReplayGainMenu();
     static QDialog* createRemoveDialog();

--- a/src/plugins/rgscanner/rgscanresults.cpp
+++ b/src/plugins/rgscanner/rgscanresults.cpp
@@ -19,9 +19,12 @@
 
 #include "rgscanresults.h"
 
+#include "opusreplaygainutils.h"
 #include "rgscanresultsmodel.h"
 
+#include <core/internalcoresettings.h>
 #include <core/library/musiclibrary.h>
+#include <utils/settings/settingsmanager.h>
 #include <utils/stringutils.h>
 
 #include <QDialogButtonBox>
@@ -31,14 +34,49 @@
 #include <QPushButton>
 #include <QTableView>
 
+#include <algorithm>
+
 using namespace Qt::StringLiterals;
 
 namespace Fooyin::RGScanner {
-RGScanResults::RGScanResults(MusicLibrary* library, TrackList tracks, std::chrono::milliseconds timeTaken,
+namespace {
+const Track* findOriginalTrack(const TrackList& tracks, const Track& scannedTrack)
+{
+    const auto it = std::ranges::find_if(
+        tracks, [&scannedTrack](const Track& originalTrack) { return originalTrack.sameIdentityAs(scannedTrack); });
+    return it != tracks.cend() ? &*it : nullptr;
+}
+
+Track mergePerTrackReplayGainWriteData(const Track& scannedTrack, const TrackList& originalTracks)
+{
+    Track writeTrack{scannedTrack};
+    const Track* originalTrack = findOriginalTrack(originalTracks, scannedTrack);
+    if(!originalTrack) {
+        return writeTrack;
+    }
+
+    if(originalTrack->hasAlbumGain()) {
+        writeTrack.setRGAlbumGain(originalTrack->rgAlbumGain());
+    }
+
+    if(originalTrack->hasAlbumPeak()) {
+        writeTrack.setRGAlbumPeak(originalTrack->rgAlbumPeak());
+    }
+
+    return writeTrack;
+}
+} // namespace
+
+RGScanResults::RGScanResults(MusicLibrary* library, SettingsManager* settings, TrackList originalTracks,
+                             TrackList tracks, const RGScanType scanType, std::chrono::milliseconds timeTaken,
                              QWidget* parent)
     : QDialog{parent}
     , m_library{library}
+    , m_settings{settings}
+    , m_originalTracks{std::move(originalTracks)}
     , m_tracks{std::move(tracks)}
+    , m_scanType{scanType}
+    , m_opusWriteMode{static_cast<OpusRGWriteMode>(settings->value<Settings::Core::Internal::OpusHeaderWriteMode>())}
     , m_resultsView{new QTableView(this)}
     , m_resultsModel{new RGScanResultsModel(m_tracks, this)}
     , m_status{new QLabel(tr("Time taken") + ": "_L1 + Utils::msToString(timeTaken, false), this)}
@@ -76,7 +114,25 @@ void RGScanResults::accept()
     m_status->setText(tr("Writing to file tags…"));
     m_buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
-    const auto request = m_library->writeTrackMetadata(m_tracks);
+    TrackList tracksToWrite;
+    tracksToWrite.reserve(m_tracks.size());
+
+    for(const Track& track : std::as_const(m_tracks)) {
+        Track writeTrack = m_scanType == RGScanType::Track ? mergePerTrackReplayGainWriteData(track, m_originalTracks)
+                                                           : Track{track};
+        if(writeTrack.isOpus()) {
+            writeTrack = prepareOpusRGWriteTrack(writeTrack, m_opusWriteMode);
+            if(m_opusWriteMode == OpusRGWriteMode::LeaveNull && track.hasOpusHeaderGain()) {
+                writeTrack.setOpusHeaderGainQ78(0);
+            }
+        }
+        else {
+            writeTrack = prepareOpusRGWriteTrack(writeTrack, m_opusWriteMode);
+        }
+        tracksToWrite.emplace_back(std::move(writeTrack));
+    }
+
+    const auto request = m_library->writeTrackMetadata(tracksToWrite);
     QObject::connect(
         m_buttonBox, &QDialogButtonBox::rejected, this, [request]() { request.cancel(); }, Qt::SingleShotConnection);
 }

--- a/src/plugins/rgscanner/rgscanresults.h
+++ b/src/plugins/rgscanner/rgscanresults.h
@@ -23,23 +23,33 @@
 
 #include <QDialog>
 
+#include <cstdint>
+
 class QDialogButtonBox;
 class QLabel;
 class QTableView;
 
 namespace Fooyin {
 class MusicLibrary;
+class SettingsManager;
 
 namespace RGScanner {
 class RGScanResultsModel;
+
+enum class RGScanType : uint8_t
+{
+    Track = 0,
+    SingleAlbum,
+    Album
+};
 
 class RGScanResults : public QDialog
 {
     Q_OBJECT
 
 public:
-    RGScanResults(MusicLibrary* library, TrackList tracks, std::chrono::milliseconds timeTaken,
-                  QWidget* parent = nullptr);
+    RGScanResults(MusicLibrary* library, SettingsManager* settings, TrackList originalTracks, TrackList tracks,
+                  RGScanType scanType, std::chrono::milliseconds timeTaken, QWidget* parent = nullptr);
 
     void accept() override;
 
@@ -48,7 +58,12 @@ public:
 
 private:
     MusicLibrary* m_library;
+    SettingsManager* m_settings;
+
+    TrackList m_originalTracks;
     TrackList m_tracks;
+    RGScanType m_scanType;
+    OpusRGWriteMode m_opusWriteMode;
 
     QTableView* m_resultsView;
     RGScanResultsModel* m_resultsModel;

--- a/src/plugins/rgscanner/rgscanresultsmodel.cpp
+++ b/src/plugins/rgscanner/rgscanresultsmodel.cpp
@@ -42,15 +42,15 @@ QVariant RGScanResultsModel::headerData(int section, Qt::Orientation orientation
     }
 
     switch(section) {
-        case(0):
+        case 0:
             return tr("Name");
-        case(1):
+        case 1:
             return tr("Track Gain");
-        case(2):
+        case 2:
             return tr("Album Gain");
-        case(3):
+        case 3:
             return tr("Track Peak");
-        case(4):
+        case 4:
             return tr("Album Peak");
         default:
             return {};
@@ -71,16 +71,18 @@ QVariant RGScanResultsModel::data(const QModelIndex& index, int role) const
     if(role == Qt::DisplayRole) {
         const Track& track = m_tracks.at(row);
         switch(index.column()) {
-            case(0):
+            case 0:
                 return track.effectiveTitle();
-            case(1):
-                return track.hasTrackGain() ? u"%1 dB"_s.arg(QString::number(track.rgTrackGain(), 'f', 2)) : QString{};
-            case(2):
-                return track.hasAlbumGain() ? u"%1 dB"_s.arg(QString::number(track.rgAlbumGain(), 'f', 2)) : QString{};
-            case(3):
-                return track.hasTrackPeak() ? QString::number(track.rgTrackPeak(), 'f', 6) : QString{};
-            case(4):
-                return track.hasAlbumPeak() ? QString::number(track.rgAlbumPeak(), 'f', 6) : QString{};
+            case 1:
+                return track.hasTrackGain() ? u"%1 dB"_s.arg(QString::number(track.effectiveRGTrackGain(), 'f', 2))
+                                            : QString{};
+            case 2:
+                return track.hasAlbumGain() ? u"%1 dB"_s.arg(QString::number(track.effectiveRGAlbumGain(), 'f', 2))
+                                            : QString{};
+            case 3:
+                return track.hasTrackPeak() ? QString::number(track.effectiveRGTrackPeak(), 'f', 6) : QString{};
+            case 4:
+                return track.hasAlbumPeak() ? QString::number(track.effectiveRGAlbumPeak(), 'f', 6) : QString{};
             default:
                 return {};
         }

--- a/tests/core/tagging/tagwritertest.cpp
+++ b/tests/core/tagging/tagwritertest.cpp
@@ -19,8 +19,11 @@
 
 #include "testutils.h"
 
+#include <core/constants.h>
 #include <core/engine/input/taglibparser.h>
 #include <core/track.h>
+
+#include <taglib/opusfile.h>
 
 #include <QBuffer>
 #include <QImage>
@@ -451,6 +454,249 @@ TEST_F(TagWriterTest, OpusWrite)
         ASSERT_TRUE(!writeTag.isEmpty());
         EXPECT_EQ(writeTag.front(), u"Success"_s);
     }
+}
+
+TEST_F(TagWriterTest, OpusR128ReadAsReplayGain)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    AudioSource source;
+    source.filepath = file.fileName();
+    source.device   = &file;
+
+    const QByteArray localPath = file.fileName().toLocal8Bit();
+    {
+        TagLib::Ogg::Opus::File opusFile(localPath.constData());
+        ASSERT_TRUE(opusFile.isValid());
+        ASSERT_TRUE(opusFile.tag());
+
+        opusFile.tag()->addField("R128_TRACK_GAIN", "0", true);
+        opusFile.tag()->addField("R128_ALBUM_GAIN", "256", true);
+        ASSERT_TRUE(opusFile.save());
+    }
+
+    {
+        Track track{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, track));
+
+        ASSERT_TRUE(track.hasTrackGain());
+        ASSERT_TRUE(track.hasAlbumGain());
+        EXPECT_FLOAT_EQ(track.rgTrackGain(), 5.0F);
+        EXPECT_FLOAT_EQ(track.rgAlbumGain(), 6.0F);
+        EXPECT_TRUE(track.extraTag(QStringLiteral("R128_TRACK_GAIN")).isEmpty());
+        EXPECT_TRUE(track.extraTag(QStringLiteral("R128_ALBUM_GAIN")).isEmpty());
+    }
+}
+
+TEST_F(TagWriterTest, OpusWriteUsesR128TagsInsteadOfReplayGainTags)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    AudioSource source;
+    source.filepath = file.fileName();
+    source.device   = &file;
+
+    {
+        Track track{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, track));
+
+        track.setId(0);
+        track.setRGTrackGain(5.0F);
+        track.setRGAlbumGain(6.0F);
+        track.setRGTrackPeak(0.25F);
+        track.setRGAlbumPeak(0.5F);
+        track.setExtraProperty(QString::fromLatin1(Constants::OpusHeaderGainQ78), QStringLiteral("-3205"));
+
+        ASSERT_TRUE(m_parser.writeTrack(source, track, Flags));
+    }
+
+    const QByteArray localPath = file.fileName().toLocal8Bit();
+    const TagLib::Ogg::Opus::File opusFile(localPath.constData());
+    ASSERT_TRUE(opusFile.isValid());
+    ASSERT_TRUE(opusFile.tag());
+
+    const auto& fields = opusFile.tag()->fieldListMap();
+    ASSERT_TRUE(fields.contains("R128_TRACK_GAIN"));
+    ASSERT_TRUE(fields.contains("R128_ALBUM_GAIN"));
+    EXPECT_EQ(QString::fromUtf8(fields["R128_TRACK_GAIN"].front().toCString(true)), QStringLiteral("0"));
+    EXPECT_EQ(QString::fromUtf8(fields["R128_ALBUM_GAIN"].front().toCString(true)), QStringLiteral("256"));
+
+    EXPECT_FALSE(fields.contains("REPLAYGAIN_TRACK_GAIN"));
+    EXPECT_FALSE(fields.contains("REPLAYGAIN_ALBUM_GAIN"));
+
+    QFile headerFile{file.fileName()};
+    ASSERT_TRUE(headerFile.open(QIODevice::ReadOnly));
+    const auto headerGain = readOpusHeaderGainQ78(&headerFile);
+    ASSERT_TRUE(headerGain.has_value());
+    EXPECT_EQ(*headerGain, -3205);
+
+    Track rereadTrack{file.fileName()};
+    ASSERT_TRUE(m_parser.readTrack(source, rereadTrack));
+    EXPECT_TRUE(rereadTrack.hasOpusHeaderGain());
+    EXPECT_NEAR(rereadTrack.opusHeaderGainDb(), -12.5195F, 0.0002F);
+    EXPECT_FLOAT_EQ(rereadTrack.rgTrackGain(), 5.0F);
+    EXPECT_FLOAT_EQ(rereadTrack.rgAlbumGain(), 6.0F);
+}
+
+TEST_F(TagWriterTest, OpusWriteTrackHeaderModeUsesOpusR128Offset)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    AudioSource source;
+    source.filepath = file.fileName();
+    source.device   = &file;
+
+    {
+        Track track{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, track));
+
+        track.setRGTrackGain(-0.25F);
+
+        const Track preparedTrack = prepareOpusRGWriteTrack(track, OpusRGWriteMode::Track);
+        ASSERT_TRUE(m_parser.writeTrack(source, preparedTrack, Flags));
+    }
+
+    const QByteArray localPath = file.fileName().toLocal8Bit();
+    const TagLib::Ogg::Opus::File opusFile(localPath.constData());
+    ASSERT_TRUE(opusFile.isValid());
+    ASSERT_TRUE(opusFile.tag());
+
+    const auto& fields = opusFile.tag()->fieldListMap();
+    ASSERT_TRUE(fields.contains("R128_TRACK_GAIN"));
+    EXPECT_EQ(QString::fromUtf8(fields["R128_TRACK_GAIN"].front().toCString(true)), QStringLiteral("0"));
+
+    QFile headerFile{file.fileName()};
+    ASSERT_TRUE(headerFile.open(QIODevice::ReadOnly));
+    const auto headerGain = readOpusHeaderGainQ78(&headerFile);
+    ASSERT_TRUE(headerGain.has_value());
+    EXPECT_EQ(*headerGain, -1344);
+
+    Track rereadTrack{file.fileName()};
+    ASSERT_TRUE(m_parser.readTrack(source, rereadTrack));
+    EXPECT_NEAR(rereadTrack.opusHeaderGainDb(), -5.25F, 0.0002F);
+    EXPECT_FLOAT_EQ(rereadTrack.rgTrackGain(), 5.0F);
+    EXPECT_NEAR(rereadTrack.effectiveRGTrackGain(), -0.25F, 0.0002F);
+}
+
+TEST_F(TagWriterTest, OpusReadRejectsInvalidHeaderCrc)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    QFile headerFile{file.fileName()};
+    ASSERT_TRUE(headerFile.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(headerFile.seek(22));
+
+    char crcByte{0};
+    ASSERT_EQ(headerFile.read(&crcByte, 1), 1);
+    ASSERT_TRUE(headerFile.seek(22));
+
+    crcByte ^= static_cast<char>(0x01);
+    ASSERT_EQ(headerFile.write(&crcByte, 1), 1);
+    ASSERT_TRUE(headerFile.flush());
+
+    ASSERT_TRUE(headerFile.seek(0));
+    EXPECT_FALSE(readOpusHeaderGainQ78(&headerFile).has_value());
+}
+
+TEST_F(TagWriterTest, OpusRemoveReplayGainClearsAllReplayGainTags)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    AudioSource source;
+    source.filepath = file.fileName();
+    source.device   = &file;
+
+    const QByteArray localPath = file.fileName().toLocal8Bit();
+    {
+        TagLib::Ogg::Opus::File opusFile(localPath.constData());
+        ASSERT_TRUE(opusFile.isValid());
+        ASSERT_TRUE(opusFile.tag());
+
+        opusFile.tag()->addField("REPLAYGAIN_TRACK_GAIN", "-7.00 dB", true);
+        opusFile.tag()->addField("REPLAYGAIN_ALBUM_GAIN", "-6.00 dB", true);
+        opusFile.tag()->addField("REPLAYGAIN_TRACK_PEAK", "0.25", true);
+        opusFile.tag()->addField("REPLAYGAIN_ALBUM_PEAK", "0.50", true);
+        opusFile.tag()->addField("R128_TRACK_GAIN", "0", true);
+        opusFile.tag()->addField("R128_ALBUM_GAIN", "256", true);
+        ASSERT_TRUE(opusFile.save());
+    }
+
+    {
+        Track track{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, track));
+
+        track.clearRGInfo();
+        track.removeExtraTag(QStringLiteral("REPLAYGAIN_TRACK_GAIN"));
+        track.removeExtraTag(QStringLiteral("REPLAYGAIN_ALBUM_GAIN"));
+        track.removeExtraTag(QStringLiteral("REPLAYGAIN_TRACK_PEAK"));
+        track.removeExtraTag(QStringLiteral("REPLAYGAIN_ALBUM_PEAK"));
+        track.removeExtraTag(QStringLiteral("R128_TRACK_GAIN"));
+        track.removeExtraTag(QStringLiteral("R128_ALBUM_GAIN"));
+
+        ASSERT_TRUE(m_parser.writeTrack(source, track, Flags));
+    }
+
+    {
+        TagLib::Ogg::Opus::File opusFile(localPath.constData());
+        ASSERT_TRUE(opusFile.isValid());
+        ASSERT_TRUE(opusFile.tag());
+
+        const auto& fields = opusFile.tag()->fieldListMap();
+        EXPECT_FALSE(fields.contains("REPLAYGAIN_TRACK_GAIN"));
+        EXPECT_FALSE(fields.contains("REPLAYGAIN_ALBUM_GAIN"));
+        EXPECT_FALSE(fields.contains("REPLAYGAIN_TRACK_PEAK"));
+        EXPECT_FALSE(fields.contains("REPLAYGAIN_ALBUM_PEAK"));
+        EXPECT_FALSE(fields.contains("R128_TRACK_GAIN"));
+        EXPECT_FALSE(fields.contains("R128_ALBUM_GAIN"));
+    }
+
+    {
+        Track rereadTrack{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, rereadTrack));
+        EXPECT_FALSE(rereadTrack.hasTrackGain());
+        EXPECT_FALSE(rereadTrack.hasAlbumGain());
+        EXPECT_FALSE(rereadTrack.hasTrackPeak());
+        EXPECT_FALSE(rereadTrack.hasAlbumPeak());
+    }
+}
+
+TEST_F(TagWriterTest, OpusWriteCanClearHeaderGain)
+{
+    const QString filepath = QStringLiteral(":/audio/audiotest.opus");
+    TempResource file{filepath};
+    file.checkValid();
+
+    AudioSource source;
+    source.filepath = file.fileName();
+    source.device   = &file;
+
+    {
+        Track track{file.fileName()};
+        ASSERT_TRUE(m_parser.readTrack(source, track));
+
+        track.setExtraProperty(QString::fromLatin1(Constants::OpusHeaderGainQ78), QStringLiteral("0"));
+        ASSERT_TRUE(m_parser.writeTrack(source, track, Flags));
+    }
+
+    QFile headerFile{file.fileName()};
+    ASSERT_TRUE(headerFile.open(QIODevice::ReadOnly));
+    const auto headerGain = readOpusHeaderGainQ78(&headerFile);
+    ASSERT_TRUE(headerGain.has_value());
+    EXPECT_EQ(*headerGain, 0);
+
+    Track rereadTrack{file.fileName()};
+    ASSERT_TRUE(m_parser.readTrack(source, rereadTrack));
+    EXPECT_FALSE(rereadTrack.hasOpusHeaderGain());
 }
 
 TEST_F(TagWriterTest, WavWrite)

--- a/tests/core/tracktest.cpp
+++ b/tests/core/tracktest.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include <core/constants.h>
 #include <core/track.h>
 #include <core/trackmetadatastore.h>
 
@@ -24,6 +25,8 @@
 #include <QIODevice>
 
 #include <gtest/gtest.h>
+
+#include <cmath>
 
 using namespace Qt::StringLiterals;
 
@@ -224,5 +227,36 @@ TEST(TrackTest, MigratesPooledMetadataToExplicitStore)
     EXPECT_EQ(sharedStore->values(StringPool::Domain::Composer), (QStringList{u"Composer A"_s}));
     EXPECT_EQ(sharedStore->values(StringPool::Domain::Performer), (QStringList{u"Performer A"_s}));
     EXPECT_EQ(sharedStore->values(StringPool::Domain::ExtraTagKey), (QStringList{u"CUSTOM"_s}));
+}
+
+TEST(TrackTest, CalculatesEffectiveReplayGainForOpusHeaderGain)
+{
+    Track track;
+    track.setRGTrackGain(5.0F);
+    track.setRGAlbumGain(5.0F);
+    track.setRGTrackPeak(0.255842F);
+    track.setRGAlbumPeak(0.255842F);
+    track.setExtraProperty(QString::fromLatin1(Constants::OpusHeaderGainQ78), u"-3205"_s);
+
+    EXPECT_TRUE(track.hasOpusHeaderGain());
+    EXPECT_NEAR(track.opusHeaderGainDb(), -12.5195F, 0.0002F);
+
+    EXPECT_TRUE(track.hasEffectiveTrackGain());
+    EXPECT_TRUE(track.hasEffectiveAlbumGain());
+    EXPECT_TRUE(track.hasEffectiveTrackPeak());
+    EXPECT_TRUE(track.hasEffectiveAlbumPeak());
+
+    EXPECT_NEAR(track.effectiveRGTrackGain(), -7.5195F, 0.0002F);
+    EXPECT_NEAR(track.effectiveRGAlbumGain(), -7.5195F, 0.0002F);
+
+    const float expectedPeak = 0.255842F / std::pow(10.0F, track.opusHeaderGainDb() / 20.0F);
+    EXPECT_NEAR(track.effectiveRGTrackPeak(), expectedPeak, 0.00001F);
+    EXPECT_NEAR(track.effectiveRGAlbumPeak(), expectedPeak, 0.00001F);
+    EXPECT_NEAR(track.techInfo(QString::fromLatin1(Constants::MetaData::OpusHeaderGain)).toDouble(), -12.5195, 0.0002);
+
+    EXPECT_FLOAT_EQ(track.rgTrackGain(), 5.0F);
+    EXPECT_FLOAT_EQ(track.rgAlbumGain(), 5.0F);
+    EXPECT_FLOAT_EQ(track.rgTrackPeak(), 0.255842F);
+    EXPECT_FLOAT_EQ(track.rgAlbumPeak(), 0.255842F);
 }
 } // namespace Fooyin::Testing


### PR DESCRIPTION
This adds support for reading and writing Opus header gain alongside `R128_TRACK_GAIN` and `R128_ALBUM_GAIN`. It also updates gain handling so effective ReplayGain values correctly account for Opus header gain. 

In the `rgscanner` plugin, it additionally adds support for applying, clearing, and editing Opus header gain directly for writable Opus files:

<img width="364" height="453" alt="image" src="https://github.com/user-attachments/assets/4ffa5f43-9a9b-4c58-b589-e60c1e380639" />


Closes #449
Addresses #340