### PR TITLE
[core] Several playback queue fixes

### DIFF
--- a/include/core/player/playbackqueue.h
+++ b/include/core/player/playbackqueue.h
@@ -52,6 +52,8 @@ public:
     [[nodiscard]] PlaylistTrack nextTrack() const;
     PlaylistTrack nextTrackChange();
 
+    [[nodiscard]] int getTrackIndex(const PlaylistTrack& track) const;
+    [[nodiscard]] bool containsTrack(const PlaylistTrack& track) const;
     void addTracks(const QueueTracks& tracks, int index = -1);
     void replaceTracks(const QueueTracks& tracks);
     std::optional<PlaylistTrack> removeFirstMatchingTrack(const PlaylistTrack& track);

--- a/include/core/player/playbackqueue.h
+++ b/include/core/player/playbackqueue.h
@@ -47,7 +47,7 @@ public:
 
     [[nodiscard]] PlaylistIndexes playlistIndexes() const;
     [[nodiscard]] PlaylistTrackIndexes indexesForPlaylist(const UId& id) const;
-    std::vector<int> indexesForTrack(const UId& playlistId, int playlistTrackIndex) const;
+    [[nodiscard]] std::vector<int> indexesForTrack(const UId& playlistId, int playlistTrackIndex) const;
 
     [[nodiscard]] PlaylistTrack nextTrack() const;
     PlaylistTrack nextTrackChange();

--- a/include/core/playlist/playlist.h
+++ b/include/core/playlist/playlist.h
@@ -58,6 +58,8 @@ struct FYCORE_EXPORT PlaylistTrack
     bool operator==(const PlaylistTrack& other) const = default;
     bool operator<(const PlaylistTrack& other) const;
 
+    [[nodiscard]] bool sameIdentityAs(const PlaylistTrack& other) const;
+
     operator QVariant() const
     {
         return QVariant::fromValue(*this);

--- a/src/core/playback/playbackordernavigator.cpp
+++ b/src/core/playback/playbackordernavigator.cpp
@@ -218,9 +218,10 @@ std::optional<PlaybackOrderNavigator::RequestedTrack> PlaybackOrderNavigator::se
 {
     if(delta <= 0) {
         if(m_playlistHandler) {
+            auto track = advancePlaybackRelativeTrack(delta);
             return RequestedTrack{
-                .track        = advancePlaybackRelativeTrack(delta),
-                .isQueueTrack = false,
+                .track        = track,
+                .isQueueTrack = m_queue->containsTrack(track),
             };
         }
         return {};

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -147,13 +147,13 @@ void PlaybackQueue::replaceTracks(const QueueTracks& tracks)
 
 std::optional<PlaylistTrack> PlaybackQueue::removeFirstMatchingTrack(const PlaylistTrack& track)
 {
-    const auto it = std::ranges::find(m_tracks, track);
-    if(it == m_tracks.end()) {
+    const auto index = getTrackIndex(track);
+    if(index == -1) {
         return {};
     }
 
-    PlaylistTrack removedTrack{*it};
-    m_tracks.erase(it);
+    PlaylistTrack removedTrack{m_tracks.at(index)};
+    m_tracks.erase(m_tracks.begin() + index);
     return removedTrack;
 }
 

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -114,9 +114,9 @@ PlaylistTrack PlaybackQueue::nextTrackChange()
 
 int PlaybackQueue::getTrackIndex(const PlaylistTrack& track) const
 {
-    auto it = std::ranges::find_if(
-        m_tracks.cbegin(), m_tracks.cend(),
-        [hash = track.track.hash()](const PlaylistTrack& track) { return hash == track.track.hash(); });
+    const auto it = std::ranges::find_if(m_tracks, [&track](const PlaylistTrack& other) {
+        return track.playlistId == other.playlistId && track.sameIdentityAs(other);
+    });
 
     if(it == m_tracks.cend()) {
         return -1;
@@ -161,13 +161,14 @@ QueueTracks PlaybackQueue::removeTracks(const QueueTracks& tracks)
 {
     QueueTracks removedTracks;
 
-    std::set<QString> tracksToRemove;
-    for(const auto& track : tracks) {
-        tracksToRemove.insert(track.track.hash());
-    }
+    std::set<PlaylistTrack> tracksToRemove{tracks.cbegin(), tracks.cend()};
 
     auto matchingTrack = [&tracksToRemove](const PlaylistTrack& track) {
-        return tracksToRemove.contains(track.track.hash());
+        return std::ranges::find_if(tracksToRemove,
+                                    [&track](const PlaylistTrack& other) {
+                                        return other.playlistId == track.playlistId && track.sameIdentityAs(other);
+                                    })
+            != tracksToRemove.cend();
     };
 
     std::ranges::copy_if(m_tracks, std::back_inserter(removedTracks), matchingTrack);

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -114,9 +114,8 @@ PlaylistTrack PlaybackQueue::nextTrackChange()
 
 int PlaybackQueue::getTrackIndex(const PlaylistTrack& track) const
 {
-    const auto it = std::ranges::find_if(m_tracks, [&track](const PlaylistTrack& other) {
-        return track.playlistId == other.playlistId && track.sameIdentityAs(other);
-    });
+    const auto it
+        = std::ranges::find_if(m_tracks, [&track](const PlaylistTrack& other) { return track.sameIdentityAs(other); });
 
     if(it == m_tracks.cend()) {
         return -1;
@@ -165,9 +164,7 @@ QueueTracks PlaybackQueue::removeTracks(const QueueTracks& tracks)
 
     auto matchingTrack = [&tracksToRemove](const PlaylistTrack& track) {
         return std::ranges::find_if(tracksToRemove,
-                                    [&track](const PlaylistTrack& other) {
-                                        return other.playlistId == track.playlistId && track.sameIdentityAs(other);
-                                    })
+                                    [&track](const PlaylistTrack& other) { return track.sameIdentityAs(other); })
             != tracksToRemove.cend();
     };
 

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -162,8 +162,9 @@ QueueTracks PlaybackQueue::removeTracks(const QueueTracks& tracks)
     QueueTracks removedTracks;
 
     std::set<QString> tracksToRemove;
-    tracksToRemove.insert_range(
-        std::views::transform(tracks, [](const PlaylistTrack& track) { return track.track.hash(); }));
+    for(const auto& track : tracks) {
+        tracksToRemove.insert(track.track.hash());
+    }
 
     auto matchingTrack = [&tracksToRemove](const PlaylistTrack& track) {
         return tracksToRemove.contains(track.track.hash());

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -143,10 +143,12 @@ QueueTracks PlaybackQueue::removeTracks(const QueueTracks& tracks)
 {
     QueueTracks removedTracks;
 
-    std::set<PlaylistTrack> tracksToRemove{tracks.cbegin(), tracks.cend()};
+    std::set<QString> tracksToRemove;
+    tracksToRemove.insert_range(
+        std::views::transform(tracks, [](const PlaylistTrack& track) { return track.track.hash(); }));
 
     auto matchingTrack = [&tracksToRemove](const PlaylistTrack& track) {
-        return tracksToRemove.contains(track);
+        return tracksToRemove.contains(track.track.hash());
     };
 
     std::ranges::copy_if(m_tracks, std::back_inserter(removedTracks), matchingTrack);

--- a/src/core/playback/playbackqueue.cpp
+++ b/src/core/playback/playbackqueue.cpp
@@ -112,6 +112,24 @@ PlaylistTrack PlaybackQueue::nextTrackChange()
     return track;
 }
 
+int PlaybackQueue::getTrackIndex(const PlaylistTrack& track) const
+{
+    auto it = std::ranges::find_if(
+        m_tracks.cbegin(), m_tracks.cend(),
+        [hash = track.track.hash()](const PlaylistTrack& track) { return hash == track.track.hash(); });
+
+    if(it == m_tracks.cend()) {
+        return -1;
+    }
+
+    return static_cast<int>(std::distance(m_tracks.cbegin(), it));
+}
+
+bool PlaybackQueue::containsTrack(const PlaylistTrack& track) const
+{
+    return getTrackIndex(track) >= 0;
+}
+
 void PlaybackQueue::addTracks(const QueueTracks& tracks, int index)
 {
     if(index >= 0) {

--- a/src/core/playback/playercontroller.cpp
+++ b/src/core/playback/playercontroller.cpp
@@ -1257,11 +1257,7 @@ void PlayerController::changeCurrentTrack(const PlaylistTrack& track, const Play
         return;
     }
 
-    p->requestTrackChange({
-        .track        = track,
-        .context      = context,
-        .isQueueTrack = false,
-    });
+    p->requestTrackChange({.track = track, .context = context, .isQueueTrack = p->m_queue.containsTrack(track)});
 }
 
 void PlayerController::commitCurrentTrack(const Track& track)

--- a/src/core/playlist/playlist.cpp
+++ b/src/core/playlist/playlist.cpp
@@ -114,6 +114,11 @@ bool PlaylistTrack::operator<(const PlaylistTrack& other) const
          < std::tie(other.track, other.playlistId, other.entryId, other.indexInPlaylist);
 }
 
+bool PlaylistTrack::sameIdentityAs(const PlaylistTrack& other) const
+{
+    return track.sameIdentityAs(other.track);
+}
+
 struct Playlist::PrivateKey
 {
     PrivateKey() { }


### PR DESCRIPTION
A couple of playback queue fixes.

* Removing tracks from the playback queue using the track context menu does not work anymore after a session restore. Reason: `PlaybackQueue::removeTracks()` uses a `set` of `PlaylistTrack`s which do not persist across sessions. Use a `set` of track hashes instead.
* Same issue exists for `PlaybackQueue::removeFirstMatchingTrack()`. I added two new `PlaybackQueue` functions that find a `PlaylistTrack` by hash, and fixed it by calling that instead.
* Double-clicking a track in a playlist or using the "Previous" action ignores whether that track is in the playback queue, so they won't be removed. Use these functions to fix that.

There is one more thing which I'm not sure is a bug:
Say we're at track X and then go to track N which is the only track in the queue. "Previous" will put us at track X-1 instead of N-1. However, "Next" will move us to N+1, not X+1. I don't know if this behavior is expected, so I left it alone for now.