### PR TITLE
[filters] Add option to change cover source preference

### DIFF
--- a/include/gui/coverprovider.h
+++ b/include/gui/coverprovider.h
@@ -27,6 +27,7 @@
 #include <QObject>
 
 #include <memory>
+#include <optional>
 #include <set>
 
 class QPixmap;

--- a/include/gui/coverprovider.h
+++ b/include/gui/coverprovider.h
@@ -37,6 +37,12 @@ namespace Fooyin {
 class AudioLoader;
 class SettingsManager;
 
+enum class ArtworkSourcePreference : uint8_t
+{
+    PreferDirectory = 0,
+    PreferEmbedded
+};
+
 /*!
  * Provides access to track album artwork.
  */
@@ -69,6 +75,13 @@ public:
      * @note this is enabled by default.
      */
     void setUsePlaceholder(bool enabled);
+
+    /*!
+     * Sets the local source preference for artwork.
+     * If std::nullopt is passed, the global user-facing setting will be used.
+     * @note the global setting is used by default.
+     */
+    void setSourcePreference(std::optional<ArtworkSourcePreference> preference);
 
     /** Returns @c true if @p track has a cover of the specific @p type. */
     [[nodiscard]] QFuture<bool> trackHasCover(const Track& track, Track::Cover type = Track::Cover::Front) const;

--- a/src/gui/coverprovider.cpp
+++ b/src/gui/coverprovider.cpp
@@ -302,7 +302,7 @@ bool prefersEmbedded(const CoverLoader& loader)
     return loader.sourcePreference == Fooyin::ArtworkSourcePreference::PreferEmbedded;
 }
 
-bool hasImageInDirectory(CoverLoader& loader)
+bool hasImageInDirectory(const CoverLoader& loader)
 {
     const QString dirPath = findDirectoryCover(loader.paths, loader.track, loader.type);
     if(dirPath.isEmpty()) {
@@ -313,7 +313,7 @@ bool hasImageInDirectory(CoverLoader& loader)
     return file.size() > 0;
 }
 
-QImage loadImageFromDirectory(CoverLoader& loader)
+QImage loadImageFromDirectory(const CoverLoader& loader)
 {
     const QString dirPath = findDirectoryCover(loader.paths, loader.track, loader.type);
     if(dirPath.isEmpty()) {
@@ -354,7 +354,7 @@ QImage loadImageFromEmbedded(const CoverLoader& loader, const QString& cachePath
     return cover;
 }
 
-bool hasCoverImage(CoverLoader loader)
+bool hasCoverImage(const CoverLoader& loader)
 {
     if(prefersEmbedded(loader)) {
         return hasEmbeddedCover(loader) || hasImageInDirectory(loader);
@@ -363,7 +363,7 @@ bool hasCoverImage(CoverLoader loader)
     return hasImageInDirectory(loader) || hasEmbeddedCover(loader);
 }
 
-CoverLoader loadCoverImage(CoverLoader loader)
+CoverLoader loadCoverImage(const CoverLoader& loader)
 {
     CoverLoader result{loader};
 
@@ -423,12 +423,13 @@ public:
     std::shared_ptr<AudioLoader> m_audioLoader;
     SettingsManager* m_settings;
 
-    bool m_usePlacerholder{true};
+    bool m_usePlaceholder{true};
     std::set<QString> m_pendingCovers;
     mutable std::unordered_map<QString, int64_t> m_noCoverRetryAfterMs;
 
     CoverPaths m_paths;
     ArtworkSourcePreference m_sourcePreference;
+    bool m_manualSourcePreference{false};
     QString m_thumbnailGroupScript;
 };
 
@@ -451,8 +452,11 @@ CoverProvider::CoverProviderPrivate::CoverProviderPrivate(CoverProvider* self, s
 
     m_settings->subscribe<Settings::Gui::Internal::TrackCoverPaths>(
         m_self, [this](const QVariant& var) { m_paths = var.value<CoverPaths>(); });
-    m_settings->subscribe<Settings::Gui::Internal::TrackCoverSourcePreference>(
-        m_self, [this](int preference) { m_sourcePreference = static_cast<ArtworkSourcePreference>(preference); });
+    m_settings->subscribe<Settings::Gui::Internal::TrackCoverSourcePreference>(m_self, [this](int preference) {
+        if(!m_manualSourcePreference) {
+            m_sourcePreference = static_cast<ArtworkSourcePreference>(preference);
+        }
+    });
     m_settings->subscribe<Settings::Gui::Internal::TrackCoverThumbnailGroupScript>(m_self, [this](QString script) {
         m_thumbnailGroupScript = std::move(script);
         m_noCoverKeys.clear();
@@ -694,7 +698,20 @@ CoverProvider::~CoverProvider() = default;
 
 void CoverProvider::setUsePlaceholder(bool enabled)
 {
-    p->m_usePlacerholder = enabled;
+    p->m_usePlaceholder = enabled;
+}
+
+void CoverProvider::setSourcePreference(std::optional<ArtworkSourcePreference> preference)
+{
+    if(!preference) {
+        p->m_sourcePreference = static_cast<ArtworkSourcePreference>(
+            p->m_settings->value<Settings::Gui::Internal::TrackCoverSourcePreference>());
+        p->m_manualSourcePreference = false;
+    }
+    else {
+        p->m_sourcePreference       = *preference;
+        p->m_manualSourcePreference = true;
+    }
 }
 
 QFuture<bool> CoverProvider::trackHasCover(const Track& track, Track::Cover type) const
@@ -715,7 +732,7 @@ QFuture<bool> CoverProvider::trackHasCover(const Track& track, Track::Cover type
 QPixmap CoverProvider::trackCover(const Track& track, Track::Cover type) const
 {
     if(!track.isValid()) {
-        return p->m_usePlacerholder ? p->loadNoCover() : QPixmap{};
+        return p->m_usePlaceholder ? p->loadNoCover() : QPixmap{};
     }
 
     const QString coverKey = generateTrackCoverKey(track, type, p->m_sourcePreference);
@@ -729,7 +746,7 @@ QPixmap CoverProvider::trackCover(const Track& track, Track::Cover type) const
         p->fetchCover(coverKey, track, type, false);
     }
 
-    return p->m_usePlacerholder ? p->loadNoCover() : QPixmap{};
+    return p->m_usePlaceholder ? p->loadNoCover() : QPixmap{};
 }
 
 QFuture<QPixmap> CoverProvider::trackCoverFull(const Track& track, Track::Cover type) const
@@ -781,7 +798,7 @@ QFuture<QPixmap> CoverProvider::trackCoverThumbnailAsync(const Track& track, con
 QPixmap CoverProvider::trackCoverThumbnail(const Track& track, ThumbnailSize size, Track::Cover type) const
 {
     if(!track.isValid()) {
-        return p->m_usePlacerholder ? p->loadNoCover(size) : QPixmap{};
+        return p->m_usePlaceholder ? p->loadNoCover(size) : QPixmap{};
     }
 
     const QString coverKey = p->thumbnailCoverKey(track, type);
@@ -792,7 +809,7 @@ QPixmap CoverProvider::trackCoverThumbnail(const Track& track, ThumbnailSize siz
             p->fetchCover(coverKey, track, type, true, size);
         }
 
-        return p->m_usePlacerholder ? p->loadNoCover(size) : QPixmap{};
+        return p->m_usePlaceholder ? p->loadNoCover(size) : QPixmap{};
     }
 
     if(!p->m_pendingCovers.contains(coverKey)) {
@@ -805,7 +822,7 @@ QPixmap CoverProvider::trackCoverThumbnail(const Track& track, ThumbnailSize siz
         p->fetchCover(coverKey, track, type, true, size);
     }
 
-    return p->m_usePlacerholder ? p->loadNoCover(size) : QPixmap{};
+    return p->m_usePlaceholder ? p->loadNoCover(size) : QPixmap{};
 }
 
 QPixmap CoverProvider::trackCoverThumbnail(const Track& track, const QSize& size, Track::Cover type) const

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -24,6 +24,7 @@
 #include "widgets/statuswidget.h"
 
 #include <core/ratingsymbols.h>
+#include <gui/coverprovider.h>
 #include <gui/guiconstants.h>
 #include <gui/guisettings.h>
 #include <utils/settings/settingsmanager.h>

--- a/src/gui/internalguisettings.h
+++ b/src/gui/internalguisettings.h
@@ -42,12 +42,6 @@ enum class SelectionDisplay : uint8_t
     PreferSelection
 };
 
-enum class ArtworkSourcePreference : uint8_t
-{
-    PreferDirectory = 0,
-    PreferEmbedded
-};
-
 struct CoverPaths
 {
     QStringList frontCoverPaths;

--- a/src/plugins/filters/filtercontroller.cpp
+++ b/src/plugins/filters/filtercontroller.cpp
@@ -182,8 +182,8 @@ public:
     MusicLibrary* m_library;
     LibraryManager* m_libraryManager;
     TrackSelectionController* m_trackSelection;
+    std::shared_ptr<AudioLoader> m_audioLoader;
     EditableLayout* m_editableLayout;
-    CoverProvider m_coverProvider;
     SettingsManager* m_settings;
 
     FilterManager* m_manager;
@@ -204,8 +204,8 @@ FilterControllerPrivate::FilterControllerPrivate(FilterController* self, ActionM
     , m_library{core.library}
     , m_libraryManager{core.libraryManager}
     , m_trackSelection{trackSelection}
+    , m_audioLoader{core.audioLoader}
     , m_editableLayout{editableLayout}
-    , m_coverProvider{core.audioLoader, settings}
     , m_settings{settings}
     , m_manager{new FilterManager(m_self, m_editableLayout, m_self)}
     , m_columnRegistry{new FilterColumnRegistry(settings, m_self)}
@@ -976,7 +976,7 @@ QString FilterController::defaultPlaylistName()
 FilterWidget* FilterController::createFilter()
 {
     auto* widget = new FilterWidget(p->m_actionManager, p->m_columnRegistry, p->m_libraryManager, p->m_library,
-                                    &p->m_coverProvider, p->m_settings);
+                                    p->m_audioLoader, p->m_settings);
 
     widget->setGroup(p->m_defaultId);
     p->attachWidget(widget, p->m_defaultId);

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -158,6 +158,7 @@ public:
     CoverProvider::ThumbnailSize m_decorationSize;
     bool m_showLabels{true};
     Track::Cover m_coverType{Track::Cover::Front};
+    std::optional<ArtworkSourcePreference> m_coverSource{std::nullopt};
     std::vector<int> m_columnOrder;
 
     using ColumnAlignments = std::vector<Qt::Alignment>;
@@ -325,6 +326,11 @@ Track::Cover FilterModel::coverType() const
     return p->m_coverType;
 }
 
+std::optional<ArtworkSourcePreference> FilterModel::coverSource() const
+{
+    return p->m_coverSource;
+}
+
 void FilterModel::setRowHeight(int height)
 {
     p->m_rowHeight = height;
@@ -384,6 +390,14 @@ void FilterModel::setShowLabels(bool show)
 void FilterModel::setCoverType(Track::Cover type)
 {
     if(std::exchange(p->m_coverType, type) != type) {
+        p->dataUpdated({Qt::DecorationRole});
+    }
+}
+
+void FilterModel::setCoverSource(std::optional<ArtworkSourcePreference> source)
+{
+    if(std::exchange(p->m_coverSource, source) != source) {
+        p->m_coverProvider->setSourcePreference(source);
         p->dataUpdated({Qt::DecorationRole});
     }
 }

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -24,6 +24,7 @@
 #include "filterrows.h"
 
 #include <core/track.h>
+#include <gui/coverprovider.h>
 #include <utils/stringcollator.h>
 #include <utils/treemodel.h>
 
@@ -62,6 +63,7 @@ public:
 
     [[nodiscard]] bool showSummary() const;
     [[nodiscard]] Track::Cover coverType() const;
+    [[nodiscard]] std::optional<ArtworkSourcePreference> coverSource() const;
 
     void setRowHeight(int height);
     void setIconSize(const QSize& size);
@@ -69,6 +71,7 @@ public:
     void setShowDecoration(bool show);
     void setShowLabels(bool show);
     void setCoverType(Track::Cover type);
+    void setCoverSource(std::optional<ArtworkSourcePreference> source);
     void setColumnOrder(const std::vector<int>& order);
 
     [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -98,7 +98,7 @@ FilterWidget::FilterWidget(ActionManager* actionManager, FilterColumnRegistry* c
     , m_settings{settings}
     , m_view{new FilterView(this)}
     , m_header{new AutoHeaderView(Qt::Horizontal, this)}
-    , m_model{new FilterModel(library, new CoverProvider(std::move(audioLoader), settings), m_settings, this)}
+    , m_model{new FilterModel(library, new CoverProvider(std::move(audioLoader), settings, this), m_settings, this)}
     , m_sortProxy{new FilterSortModel(this)}
     , m_index{-1}
     , m_multipleColumns{false}

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -26,6 +26,7 @@
 #include "filterdelegate.h"
 #include "filteritem.h"
 #include "filtermodel.h"
+#include "gui/coverprovider.h"
 
 #include <gui/guiconstants.h>
 #include <gui/trackselectioncontroller.h>
@@ -327,10 +328,18 @@ void FilterWidget::saveLayoutData(QJsonObject& layout)
         columns.push_back(colStr);
     }
 
+    const auto coverSourceToInt = [](std::optional<ArtworkSourcePreference> source) -> int {
+        if(!source) {
+            return -1;
+        }
+        return static_cast<int>(*source);
+    };
+
     layout["Columns"_L1]         = columns.join(u"|"_s);
     layout["Display"_L1]         = static_cast<int>(m_view->viewMode());
     layout["Captions"_L1]        = static_cast<int>(m_view->captionDisplay());
     layout["Artwork"_L1]         = static_cast<int>(m_model->coverType());
+    layout["Source"_L1]          = coverSourceToInt(m_model->coverSource());
     layout["ShowSummary"_L1]     = m_model->showSummary();
     layout["ShowHeader"_L1]      = m_showHeader;
     layout["ShowScrollbar"_L1]   = m_showScrollbar;
@@ -379,6 +388,15 @@ void FilterWidget::loadLayoutData(const QJsonObject& layout)
     }
     if(layout.contains("Artwork"_L1)) {
         m_model->setCoverType(static_cast<Track::Cover>(layout.value("Artwork"_L1).toInt()));
+    }
+    if(layout.contains("Source"_L1)) {
+        auto source = layout.value("Source"_L1).toInt();
+        if(source == -1) {
+            m_model->setCoverSource(std::nullopt);
+        }
+        else {
+            m_model->setCoverSource(static_cast<ArtworkSourcePreference>(source));
+        }
     }
     if(layout.contains("ShowSummary"_L1)) {
         m_model->setShowSummary(layout.value("ShowSummary"_L1).toBool());
@@ -781,6 +799,7 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
     auto* displayMenu  = new QMenu(FilterWidget::tr("Display"), menu);
     auto* displayGroup = new QActionGroup(displayMenu);
     auto* coverGroup   = new QActionGroup(displayMenu);
+    auto* sourceGroup  = new QActionGroup(displayMenu);
 
     auto* displayList      = new QAction(FilterWidget::tr("Columns"), displayGroup);
     auto* displayArtBottom = new QAction(FilterWidget::tr("Artwork (bottom labels)"), displayGroup);
@@ -789,6 +808,9 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
     auto* coverFront       = new QAction(FilterWidget::tr("Front cover"), coverGroup);
     auto* coverBack        = new QAction(FilterWidget::tr("Back cover"), coverGroup);
     auto* coverArtist      = new QAction(FilterWidget::tr("Artist"), coverGroup);
+    auto* sourceEmbedded   = new QAction(FilterWidget::tr("Use embedded covers"), sourceGroup);
+    auto* sourceDirectory  = new QAction(FilterWidget::tr("Use directory covers"), sourceGroup);
+    auto* sourceDefault    = new QAction(FilterWidget::tr("Use default source"), sourceGroup);
 
     displayList->setCheckable(true);
     displayArtBottom->setCheckable(true);
@@ -797,10 +819,14 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
     coverFront->setCheckable(true);
     coverBack->setCheckable(true);
     coverArtist->setCheckable(true);
+    sourceEmbedded->setCheckable(true);
+    sourceDirectory->setCheckable(true);
+    sourceDefault->setCheckable(true);
 
     const auto currentMode     = m_view->viewMode();
     const auto currentCaptions = m_view->captionDisplay();
     const auto currentType     = m_model->coverType();
+    const auto currentSource   = m_model->coverSource();
 
     using ViewMode       = ExpandedTreeView::ViewMode;
     using CaptionDisplay = ExpandedTreeView::CaptionDisplay;
@@ -828,6 +854,16 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
         coverArtist->setChecked(true);
     }
 
+    if(!currentSource) {
+        sourceDefault->setChecked(true);
+    }
+    else if(*currentSource == ArtworkSourcePreference::PreferEmbedded) {
+        sourceEmbedded->setChecked(true);
+    }
+    else if(*currentSource == ArtworkSourcePreference::PreferDirectory) {
+        sourceDirectory->setChecked(true);
+    }
+
     QObject::connect(displayList, &QAction::triggered, this, [this]() {
         updateViewMode(ViewMode::Tree);
         updateCaptions(CaptionDisplay::Bottom);
@@ -847,6 +883,11 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
     QObject::connect(coverFront, &QAction::triggered, this, [this]() { m_model->setCoverType(Track::Cover::Front); });
     QObject::connect(coverBack, &QAction::triggered, this, [this]() { m_model->setCoverType(Track::Cover::Back); });
     QObject::connect(coverArtist, &QAction::triggered, this, [this]() { m_model->setCoverType(Track::Cover::Artist); });
+    QObject::connect(sourceDefault, &QAction::triggered, this, [this]() { m_model->setCoverSource(std::nullopt); });
+    QObject::connect(sourceEmbedded, &QAction::triggered, this,
+                     [this]() { m_model->setCoverSource(ArtworkSourcePreference::PreferEmbedded); });
+    QObject::connect(sourceDirectory, &QAction::triggered, this,
+                     [this]() { m_model->setCoverSource(ArtworkSourcePreference::PreferDirectory); });
 
     auto* displaySummary = new QAction(FilterWidget::tr("Summary item"), displayMenu);
     displaySummary->setCheckable(true);
@@ -886,6 +927,8 @@ void FilterWidget::addDisplayMenu(QMenu* menu)
     displayMenu->addAction(alternatingRows);
     displayMenu->addSeparator();
     displayMenu->addActions(coverGroup->actions());
+    displayMenu->addSeparator();
+    displayMenu->addActions(sourceGroup->actions());
 
     menu->addMenu(displayMenu);
 }

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -26,8 +26,8 @@
 #include "filterdelegate.h"
 #include "filteritem.h"
 #include "filtermodel.h"
-#include "gui/coverprovider.h"
 
+#include <gui/coverprovider.h>
 #include <gui/guiconstants.h>
 #include <gui/trackselectioncontroller.h>
 #include <gui/widgets/autoheaderview.h>
@@ -90,15 +90,15 @@ protected:
 };
 
 FilterWidget::FilterWidget(ActionManager* actionManager, FilterColumnRegistry* columnRegistry,
-                           LibraryManager* /*libraryManager*/, MusicLibrary* library, CoverProvider* coverProvider,
-                           SettingsManager* settings, QWidget* parent)
+                           LibraryManager* /*libraryManager*/, MusicLibrary* library,
+                           std::shared_ptr<AudioLoader> audioLoader, SettingsManager* settings, QWidget* parent)
     : FyWidget{parent}
     , m_actionManager{actionManager}
     , m_columnRegistry{columnRegistry}
     , m_settings{settings}
     , m_view{new FilterView(this)}
     , m_header{new AutoHeaderView(Qt::Horizontal, this)}
-    , m_model{new FilterModel(library, coverProvider, m_settings, this)}
+    , m_model{new FilterModel(library, new CoverProvider(std::move(audioLoader), settings), m_settings, this)}
     , m_sortProxy{new FilterSortModel(this)}
     , m_index{-1}
     , m_multipleColumns{false}

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -27,6 +27,7 @@
 #include <gui/widgets/expandedtreeview.h>
 
 namespace Fooyin {
+class AudioLoader;
 class AutoHeaderView;
 class ActionManager;
 class CoverProvider;
@@ -55,8 +56,9 @@ public:
     };
 
     explicit FilterWidget(ActionManager* actionManager, FilterColumnRegistry* columnRegistry,
-                          LibraryManager* libraryManager, MusicLibrary* library, CoverProvider* coverProvider,
-                          SettingsManager* settings, QWidget* parent = nullptr);
+                          LibraryManager* libraryManager, MusicLibrary* library,
+                          std::shared_ptr<AudioLoader> audioLoader, SettingsManager* settings,
+                          QWidget* parent = nullptr);
     ~FilterWidget() override;
 
     [[nodiscard]] Id group() const;
@@ -151,6 +153,7 @@ private:
     ActionManager* m_actionManager;
     FilterColumnRegistry* m_columnRegistry;
     SettingsManager* m_settings;
+    CoverProvider* m_coverProvider;
 
     FilterView* m_view;
     AutoHeaderView* m_header;

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -153,7 +153,6 @@ private:
     ActionManager* m_actionManager;
     FilterColumnRegistry* m_columnRegistry;
     SettingsManager* m_settings;
-    CoverProvider* m_coverProvider;
 
     FilterView* m_view;
     AutoHeaderView* m_header;


### PR DESCRIPTION
This adds a filters context menu option (Filter options > Display) to override the artwork local source preference from the global settings. I did this by first adding a `setSourcePreference` function to `CoverProvider` and then wiring it up to the filter model.

Additionally:
+ Fix a misspelled variable name.
+ Pass `CoverLoader` by reference in some `CoverProvider`-internal functions.

Closes #1021.