### PR TITLE
Extend Delete file functionality

### DIFF
--- a/src/plugins/fileops/fileopsdeletedialog.cpp
+++ b/src/plugins/fileops/fileopsdeletedialog.cpp
@@ -53,8 +53,8 @@ FileOpsDeleteDialog::FileOpsDeleteDialog(const TrackList& tracks, SettingsManage
     layout->addWidget(dontAsk);
 
     auto* buttons      = new QDialogButtonBox(this);
-    auto* deleteButton = buttons->addButton(tr("Delete"), QDialogButtonBox::DestructiveRole);
-    auto* cancelButton = buttons->addButton(QDialogButtonBox::Cancel);
+    auto* deleteButton = buttons->addButton(tr("&Delete"), QDialogButtonBox::DestructiveRole);
+    auto* cancelButton = buttons->addButton(tr("&Cancel"), QDialogButtonBox::RejectRole);
     cancelButton->setDefault(true);
     layout->addWidget(buttons);
 

--- a/src/plugins/fileops/fileopsdeletedialog.cpp
+++ b/src/plugins/fileops/fileopsdeletedialog.cpp
@@ -41,10 +41,9 @@ FileOpsDeleteDialog::FileOpsDeleteDialog(const TrackList& tracks, SettingsManage
 
     auto* layout = new QVBoxLayout(this);
 
-    const QString message = tracks.size() == 1
-                              ? tr("Are you sure you want to delete \"%1\"?\n%2")
-                                    .arg(tracks.front().effectiveTitle(), tracks.front().filepath())
-                              : tr("Are you sure you want to delete %1 tracks?").arg(tracks.size());
+    const QString message = tracks.size() == 1 ? tr("Are you sure you want to delete \"%1\"?\n%2")
+                                                     .arg(tracks.front().effectiveTitle(), tracks.front().filepath())
+                                               : tr("Are you sure you want to delete %1 tracks?").arg(tracks.size());
 
     auto* label = new QLabel(message, this);
     label->setWordWrap(true);

--- a/src/plugins/fileops/fileopsdeletedialog.cpp
+++ b/src/plugins/fileops/fileopsdeletedialog.cpp
@@ -42,7 +42,8 @@ FileOpsDeleteDialog::FileOpsDeleteDialog(const TrackList& tracks, SettingsManage
     auto* layout = new QVBoxLayout(this);
 
     const QString message = tracks.size() == 1
-                              ? tr("Are you sure you want to delete \"%1\"?").arg(tracks.front().effectiveTitle())
+                              ? tr("Are you sure you want to delete \"%1\"?\n%2")
+                                    .arg(tracks.front().effectiveTitle(), tracks.front().filepath())
                               : tr("Are you sure you want to delete %1 tracks?").arg(tracks.size());
 
     auto* label = new QLabel(message, this);

--- a/src/plugins/fileops/fileopsplugin.cpp
+++ b/src/plugins/fileops/fileopsplugin.cpp
@@ -25,6 +25,7 @@
 #include "fileopsdialog.h"
 #include "fileopssettings.h"
 
+#include <core/player/playercontroller.h>
 #include <gui/guiconstants.h>
 #include <gui/statusevent.h>
 #include <gui/trackselectioncontroller.h>
@@ -73,6 +74,7 @@ namespace Fooyin::FileOps {
 FileOpsPlugin::FileOpsPlugin()
     : m_actionManager{nullptr}
     , m_library{nullptr}
+    , m_playerController{nullptr}
     , m_trackSelectionController{nullptr}
     , m_settings{nullptr}
     , m_fileOpsMenu{nullptr}
@@ -80,14 +82,34 @@ FileOpsPlugin::FileOpsPlugin()
 
 void FileOpsPlugin::initialise(const CorePluginContext& context)
 {
-    m_library  = context.library;
-    m_settings = context.settingsManager;
+    m_library          = context.library;
+    m_playerController = context.playerController;
+    m_settings         = context.settingsManager;
 }
 
 void FileOpsPlugin::initialise(const GuiPluginContext& context)
 {
     m_actionManager            = context.actionManager;
     m_trackSelectionController = context.trackSelection;
+
+    auto* deletePlayingAction = new QAction(tr("Delete currently playing file"), this);
+    auto* deletePlayingCmd
+        = m_actionManager->registerAction(deletePlayingAction, "FileOps.DeleteCurrentlyPlaying");
+    deletePlayingCmd->setCategories({tr("Edit")});
+
+    const auto updateDeletePlayingAction = [this, deletePlayingAction]() {
+        deletePlayingAction->setEnabled(m_playerController->playState() != Player::PlayState::Stopped
+                                        && m_playerController->currentTrack().isValid()
+                                        && canOperateOnTracks({m_playerController->currentTrack()}));
+    };
+
+    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, deletePlayingAction,
+                     updateDeletePlayingAction);
+    QObject::connect(m_playerController, &PlayerController::playStateChanged, deletePlayingAction,
+                     updateDeletePlayingAction);
+    updateDeletePlayingAction();
+
+    QObject::connect(deletePlayingAction, &QAction::triggered, this, &FileOpsPlugin::deleteCurrentlyPlaying);
 
     recreateMenu();
 }
@@ -216,4 +238,53 @@ void FileOpsPlugin::recreateMenu()
     });
     m_fileOpsMenu->addAction(deleteAction);
 }
+
+void FileOpsPlugin::deleteCurrentlyPlaying()
+{
+    const Track playing = m_playerController->currentTrack();
+    if(!playing.isValid() || !canOperateOnTracks({playing})) {
+        return;
+    }
+
+    const TrackList tracks{playing};
+
+    const auto runDelete = [this, tracks]() {
+        // Advance playback before deleting so the engine releases the file handle.
+        // This avoids deletion failures on Windows (file locking) and ensures
+        // consistent behaviour across all platforms.
+        if(m_playerController->hasNextTrack()) {
+            m_playerController->next();
+        }
+        else {
+            m_playerController->stop();
+        }
+
+        auto* worker = new FileOpsWorker(m_library, tracks, m_settings);
+        auto* thread = new QThread(this);
+        worker->moveToThread(thread);
+
+        QObject::connect(worker, &FileOpsWorker::deleteFinished, this, [](const TrackList& deletedTracks) {
+            const QString status = deletedTracks.empty() ? tr("No tracks deleted") : tr("Track deleted");
+            StatusEvent::post(status);
+        });
+        QObject::connect(worker, &Worker::finished, thread, &QThread::quit);
+        QObject::connect(thread, &QThread::finished, worker, &QObject::deleteLater);
+        QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+
+        thread->start();
+        QMetaObject::invokeMethod(worker, &FileOpsWorker::deleteFiles);
+    };
+
+    const bool confirm = m_settings->fileValue(Settings::ConfirmDelete, true).toBool();
+    if(confirm) {
+        auto* dialog = new FileOpsDeleteDialog(tracks, m_settings, Utils::getMainWindow());
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        QObject::connect(dialog, &QDialog::accepted, dialog, [runDelete]() { runDelete(); });
+        dialog->open();
+    }
+    else {
+        runDelete();
+    }
+}
+
 } // namespace Fooyin::FileOps

--- a/src/plugins/fileops/fileopsplugin.cpp
+++ b/src/plugins/fileops/fileopsplugin.cpp
@@ -93,8 +93,7 @@ void FileOpsPlugin::initialise(const GuiPluginContext& context)
     m_trackSelectionController = context.trackSelection;
 
     auto* deletePlayingAction = new QAction(tr("Delete currently playing file"), this);
-    auto* deletePlayingCmd
-        = m_actionManager->registerAction(deletePlayingAction, "FileOps.DeleteCurrentlyPlaying");
+    auto* deletePlayingCmd    = m_actionManager->registerAction(deletePlayingAction, "FileOps.DeleteCurrentlyPlaying");
     deletePlayingCmd->setCategories({tr("Edit")});
 
     const auto updateDeletePlayingAction = [this, deletePlayingAction]() {

--- a/src/plugins/fileops/fileopsplugin.h
+++ b/src/plugins/fileops/fileopsplugin.h
@@ -28,6 +28,7 @@ class QMenu;
 
 namespace Fooyin {
 class ActionContainer;
+class PlayerController;
 
 namespace FileOps {
 class FileOpsPlugin : public QObject,
@@ -49,9 +50,11 @@ public:
 
 private:
     void recreateMenu();
+    void deleteCurrentlyPlaying();
 
     ActionManager* m_actionManager;
     MusicLibrary* m_library;
+    PlayerController* m_playerController;
     TrackSelectionController* m_trackSelectionController;
     SettingsManager* m_settings;
 


### PR DESCRIPTION
This extends the delete file functionality added in https://github.com/fooyin/fooyin/pull/932 with the following:
- add keyboard mnemonics to delete confirmation dialog
- show filepath in single-track delete confirmation dialog (I found just showing the track Title was a little lacking in information)
- add Delete Currently Playing File shortcut

Delete Currently Playing File does not trigger if file is an archive and only if there is an active track playing or paused.
Shortcut/Hotkey is unassigned by default.

This is to mimic the following hotkey assignment in foobar2000: 
Type:  [ Context / Now Playing ], Action: Delete

I used LLM for assistance as I am not very familiar with QT. (This will be my first QT related PR, let me know if anything is missing...)