### PR TITLE
[core] Input: Improve artist slash check

### DIFF
--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -309,9 +309,9 @@ void parseTag(Fooyin::Track& track, TagType tagType, const AVDictionaryEntry* ta
     const auto splitArtists = [tagType](const QString& artist) {
         const bool isId3Slash    = tagType == ID3v1_1 || tagType == ID3v1_2 || tagType == ID3v2_2 || tagType == ID3v2_3;
         const bool containsSlash = artist.contains("/"_L1);
-        const bool isCommonSlashArtist = artist == "AC/DC"_L1 || artist == "AC / DC"_L1;
+        const bool hasCommonSlashArtist = artist.contains("AC/DC"_L1) || artist.contains("AC / DC"_L1);
 
-        return splitMetadata(artist, isId3Slash && containsSlash && !isCommonSlashArtist ? u'/' : u';');
+        return splitMetadata(artist, isId3Slash && containsSlash && !hasCommonSlashArtist ? u'/' : u';');
     };
 
     if(strcasecmp(tag->key, "album") == 0) {

--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -1139,7 +1139,7 @@ void readId3Tags(const TagLib::ID3v2::Tag* id3Tags, Track& track, const TagPolic
             if(!artistsFrame.isEmpty()) {
                 const QString artist = convertString(artistsFrame.front()->toString());
                 // Ignore common artist names
-                if(artist.contains("/"_L1) && artist != "AC/DC"_L1 && artist != "AC / DC"_L1) {
+                if(artist.contains("/"_L1) && !artist.contains("AC/DC"_L1) && !artist.contains("AC / DC"_L1)) {
                     QStringList artists = artist.split(u'/', Qt::SkipEmptyParts);
                     std::ranges::transform(artists, artists.begin(), [](QString& entry) { return entry.trimmed(); });
                     track.setArtists(artists);


### PR DESCRIPTION
Do `contains()` instead of an equality check so it works for multiple artists.