### PR TITLE
[core] TagLib: Make TDRC override TYER date tag

### DIFF
--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -1146,8 +1146,18 @@ void readId3Tags(const TagLib::ID3v2::Tag* id3Tags, Fooyin::Track& track)
     }
 
     const TagLib::ID3v2::FrameListMap& frames = id3Tags->frameListMap();
+    const unsigned int majorVersion           = id3Tags->header()->majorVersion();
 
-    if(id3Tags->header()->majorVersion() == 3) {
+    if(majorVersion == 4) {
+        // TDRC replaces TYER
+        if(frames.contains("TDRC") && frames.contains("TYER")) {
+            const TagLib::ID3v2::FrameList& dateFrame = frames["TDRC"];
+            if(!dateFrame.isEmpty()) {
+                track.setDate(convertString(dateFrame.front()->toString()));
+            }
+        }
+    }
+    else if(majorVersion == 3) {
         // Handle '/' being used as a separator for artists in v2.3
         if(frames.contains("TPE1")) {
             const TagLib::ID3v2::FrameList& artistsFrame = frames["TPE1"];


### PR DESCRIPTION
Closes #787.

If we spot both `TDRC` and `TYER` in the same file, let's use `TDRC` on ID3v2.4. FFmpeg does the opposite and uses `TYER` instead, but I think using the newer tag makes more sense. If we want both tag readers to have the same behavior to the user, we could of course switch it around.

Edit: Another possibility is to concatenate if the contents of `TDRC` and `TYER` don't match. But this might confuse users who don't know much about ID3 tags.