### PR TITLE
[core] Fix "Stop after this" when playback is stopped

### DIFF
--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -1701,7 +1701,7 @@ void PlaylistModel::playingTrackChanged(const PlaylistTrack& track)
         refreshTracksForDependencies(indexesToRefresh, All);
     }
 
-    if(m_stopAtIndex.isValid()
+    if(m_stopAtIndex.isValid() && m_playingIndex.isValid()
        && m_playingIndex == m_stopAtIndex.sibling(m_stopAtIndex.row(), m_playingIndex.column())) {
         m_settings->set<Settings::Core::StopAfterCurrent>(true);
         m_stopAtIndex = QPersistentModelIndex{};


### PR DESCRIPTION
Another quick fix: when playback is stopped and "Stop after this" is used, starting any track will set "Stop after current" instead. Reason is `m_playingIndex` being invalid in `playingTrackChanged()`. Verify it in the condition.