### PR TITLE
[gui] TabStackWidget: Use hovered tab index for name editor

### DIFF
--- a/include/gui/widgets/editabletabbar.h
+++ b/include/gui/widgets/editabletabbar.h
@@ -39,7 +39,7 @@ public:
 
     explicit EditableTabBar(QWidget* parent = nullptr);
 
-    void showEditor();
+    void showEditor(int index);
     void closeEditor();
 
     void setEditTitle(const QString& title);

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -323,7 +323,8 @@ void PlaylistTabs::contextMenuEvent(QContextMenuEvent* event)
 
         auto* renameAction
             = new QAction(playlist->isAutoPlaylist() ? tr("Rename autoplaylist") : tr("Rename playlist"), menu);
-        QObject::connect(renameAction, &QAction::triggered, tabBar, &EditableTabBar::showEditor);
+        QObject::connect(renameAction, &QAction::triggered, tabBar,
+                         [tabBar] { tabBar->showEditor(tabBar->currentIndex()); });
 
         menu->addAction(renameAction);
         menu->addSeparator();

--- a/src/gui/splitters/tabstackwidget.cpp
+++ b/src/gui/splitters/tabstackwidget.cpp
@@ -328,7 +328,8 @@ void TabStackWidget::contextMenuEvent(QContextMenuEvent* event)
     posMenu->addAction(west);
 
     auto* rename = new QAction(tr("&Rename"), menu);
-    QObject::connect(rename, &QAction::triggered, m_tabs->editableTabBar(), &EditableTabBar::showEditor);
+    QObject::connect(rename, &QAction::triggered, m_tabs->editableTabBar(),
+                     [this, index] { m_tabs->editableTabBar()->showEditor(index); });
 
     auto* remove = new QAction(tr("Re&move"), menu);
     QObject::connect(remove, &QAction::triggered, this, [this, index]() { removeWidget(index); });

--- a/src/gui/widgets/editabletabbar.cpp
+++ b/src/gui/widgets/editabletabbar.cpp
@@ -39,26 +39,24 @@ EditableTabBar::EditableTabBar(QWidget* parent)
     setMovable(true);
 }
 
-void EditableTabBar::showEditor()
+void EditableTabBar::showEditor(int index)
 {
-    const int currIndex = currentIndex();
-
     if(m_mode == EditMode::Inline) {
-        m_lineEdit = new PopupLineEdit(tabText(currentIndex()), this);
+        m_lineEdit = new PopupLineEdit(tabText(index), this);
         m_lineEdit->setAttribute(Qt::WA_DeleteOnClose);
 
         QObject::connect(m_lineEdit, &QObject::destroyed, this, [this]() { m_lineEdit = nullptr; });
         QObject::connect(m_lineEdit, &PopupLineEdit::editingCancelled, m_lineEdit, &QWidget::close);
-        QObject::connect(m_lineEdit, &PopupLineEdit::editingFinished, this, [this, currIndex]() {
+        QObject::connect(m_lineEdit, &PopupLineEdit::editingFinished, this, [this, index]() {
             const QString text = m_lineEdit->text();
-            if(text != tabText(currIndex)) {
-                setTabText(currIndex, m_lineEdit->text());
-                emit tabTextChanged(currIndex, m_lineEdit->text());
+            if(text != tabText(index)) {
+                setTabText(index, m_lineEdit->text());
+                emit tabTextChanged(index, m_lineEdit->text());
             }
             m_lineEdit->close();
         });
 
-        const QRect rect = tabRect(currIndex);
+        const QRect rect = tabRect(index);
         m_lineEdit->setGeometry(rect);
 
         m_lineEdit->show();
@@ -66,15 +64,15 @@ void EditableTabBar::showEditor()
         m_lineEdit->setFocus(Qt::ActiveWindowFocusReason);
     }
     else {
-        const QString currentText = tabText(currIndex);
+        const QString currentText = tabText(index);
 
         bool ok{false};
         const QString text = QInputDialog::getText(Utils::getMainWindow(), tr("Rename Tab"), tr("Name:"),
                                                    QLineEdit::Normal, currentText, &ok);
 
         if(ok && !text.isEmpty() && text != currentText) {
-            setTabText(currIndex, text);
-            emit tabTextChanged(currIndex, text);
+            setTabText(index, text);
+            emit tabTextChanged(index, text);
         }
     }
 }
@@ -117,8 +115,9 @@ void EditableTabBar::mouseDoubleClickEvent(QMouseEvent* event)
         return;
     }
 
-    if(tabAt(pos) >= 0) {
-        showEditor();
+    const int tab = tabAt(pos);
+    if(tab >= 0) {
+        showEditor(tab);
     }
 
     QTabBar::mouseDoubleClickEvent(event);


### PR DESCRIPTION
When a tab in a tab stack is renamed through the context menu, the renaming will happen for the currently active tab instead of the tab that was actually hovered before the right click. Fixed by making `EditableTabBar::showEditor()` take an `index` argument and passing it down.