### PR TITLE
[lyrics] Don't update lyrics widget if track changed during lyrics editing

### DIFF
--- a/src/plugins/lyrics/lyricswidget.cpp
+++ b/src/plugins/lyrics/lyricswidget.cpp
@@ -787,22 +787,30 @@ void LyricsWidget::handleSavedLyrics(const Track& track, const Lyrics& lyrics)
     changeLyrics(lyrics);
 }
 
-void LyricsWidget::changeLyrics(const Lyrics& lyrics)
+void LyricsWidget::changeLyrics(const Lyrics& lyrics, bool onEdit)
 {
-    m_currentLyrics = lyrics;
+    const bool fullUpdate = !onEdit || m_currentTrack.sameIdentityAs(*m_editingTrack);
+
+    if(fullUpdate) {
+        m_currentLyrics = lyrics;
+    }
 
     if(!lyrics.isLocal) {
         m_lyricsSaver->autoSaveLyrics(lyrics, m_currentTrack);
     }
 
     if(lyrics.isValid()) {
-        m_model->setLyrics(m_currentLyrics);
-        m_lyricsView->setDisplayString({});
+        if(fullUpdate) {
+            m_lyricsView->setDisplayString({});
+            m_model->setLyrics(m_currentLyrics);
+        }
         updateEdgeFadeState();
     }
     else {
-        m_lyricsView->setDisplayString(noLyricsDisplayText(m_currentTrack));
-        m_model->setLyrics({});
+        if(fullUpdate) {
+            m_lyricsView->setDisplayString(noLyricsDisplayText(m_currentTrack));
+            m_model->setLyrics({});
+        }
         m_lyricsView->setEdgeFadeEnabled(false);
     }
 
@@ -815,13 +823,20 @@ void LyricsWidget::openEditor(const Lyrics& lyrics)
         = new LyricsEditorDialog(m_currentTrack, lyrics, m_playerController, m_lyricsSaver, Utils::getMainWindow());
     dlg->setAttribute(Qt::WA_DeleteOnClose);
 
-    QObject::connect(dlg, &QDialog::finished, dlg, &LyricsEditorDialog::saveState);
+    m_editingTrack = m_currentTrack;
+
+    QObject::connect(dlg, &QDialog::finished, dlg, [this, dlg] {
+        dlg->saveState();
+        m_editingTrack = {};
+    });
     QObject::connect(dlg, &LyricsEditorDialog::lyricsEdited, this, [this](const Lyrics& updatedLyrics) {
-        std::erase_if(m_lyrics, [](const Lyrics& existingLyrics) { return existingLyrics.isLocal; });
-        if(updatedLyrics.isValid()) {
-            m_lyrics.insert(m_lyrics.begin(), updatedLyrics);
+        if(m_currentTrack.sameIdentityAs(*m_editingTrack)) {
+            std::erase_if(m_lyrics, [](const Lyrics& existingLyrics) { return existingLyrics.isLocal; });
+            if(updatedLyrics.isValid()) {
+                m_lyrics.insert(m_lyrics.begin(), updatedLyrics);
+            }
         }
-        changeLyrics(updatedLyrics);
+        changeLyrics(updatedLyrics, true);
     });
 
     dlg->show();

--- a/src/plugins/lyrics/lyricswidget.h
+++ b/src/plugins/lyrics/lyricswidget.h
@@ -106,7 +106,7 @@ private:
     void loadLyrics(const Lyrics& lyrics);
     void handleLyricsSearchFinished(const Track& track, bool foundAny);
     void handleSavedLyrics(const Track& track, const Lyrics& lyrics);
-    void changeLyrics(const Lyrics& lyrics);
+    void changeLyrics(const Lyrics& lyrics, bool onEdit = false);
     void openEditor(const Lyrics& lyrics);
     void openSearchDialog();
 
@@ -147,6 +147,7 @@ private:
     int m_currentLineEnd;
 
     Track m_currentTrack;
+    std::optional<Track> m_editingTrack;
     std::vector<Lyrics> m_lyrics;
     QMetaObject::Connection m_finderConnection;
     ScriptParser m_parser;


### PR DESCRIPTION
I believe #748 was already fixed at some point because I cannot reproduce it on my end.

The remaining problem is that if the current track changes while its lyrics are being edited, the lyrics view will still be changed for the new track, making it look like the lyrics were updated for the new track instead. This PR fixes that.

Closes #748.

By the way, is it intentional that the Lyrics tab in the properties dialog always uses the track's metadata lyrics?