### PR TITLE
[vumeter] Don't set static layer DPR

### DIFF
--- a/src/plugins/vumeter/vumeterwidget.cpp
+++ b/src/plugins/vumeter/vumeterwidget.cpp
@@ -458,7 +458,6 @@ void VuMeterWidgetPrivate::ensureStaticLayer()
     m_staticLayer = QPixmap{static_cast<int>(static_cast<qreal>(targetSize.width()) * targetDpr),
                             static_cast<int>(static_cast<qreal>(targetSize.height()) * targetDpr)};
 
-    m_staticLayer.setDevicePixelRatio(targetDpr);
     m_staticLayer.fill(m_colours.colour(Colours::Type::Background, m_self->palette()));
 
     QPainter staticPainter{&m_staticLayer};

--- a/src/plugins/vumeter/vumeterwidget.cpp
+++ b/src/plugins/vumeter/vumeterwidget.cpp
@@ -39,6 +39,7 @@
 #include <QTimerEvent>
 #include <QWindow>
 
+#include <cmath>
 #include <optional>
 
 using namespace Qt::StringLiterals;
@@ -127,6 +128,7 @@ public:
 
     void invalidateStaticLayer();
     void ensureStaticLayer();
+    [[nodiscard]] QRectF staticLayerSourceRect(const QRect& logicalRect) const;
 
     [[nodiscard]] float channelSize() const;
     [[nodiscard]] float barSize() const;
@@ -455,15 +457,24 @@ void VuMeterWidgetPrivate::ensureStaticLayer()
     m_staticLayerSize = targetSize;
     m_staticLayerDpr  = targetDpr;
 
-    m_staticLayer = QPixmap{static_cast<int>(static_cast<qreal>(targetSize.width()) * targetDpr),
-                            static_cast<int>(static_cast<qreal>(targetSize.height()) * targetDpr)};
+    m_staticLayer = QPixmap{static_cast<int>(std::ceil(static_cast<qreal>(targetSize.width()) * targetDpr)),
+                            static_cast<int>(std::ceil(static_cast<qreal>(targetSize.height()) * targetDpr))};
 
+    m_staticLayer.setDevicePixelRatio(targetDpr);
     m_staticLayer.fill(m_colours.colour(Colours::Type::Background, m_self->palette()));
 
     QPainter staticPainter{&m_staticLayer};
     drawLegend(staticPainter);
 
     m_staticLayerDirty = false;
+}
+
+QRectF VuMeterWidgetPrivate::staticLayerSourceRect(const QRect& logicalRect) const
+{
+    return {static_cast<qreal>(logicalRect.x()) * m_staticLayerDpr,
+            static_cast<qreal>(logicalRect.y()) * m_staticLayerDpr,
+            static_cast<qreal>(logicalRect.width()) * m_staticLayerDpr,
+            static_cast<qreal>(logicalRect.height()) * m_staticLayerDpr};
 }
 
 float VuMeterWidgetPrivate::channelSize() const
@@ -1148,17 +1159,17 @@ void VuMeterWidget::paintEvent(QPaintEvent* event)
     QPainter painter{this};
     p->ensureStaticLayer();
 
+    const QRect dirty = event->rect();
+
     if(!p->m_staticLayer.isNull()) {
-        const QRect dirty = event->rect();
-        painter.drawPixmap(dirty, p->m_staticLayer, dirty);
+        painter.drawPixmap(QRectF{dirty}, p->m_staticLayer, p->staticLayerSourceRect(dirty));
     }
     else {
         painter.fillRect(0, 0, width(), height(), p->m_colours.colour(Colours::Type::Background, palette()));
         p->drawLegend(painter);
     }
 
-    const QRect dirty = event->rect();
-    const auto first  = static_cast<float>(p->isHorizontal() ? dirty.left() : dirty.bottom());
+    const auto first = static_cast<float>(p->isHorizontal() ? dirty.left() : dirty.bottom());
 
     const int channels = p->m_format.channelCount();
     if(channels <= 0) {


### PR DESCRIPTION
When DE scaling is set to >100%, the legend overlay is drawn oversized:

[Screencast From 2026-04-27 23-35-13.webm](https://github.com/user-attachments/assets/f40f8030-7576-4f8f-b6ad-9e2120081c4e)

Fix by removing the call to `QPixmap::setDevicePixelRatio()`.