### PR TITLE
[core] Fix automatic rating scale detection for custom tags

### DIFF
--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -897,8 +897,9 @@ void readGeneralProperties(const TagLib::PropertyMap& props, Track& track, bool 
         else {
             const auto tagEntry = convertString(field);
             if(!policy.rating.automaticRead() && tagEntry == policy.rating.readTag && !value.isEmpty()) {
+                const bool ratingTagFallback = policy.rating.readScale == RatingScale::Automatic;
                 readTextRatingTag(track, policy.rating, policy.rating.readTag, tagEntry, convertString(value.front()),
-                                  false);
+                                  ratingTagFallback);
             }
             else {
                 for(const auto& tagValue : value) {


### PR DESCRIPTION
When reading custom rating tags with automatic scale mode enabled, the ratingTagFallback parameter was hardcoded to false, preventing automatic detection of rating scales (1-5, 1-10, etc.). This caused custom tag values to be incorrectly rejected as invalid.

The fix dynamically sets ratingTagFallback based on the configured rating scale, enabling automatic detection when RatingScale::Automatic is selected.