### PR TITLE
Replace cardinal directions with standard directions for tab stack

### DIFF
--- a/src/gui/splitters/tabstackwidget.cpp
+++ b/src/gui/splitters/tabstackwidget.cpp
@@ -286,10 +286,10 @@ void TabStackWidget::contextMenuEvent(QContextMenuEvent* event)
 
     auto* positionGroup = new QActionGroup(menu);
 
-    auto* north = new QAction(tr("&North"), posMenu);
-    auto* east  = new QAction(tr("&East"), posMenu);
-    auto* south = new QAction(tr("&South"), posMenu);
-    auto* west  = new QAction(tr("&West"), posMenu);
+    auto* north = new QAction(tr("&Above"), posMenu);
+    auto* east  = new QAction(tr("&Right"), posMenu);
+    auto* south = new QAction(tr("&Below"), posMenu);
+    auto* west  = new QAction(tr("&Left"), posMenu);
 
     north->setCheckable(true);
     east->setCheckable(true);


### PR DESCRIPTION
Currently the tab position options of the tab stack widgets are named after the cardinal directions: north, east, south and west. And while this is consistent with the underlying code, it doesn't fit the program in my opinion.

This is why I suggest replacing the position options to standard directions according to the Qt documentations [description of the position enum](https://doc.qt.io/qt-6/qtabwidget.html#TabPosition-enum):
North → Above
East → Right
South → Below
West → Left