### PR TITLE
[utils] Calculate rich text size with QFontMetrics::size()

### DIFF
--- a/src/gui/scripting/richtextutils.cpp
+++ b/src/gui/scripting/richtextutils.cpp
@@ -33,9 +33,10 @@ RichTextMetrics measureRichTextLine(const RichText& richText, const QFont& baseF
     for(const auto& block : richText.blocks) {
         const QFont font = resolvedRichTextFont(block.format, baseFont);
         const QFontMetrics fm{font};
+        const auto size = fm.size(Qt::TextSingleLine, block.text);
 
-        metrics.width += fm.horizontalAdvance(block.text);
-        metrics.height = std::max(metrics.height, fm.height());
+        metrics.width += size.width();
+        metrics.height = std::max(metrics.height, size.height());
     }
 
     metrics.height = std::max(metrics.height, defaultHeight);

--- a/src/gui/scripting/richtextutils.cpp
+++ b/src/gui/scripting/richtextutils.cpp
@@ -33,10 +33,9 @@ RichTextMetrics measureRichTextLine(const RichText& richText, const QFont& baseF
     for(const auto& block : richText.blocks) {
         const QFont font = resolvedRichTextFont(block.format, baseFont);
         const QFontMetrics fm{font};
-        const auto size = fm.size(Qt::TextSingleLine, block.text);
 
-        metrics.width += size.width();
-        metrics.height = std::max(metrics.height, size.height());
+        metrics.width += fm.horizontalAdvance(block.text);
+        metrics.height = std::max(metrics.height, fm.height());
     }
 
     metrics.height = std::max(metrics.height, defaultHeight);

--- a/src/gui/widgets/elidedlabel.cpp
+++ b/src/gui/widgets/elidedlabel.cpp
@@ -97,7 +97,7 @@ PreparedTextLine prepareRichTextLine(const std::vector<RichTextBlock>& blocks, c
         prepared.text   = text;
         prepared.font   = font;
         prepared.colour = resolvedRichTextColour(block.format, baseColour, linkColour);
-        prepared.width  = fm.size(Qt::TextSingleLine, text).width();
+        prepared.width  = fm.horizontalAdvance(text);
         prepared.height = fm.height();
 
         line.totalWidth += prepared.width;

--- a/src/gui/widgets/statuswidget.cpp
+++ b/src/gui/widgets/statuswidget.cpp
@@ -134,9 +134,9 @@ StatusWidgetPrivate::StatusWidgetPrivate(StatusWidget* self, PlayerController* p
     , m_selectionText{new StatusLabel(m_self)}
 {
     m_scriptParser.addProvider(playlistVariableProvider());
-    m_environment.setRatingStarSymbols({m_settings->value<Settings::Gui::RatingFullStarSymbol>(),
-                                        m_settings->value<Settings::Gui::RatingHalfStarSymbol>(),
-                                        m_settings->value<Settings::Gui::RatingEmptyStarSymbol>()});
+    m_environment.setRatingStarSymbols({.fullStarSymbol  = m_settings->value<Settings::Gui::RatingFullStarSymbol>(),
+                                        .halfStarSymbol  = m_settings->value<Settings::Gui::RatingHalfStarSymbol>(),
+                                        .emptyStarSymbol = m_settings->value<Settings::Gui::RatingEmptyStarSymbol>()});
     m_environment.setEvaluationPolicy(TrackListContextPolicy::Fallback, {}, true);
     m_scriptContext.environment = &m_environment;
 
@@ -149,6 +149,7 @@ StatusWidgetPrivate::StatusWidgetPrivate(StatusWidget* self, PlayerController* p
     m_scanCancelButton->setAutoRaise(true);
     m_scanCancelButton->setIcon(Gui::iconFromTheme(Constants::Icons::Close));
     m_scanCancelButton->setToolTip(tr("Cancel scan"));
+
     layout->addWidget(m_iconLabel, 0, Qt::AlignLeft);
     layout->addWidget(m_scanCancelButton, 0, Qt::AlignLeft);
     layout->addWidget(m_scanText, 1);
@@ -162,6 +163,9 @@ StatusWidgetPrivate::StatusWidgetPrivate(StatusWidget* self, PlayerController* p
     m_playingText->hide();
     m_messageText->hide();
     m_selectionText->setHidden(!m_settings->value<Settings::Gui::Internal::StatusShowSelection>());
+
+    m_selectionText->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_selectionText->setElideMode(Qt::ElideNone);
 
     updateActionVisibility();
 


### PR DESCRIPTION
The bug fixed in #908 reappeared when `ElidedLabel::richTextNaturalSize()` was switched over to use `measureRichText()`. Squash it again, this time in `measureRichTextLine()`.