### PR TITLE
[core] Scripting: Show correct file size for selections and playlist

### DIFF
--- a/src/core/scripting/functions/tracklistfuncs.cpp
+++ b/src/core/scripting/functions/tracklistfuncs.cpp
@@ -41,7 +41,7 @@ QString playtime(const TrackList& tracks)
     return Utils::msToString(total);
 }
 
-QString playlistSize(const TrackList& tracks)
+uint64_t trackListSize(const TrackList& tracks)
 {
     uint64_t total{0};
     std::set<QString> seenSegmentPaths;
@@ -64,7 +64,7 @@ QString playlistSize(const TrackList& tracks)
         }
     }
 
-    return Utils::formatFileSize(total);
+    return total;
 }
 
 QString genres(const TrackList& tracks)

--- a/src/core/scripting/functions/tracklistfuncs.h
+++ b/src/core/scripting/functions/tracklistfuncs.h
@@ -26,6 +26,6 @@
 namespace Fooyin::Scripting {
 int trackCount(const TrackList& tracks);
 QString playtime(const TrackList& tracks);
-QString playlistSize(const TrackList& tracks);
+uint64_t trackListSize(const TrackList& tracks);
 QString genres(const TrackList& tracks);
 } // namespace Fooyin::Scripting

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -315,6 +315,8 @@ bool isTrackListVariableKind(const VariableKind kind)
 {
     switch(kind) {
         case VariableKind::Genres:
+        case VariableKind::FileSize:
+        case VariableKind::FileSizeNatural:
         case VariableKind::TrackCount:
         case VariableKind::Playtime:
         case VariableKind::PlaylistSize:
@@ -482,10 +484,13 @@ std::optional<ScriptRegistry::FuncRet> trackListValue(const VariableKind kind, c
         case VariableKind::Playtime:
         case VariableKind::PlaylistDuration:
             return cache.playtime;
+        case VariableKind::FileSize:
         case VariableKind::PlaylistSize:
-            return cache.playlistSize;
+            return cache.size;
+        case VariableKind::FileSizeNatural:
+            return Utils::formatFileSize(cache.size);
         case VariableKind::PlaylistElapsed:
-            return cache.playlistElapsed;
+            return cache.elapsed;
         case VariableKind::Genres:
             return cache.genres;
         default:
@@ -751,7 +756,7 @@ bool ScriptRegistry::playbackValueAvailableForTrack(const Track& track) const
     return indexMatches && trackMatches;
 }
 
-QString ScriptRegistry::playlistDuration(const TrackList& tracks) const
+QString ScriptRegistry::trackListDuration(const TrackList& tracks) const
 {
     const auto* environment = playbackEnvironment(m_context);
     if(!environment || tracks.empty()) {
@@ -933,12 +938,14 @@ ScriptResult ScriptRegistry::valueForPlaylist(VariableKind kind, const QString& 
 
     if(isTrackListVariableKind(kind)) {
         switch(kind) {
+            case VariableKind::Genres:
+            case VariableKind::FileSize:
+            case VariableKind::FileSizeNatural:
             case VariableKind::TrackCount:
             case VariableKind::Playtime:
             case VariableKind::PlaylistSize:
             case VariableKind::PlaylistDuration:
             case VariableKind::PlaylistElapsed:
-            case VariableKind::Genres:
                 return value(kind, var, makeScriptSubject(playlist.tracks()));
             default:
                 break;
@@ -968,9 +975,9 @@ const ScriptRegistry::TrackListAggregateCache& ScriptRegistry::cachedTrackListVa
         m_trackListCache.currentPosition = currentPosition;
         m_trackListCache.playlistIndex   = playlistIndex;
         m_trackListCache.playtime        = Scripting::playtime(tracks);
-        m_trackListCache.playlistSize    = Scripting::playlistSize(tracks);
+        m_trackListCache.size            = Scripting::trackListSize(tracks);
         m_trackListCache.genres          = Scripting::genres(tracks);
-        m_trackListCache.playlistElapsed = playlistDuration(tracks);
+        m_trackListCache.elapsed         = trackListDuration(tracks);
     }
 
     return m_trackListCache;

--- a/src/core/scripting/scriptregistry.h
+++ b/src/core/scripting/scriptregistry.h
@@ -100,9 +100,9 @@ public:
         int currentPosition{-1};
         int playlistIndex{-1};
         QString playtime;
-        QString playlistSize;
+        uint64_t size;
         QString genres;
-        QString playlistElapsed;
+        QString elapsed;
     };
 
     [[nodiscard]] ScriptContext currentContext() const;
@@ -137,7 +137,7 @@ public:
     [[nodiscard]] QString libraryPathVariable(const Track& track) const;
     [[nodiscard]] QString relativePathVariable(const Track& track) const;
     [[nodiscard]] QString getBitrate(const Track& track) const;
-    [[nodiscard]] QString playlistDuration(const TrackList& tracks) const;
+    [[nodiscard]] QString trackListDuration(const TrackList& tracks) const;
 
     void clearTrackListCache();
     [[nodiscard]] const TrackListAggregateCache& cachedTrackListValues(const TrackList& tracks) const;


### PR DESCRIPTION
Currently, `%filesize%` and `%filesize_natural%` show the wrong file size for selections of more than 1 track or the whole playlist. Fix by extending `trackListValue()` to handle these variables & rename a couple related variables/functions to better reflect that they operate on track lists.