### PR TITLE
[gui] PopupLineEdit: Don't emit editingFinished signal on escape

### DIFF
--- a/include/gui/widgets/popuplineedit.h
+++ b/include/gui/widgets/popuplineedit.h
@@ -42,5 +42,6 @@ protected:
 
 private:
     bool m_cancelled{};
+    QString m_initialString;
 };
 } // namespace Fooyin

--- a/include/gui/widgets/popuplineedit.h
+++ b/include/gui/widgets/popuplineedit.h
@@ -39,5 +39,8 @@ protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
+
+private:
+    bool m_cancelled{};
 };
 } // namespace Fooyin

--- a/src/gui/widgets/editabletabbar.cpp
+++ b/src/gui/widgets/editabletabbar.cpp
@@ -51,7 +51,7 @@ void EditableTabBar::showEditor(int index)
         QObject::connect(m_lineEdit, &PopupLineEdit::editingCancelled, m_lineEdit, &QWidget::close);
         QObject::connect(m_lineEdit, &PopupLineEdit::editingFinished, this, [this, index]() {
             const QString text = m_lineEdit->text();
-            if(text != tabText(index)) {
+            if(!text.isEmpty() && text != tabText(index)) {
                 setTabText(index, m_lineEdit->text());
                 Q_EMIT tabTextChanged(index, m_lineEdit->text());
             }

--- a/src/gui/widgets/popuplineedit.cpp
+++ b/src/gui/widgets/popuplineedit.cpp
@@ -47,15 +47,17 @@ void PopupLineEdit::keyPressEvent(QKeyEvent* event)
     QLineEdit::keyPressEvent(event);
 
     if(event->key() == Qt::Key_Escape) {
+        m_cancelled = true;
         Q_EMIT editingCancelled();
     }
 }
 
 void PopupLineEdit::focusOutEvent(QFocusEvent* event)
 {
-    QLineEdit::focusOutEvent(event);
-
-    Q_EMIT editingFinished();
+    if(!m_cancelled) {
+        // Allow our base widget to emit editingFinished.
+        QLineEdit::focusOutEvent(event);
+    }
 }
 } // namespace Fooyin
 

--- a/src/gui/widgets/popuplineedit.cpp
+++ b/src/gui/widgets/popuplineedit.cpp
@@ -29,6 +29,7 @@ PopupLineEdit::PopupLineEdit(QWidget* parent)
 
 PopupLineEdit::PopupLineEdit(const QString& contents, QWidget* parent)
     : QLineEdit{contents, parent}
+    , m_initialString{contents}
 { }
 
 void PopupLineEdit::paintEvent(QPaintEvent* event)
@@ -54,6 +55,10 @@ void PopupLineEdit::keyPressEvent(QKeyEvent* event)
 
 void PopupLineEdit::focusOutEvent(QFocusEvent* event)
 {
+    if(m_initialString == text()) {
+        Q_EMIT editingCancelled();
+    }
+
     if(!m_cancelled) {
         // Allow our base widget to emit editingFinished.
         QLineEdit::focusOutEvent(event);


### PR DESCRIPTION
This is to fix edits to tab or playlist names still being accepted after pressing Escape because we erroneously emitted `editingFinished()` after `editingCancelled()`. Also, make `EditableTabBar::showEditor()` not accept empty text in inline editing to match the behavior of dialog edit mode.