### PR TITLE
[core] Fix $ascii function accepting Latin1 Supplement characters

### DIFF
--- a/src/core/scripting/functions/stringfuncs.cpp
+++ b/src/core/scripting/functions/stringfuncs.cpp
@@ -151,12 +151,6 @@ QString ascii(const QStringList& vec)
         if(ch.unicode() < 128) {
             result.append(ch);
         }
-        else if(ch.category() != QChar::Mark_NonSpacing) {
-            const char asciiChar = ch.toLatin1();
-            if(asciiChar != 0 && static_cast<unsigned char>(asciiChar) < 128) {
-                result.append(QChar::fromLatin1(asciiChar));
-            }
-        }
     }
 
     return result;

--- a/src/core/scripting/functions/stringfuncs.cpp
+++ b/src/core/scripting/functions/stringfuncs.cpp
@@ -153,7 +153,7 @@ QString ascii(const QStringList& vec)
         }
         else if(ch.category() != QChar::Mark_NonSpacing) {
             const char asciiChar = ch.toLatin1();
-            if(asciiChar != 0) {
+            if(asciiChar != 0 && static_cast<unsigned char>(asciiChar) < 128) {
                 result.append(QChar::fromLatin1(asciiChar));
             }
         }

--- a/tests/core/scriptparsertest.cpp
+++ b/tests/core/scriptparsertest.cpp
@@ -431,6 +431,13 @@ TEST_F(ScriptParserTest, StringTest)
     EXPECT_EQ(u"false", m_parser.evaluate(u"$if($isalnum(abc_123),true,false)"_s));
     EXPECT_EQ(u"true", m_parser.evaluate(u"$if($isnum(12345),true,false)"_s));
     EXPECT_EQ(u"false", m_parser.evaluate(u"$if($isnum(12a45),true,false)"_s));
+    EXPECT_EQ(u"o", m_parser.evaluate(u"$ascii(ô)"_s));
+    EXPECT_EQ(u"", m_parser.evaluate(u"$ascii(µ)"_s));
+    EXPECT_EQ(u"", m_parser.evaluate(u"$ascii(μ)"_s));
+    EXPECT_EQ(u"", m_parser.evaluate(u"$ascii(¥)"_s));
+    EXPECT_EQ(u"", m_parser.evaluate(u"$ascii(©)"_s));
+    EXPECT_EQ(u"Hello", m_parser.evaluate(u"$ascii(Hello)"_s));
+    EXPECT_EQ(u"", m_parser.evaluate(u"$ascii()"_s));
 }
 
 TEST_F(ScriptParserTest, MathTest)


### PR DESCRIPTION
The $ascii function was incorrectly accepting characters from the Latin1 Supplement range (U+0080 to U+00FF) such as µ (micro sign), ¥ (yen sign), and © (copyright sign). These characters are not ASCII and should be excluded.

Fixes #1185