### PR TITLE
[core,gui] Add "Now Playing" output functionality

### DIFF
--- a/include/core/scripting/expression.h
+++ b/include/core/scripting/expression.h
@@ -150,6 +150,7 @@ enum class VariableKind : uint8_t
     PlaybackTimeRemainingSeconds,
     IsPlaying,
     IsPaused,
+    IsStopped,
     LibraryName,
     LibraryPath,
     RelativePath,

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -225,6 +225,7 @@ constexpr auto OutputDevices                      = "Fooyin.Page.Playback.Output
 constexpr auto Decoding                           = "Fooyin.Page.Playback.Decoding";
 constexpr auto ReplayGain                         = "Fooyin.Page.Playback.ReplayGain";
 constexpr auto DspManager                         = "Fooyin.Page.Playback.DspManager";
+constexpr auto NowPlaying                         = "Fooyin.Page.Playback.NowPlaying";
 constexpr auto InterfaceGeneral                   = "Fooyin.Page.Interface.General";
 constexpr auto InterfaceDisplay                   = "Fooyin.Page.Interface.Display";
 constexpr auto InterfaceTrackDisplay              = "Fooyin.Page.Interface.TrackDisplay";

--- a/src/core/scripting/scriptbinder.cpp
+++ b/src/core/scripting/scriptbinder.cpp
@@ -275,6 +275,9 @@ VariableKind resolveBuiltInVariableKind(const QString& var)
     if(var == "ISPAUSED"_L1) {
         return VariableKind::IsPaused;
     }
+    if(var == "ISSTOPPED"_L1) {
+        return VariableKind::IsStopped;
+    }
     if(var == "LIBRARYNAME"_L1) {
         return VariableKind::LibraryName;
     }

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -34,6 +34,7 @@
 #include <utils/stringutils.h>
 #include <utils/utils.h>
 
+#include <QDateTime>
 #include <QDir>
 #include <QRegularExpression>
 
@@ -203,6 +204,12 @@ int bitDepthMetadata(const Fooyin::Track& track)
     return track.bitDepth() > 0 ? track.bitDepth() : -1;
 }
 
+Fooyin::ScriptResult dateTimeVariable()
+{
+    const QString value = QDateTime::currentDateTime().toString(u"yyyy-MM-dd hh:mm:ss"_s);
+    return {.value = value, .cond = !value.isEmpty()};
+}
+
 Fooyin::ScriptContext makeContext(const Fooyin::ScriptContext& base, const Fooyin::Track* track,
                                   const Fooyin::TrackList* tracks, const Fooyin::Playlist* playlist)
 {
@@ -307,7 +314,6 @@ const Fooyin::ScriptLibraryEnvironment* libraryEnvironment(const Fooyin::ScriptC
 {
     return context.environment ? context.environment->libraryEnvironment() : nullptr;
 }
-
 } // namespace
 
 namespace Fooyin {
@@ -516,6 +522,9 @@ std::optional<QString> playbackVariableValue(const VariableKind kind, const Scri
         case VariableKind::IsPaused:
             return registry.playbackValueAvailableForTrack(track) ? std::optional{registry.isPaused()}
                                                                   : std::optional<QString>{};
+        case VariableKind::IsStopped:
+            return registry.playbackValueAvailableForTrack(track) ? std::optional{registry.isStopped()}
+                                                                  : std::optional<QString>{};
         default:
             return {};
     }
@@ -608,6 +617,18 @@ QString ScriptRegistry::isPaused() const
     }
     if(const auto* environment = playbackEnvironment(m_context);
        environment != nullptr && environment->playState() == Player::PlayState::Paused) {
+        return u"1"_s;
+    }
+    return {};
+}
+
+QString ScriptRegistry::isStopped() const
+{
+    if(!playbackValueAvailableForTrack()) {
+        return {};
+    }
+    if(const auto* environment = playbackEnvironment(m_context);
+       environment != nullptr && environment->playState() == Player::PlayState::Stopped) {
         return u"1"_s;
     }
     return {};
@@ -979,11 +1000,14 @@ const ScriptRegistry::TrackListAggregateCache& ScriptRegistry::cachedTrackListVa
 ScriptRegistry::ScriptRegistry()
 {
     addDefaultFunctions();
+
     registerFunction(u"info"_s, makeScriptFunctionInvoker<trackInfo>());
     registerFunction(u"meta"_s, makeScriptFunctionInvoker<trackMeta>());
     registerFunction(u"meta_sep"_s, makeScriptFunctionInvoker<trackMetaSep>());
     registerFunction(u"meta_test"_s, makeScriptFunctionInvoker<trackMetaTest>());
     registerFunction(u"meta_num"_s, makeScriptFunctionInvoker<trackMetaNum>());
+
+    registerVariable(VariableKind::Generic, u"datetime"_s, makeScriptVariableInvoker<dateTimeVariable>());
 }
 
 ScriptRegistry::~ScriptRegistry() = default;

--- a/src/core/scripting/scriptregistry.h
+++ b/src/core/scripting/scriptregistry.h
@@ -133,6 +133,7 @@ public:
     [[nodiscard]] QString playbackTimeRemainingSeconds() const;
     [[nodiscard]] QString isPlaying() const;
     [[nodiscard]] QString isPaused() const;
+    [[nodiscard]] QString isStopped() const;
     [[nodiscard]] QString libraryNameVariable(const Track& track) const;
     [[nodiscard]] QString libraryPathVariable(const Track& track) const;
     [[nodiscard]] QString relativePathVariable(const Track& track) const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -205,6 +205,10 @@ set(SOURCES
     menubar/playbackmenu.h
     menubar/viewmenu.cpp
     menubar/viewmenu.h
+    nowplayingoutput/nowplayingoutputservice.cpp
+    nowplayingoutput/nowplayingoutputservice.h
+    nowplayingoutput/nowplayingoutputpage.cpp
+    nowplayingoutput/nowplayingoutputpage.h
     playlist/manager/playlistmanagermodel.cpp
     playlist/manager/playlistmanagermodel.h
     playlist/manager/playlistmanagerwidget.cpp

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -19,6 +19,7 @@
 
 #include "internalguisettings.h"
 
+#include "nowplayingoutput/nowplayingoutputservice.h"
 #include "search/searchwidget.h"
 #include "widgets/statuswidget.h"
 
@@ -204,5 +205,18 @@ GuiSettings::GuiSettings(SettingsManager* settingsManager)
                                                                         u"Interface/ContextMenuLayoutEditingLayout"_s);
     m_settings->createSetting<Internal::PropertiesSidebarTrackScript>(u"[%track%. ]%title%"_s,
                                                                       u"Interface/PropertiesSidebarTrackScript "_s);
+    m_settings->createSetting<Internal::NowPlayingOutputEnabled>(false, u"NowPlayingOutput/Enabled"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputScript>(uR"($if($or(%isplaying%,%ispaused%),
+%datetime% $if(%ispaused%,⏸,►) %artist% [\(%album%\)] - %title% [%playback_time%]
+ [$progress(%playback_time_s%,%duration_s%,30,█,─)] [%duration%],))"_s,
+                                                                u"NowPlayingOutput/Script"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputUpdateEvents>(
+        static_cast<int>(NowPlayingOutputService::DefaultEvents), u"NowPlayingOutput/UpdateEvents"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputTargets>(static_cast<int>(NowPlayingOutputService::NoOutput),
+                                                                 u"NowPlayingOutput/Targets"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputFilePath>(u""_s, u"NowPlayingOutput/OutputFilePath"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputOptions>(
+        static_cast<int>(NowPlayingOutputService::OutputDefaultOptions), u"NowPlayingOutput/Options"_s);
+    m_settings->createSetting<Internal::NowPlayingOutputAppendLineLimit>(0, u"NowPlayingOutput/AppendLineLimit"_s);
 }
 } // namespace Fooyin

--- a/src/gui/internalguisettings.h
+++ b/src/gui/internalguisettings.h
@@ -213,6 +213,13 @@ enum GuiInternalSettings : uint32_t
     PlaylistBackgroundOpacity                = 61 | Type::Int,
     PlaylistBackgroundFadeDuration           = 62 | Type::Int,
     PlaylistBackgroundCoverType              = 63 | Type::Int,
+    NowPlayingOutputEnabled                  = 64 | Type::Bool,
+    NowPlayingOutputScript                   = 65 | Type::String,
+    NowPlayingOutputUpdateEvents             = 66 | Type::Int,
+    NowPlayingOutputTargets                  = 67 | Type::Int,
+    NowPlayingOutputFilePath                 = 68 | Type::String,
+    NowPlayingOutputOptions                  = 69 | Type::Int,
+    NowPlayingOutputAppendLineLimit          = 70 | Type::Int,
 };
 Q_ENUM_NS(GuiInternalSettings)
 } // namespace Settings::Gui::Internal

--- a/src/gui/nowplayingoutput/nowplayingoutputpage.cpp
+++ b/src/gui/nowplayingoutput/nowplayingoutputpage.cpp
@@ -1,0 +1,355 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "nowplayingoutputpage.h"
+
+#include "internalguisettings.h"
+#include "nowplayingoutput/nowplayingoutputservice.h"
+
+#include <core/player/playercontroller.h>
+#include <core/scripting/scriptenvironmenthelpers.h>
+#include <core/scripting/scriptparser.h>
+#include <gui/guiconstants.h>
+#include <gui/iconloader.h>
+#include <gui/widgets/scriptlineedit.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QCheckBox>
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QSizePolicy>
+#include <QSpacerItem>
+#include <QSpinBox>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+class NowPlayingOutputPageWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    NowPlayingOutputPageWidget(PlayerController* playerController, SettingsManager* settings);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    void updateWidgetState();
+    void updatePreview();
+    void browseOutputFile();
+
+    [[nodiscard]] NowPlayingOutputService::UpdateEvents updateEvents() const;
+    void setUpdateEvents(NowPlayingOutputService::UpdateEvents events);
+    [[nodiscard]] NowPlayingOutputService::OutputTargets outputTargets() const;
+    void setOutputTargets(NowPlayingOutputService::OutputTargets targets);
+    [[nodiscard]] NowPlayingOutputService::OutputOptions outputOptions() const;
+    void setOutputOptions(NowPlayingOutputService::OutputOptions options);
+
+    SettingsManager* m_settings;
+    PlayerController* m_playerController;
+    ScriptParser m_scriptParser;
+
+    QCheckBox* m_enabled;
+    ScriptTextEdit* m_script;
+    QPlainTextEdit* m_preview;
+    QCheckBox* m_updateOnTrackChange;
+    QCheckBox* m_updateOnPlayPause;
+    QCheckBox* m_updateOnStop;
+    QCheckBox* m_updateEverySecond;
+    QCheckBox* m_copyToClipboard;
+    QCheckBox* m_writeToFile;
+    QLabel* m_outputFilePathLabel;
+    QLineEdit* m_outputFilePath;
+    QCheckBox* m_appendToFile;
+    QLabel* m_appendLineLimitLabel;
+    QSpinBox* m_appendLineLimit;
+};
+
+NowPlayingOutputPageWidget::NowPlayingOutputPageWidget(PlayerController* playerController, SettingsManager* settings)
+    : m_settings{settings}
+    , m_playerController{playerController}
+    , m_enabled{new QCheckBox(tr("Enabled"), this)}
+    , m_script{new ScriptTextEdit(this)}
+    , m_preview{new QPlainTextEdit(this)}
+    , m_updateOnTrackChange{new QCheckBox(tr("Track changes"), this)}
+    , m_updateOnPlayPause{new QCheckBox(tr("Play and pause"), this)}
+    , m_updateOnStop{new QCheckBox(tr("Stop"), this)}
+    , m_updateEverySecond{new QCheckBox(tr("Every second"), this)}
+    , m_copyToClipboard{new QCheckBox(tr("Clipboard"), this)}
+    , m_writeToFile{new QCheckBox(tr("File"), this)}
+    , m_outputFilePathLabel{new QLabel(tr("Path") + ":"_L1, this)}
+    , m_outputFilePath{new QLineEdit(this)}
+    , m_appendToFile{new QCheckBox(tr("Append instead of overwrite"), this)}
+    , m_appendLineLimitLabel{new QLabel(tr("Maximum lines") + ":"_L1, this)}
+    , m_appendLineLimit{new QSpinBox(this)}
+{
+    auto* generalGroup  = new QGroupBox(tr("General"), this);
+    auto* generalLayout = new QGridLayout(generalGroup);
+
+    int row{0};
+    generalLayout->addWidget(m_enabled, row++, 0);
+
+    auto* scriptGroup  = new QGroupBox(tr("Format"), this);
+    auto* scriptLayout = new QGridLayout(scriptGroup);
+
+    m_script->setMinimumHeight(120);
+    m_preview->setReadOnly(true);
+    m_preview->setMaximumHeight(56);
+    m_preview->setWordWrapMode(QTextOption::NoWrap);
+    m_preview->setPlaceholderText(tr("No current track"));
+
+    row = 0;
+    scriptLayout->addWidget(m_script, row++, 0);
+    scriptLayout->addWidget(m_preview, row++, 0);
+    scriptLayout->setColumnStretch(0, 1);
+
+    auto* eventsGroup  = new QGroupBox(tr("Update events"), this);
+    auto* eventsLayout = new QGridLayout(eventsGroup);
+
+    row = 0;
+    eventsLayout->addWidget(m_updateOnTrackChange, row, 0);
+    eventsLayout->addWidget(m_updateOnPlayPause, row++, 1);
+    eventsLayout->addWidget(m_updateOnStop, row, 0);
+    eventsLayout->addWidget(m_updateEverySecond, row++, 1);
+
+    auto* outputGroup  = new QGroupBox(tr("Output"), this);
+    auto* outputLayout = new QGridLayout(outputGroup);
+
+    m_appendLineLimit->setRange(0, 1000000);
+    m_appendLineLimit->setSpecialValueText(tr("Unlimited"));
+
+    auto* browseAction = new QAction({}, this);
+    Gui::setThemeIcon(browseAction, Constants::Icons::Options);
+    browseAction->setToolTip(tr("Browse to an output file"));
+    QObject::connect(browseAction, &QAction::triggered, this, &NowPlayingOutputPageWidget::browseOutputFile);
+    m_outputFilePath->addAction(browseAction, QLineEdit::TrailingPosition);
+
+    auto* filePathLayout = new QHBoxLayout();
+    filePathLayout->addWidget(m_outputFilePathLabel);
+    filePathLayout->addWidget(m_outputFilePath, 1);
+
+    auto* appendLineLimitLayout = new QHBoxLayout();
+    appendLineLimitLayout->addWidget(m_appendLineLimitLabel);
+    appendLineLimitLayout->addWidget(m_appendLineLimit);
+    appendLineLimitLayout->addStretch(1);
+
+    row = 0;
+    outputLayout->addWidget(m_copyToClipboard, row++, 0, 1, 3);
+    outputLayout->addWidget(m_writeToFile, row++, 0, 1, 3);
+    outputLayout->addItem(new QSpacerItem(10, 0), row, 0);
+    outputLayout->addLayout(filePathLayout, row++, 1, 1, 3);
+    outputLayout->addItem(new QSpacerItem(10, 0), row, 0);
+    outputLayout->addWidget(m_appendToFile, row++, 1, 1, 2);
+    outputLayout->addItem(new QSpacerItem(10, 0), row, 0);
+    outputLayout->addLayout(appendLineLimitLayout, row++, 1, 1, 3);
+    outputLayout->setColumnStretch(3, 1);
+
+    auto* layout = new QGridLayout(this);
+
+    row = 0;
+    layout->addWidget(generalGroup, row++, 0);
+    layout->addWidget(scriptGroup, row++, 0);
+    layout->addWidget(eventsGroup, row++, 0);
+    layout->addWidget(outputGroup, row++, 0);
+    layout->setRowStretch(row, 1);
+
+    QObject::connect(m_enabled, &QCheckBox::toggled, this, &NowPlayingOutputPageWidget::updateWidgetState);
+    QObject::connect(m_writeToFile, &QCheckBox::toggled, this, &NowPlayingOutputPageWidget::updateWidgetState);
+    QObject::connect(m_appendToFile, &QCheckBox::toggled, this, &NowPlayingOutputPageWidget::updateWidgetState);
+    QObject::connect(m_script, &QPlainTextEdit::textChanged, this, &NowPlayingOutputPageWidget::updatePreview);
+
+    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this,
+                     &NowPlayingOutputPageWidget::updatePreview);
+    QObject::connect(m_playerController, &PlayerController::currentTrackUpdated, this,
+                     &NowPlayingOutputPageWidget::updatePreview);
+    QObject::connect(m_playerController, &PlayerController::playStateChanged, this,
+                     &NowPlayingOutputPageWidget::updatePreview);
+    QObject::connect(m_playerController, &PlayerController::positionChangedSeconds, this,
+                     &NowPlayingOutputPageWidget::updatePreview);
+}
+
+void NowPlayingOutputPageWidget::load()
+{
+    using namespace Settings::Gui::Internal;
+
+    m_enabled->setChecked(m_settings->value<NowPlayingOutputEnabled>());
+    m_script->setPlainText(m_settings->value<NowPlayingOutputScript>());
+    setUpdateEvents(NowPlayingOutputService::UpdateEvents::fromInt(m_settings->value<NowPlayingOutputUpdateEvents>()));
+    setOutputTargets(NowPlayingOutputService::OutputTargets::fromInt(m_settings->value<NowPlayingOutputTargets>()));
+    m_outputFilePath->setText(m_settings->value<NowPlayingOutputFilePath>());
+    setOutputOptions(NowPlayingOutputService::OutputOptions::fromInt(m_settings->value<NowPlayingOutputOptions>()));
+    m_appendLineLimit->setValue(m_settings->value<NowPlayingOutputAppendLineLimit>());
+
+    updateWidgetState();
+    updatePreview();
+}
+
+void NowPlayingOutputPageWidget::apply()
+{
+    using namespace Settings::Gui::Internal;
+
+    m_settings->set<NowPlayingOutputEnabled>(m_enabled->isChecked());
+    m_settings->set<NowPlayingOutputScript>(m_script->toPlainText());
+    m_settings->set<NowPlayingOutputUpdateEvents>(static_cast<int>(updateEvents().toInt()));
+    m_settings->set<NowPlayingOutputTargets>(static_cast<int>(outputTargets().toInt()));
+    m_settings->set<NowPlayingOutputFilePath>(m_outputFilePath->text());
+    m_settings->set<NowPlayingOutputOptions>(static_cast<int>(outputOptions().toInt()));
+    m_settings->set<NowPlayingOutputAppendLineLimit>(m_appendLineLimit->value());
+}
+
+void NowPlayingOutputPageWidget::reset()
+{
+    using namespace Settings::Gui::Internal;
+
+    m_settings->reset<NowPlayingOutputEnabled>();
+    m_settings->reset<NowPlayingOutputScript>();
+    m_settings->reset<NowPlayingOutputUpdateEvents>();
+    m_settings->reset<NowPlayingOutputTargets>();
+    m_settings->reset<NowPlayingOutputFilePath>();
+    m_settings->reset<NowPlayingOutputOptions>();
+    m_settings->reset<NowPlayingOutputAppendLineLimit>();
+}
+
+void NowPlayingOutputPageWidget::updateWidgetState()
+{
+    const bool enabled      = m_enabled->isChecked();
+    const bool writeToFile  = enabled && m_writeToFile->isChecked();
+    const bool trimFileMode = writeToFile && m_appendToFile->isChecked();
+
+    m_script->setEnabled(enabled);
+    m_preview->setEnabled(enabled);
+    m_updateOnTrackChange->setEnabled(enabled);
+    m_updateOnPlayPause->setEnabled(enabled);
+    m_updateOnStop->setEnabled(enabled);
+    m_updateEverySecond->setEnabled(enabled);
+    m_copyToClipboard->setEnabled(enabled);
+    m_writeToFile->setEnabled(enabled);
+    m_outputFilePathLabel->setEnabled(writeToFile);
+    m_outputFilePath->setEnabled(writeToFile);
+    m_appendToFile->setEnabled(writeToFile);
+    m_appendLineLimitLabel->setEnabled(trimFileMode);
+    m_appendLineLimit->setEnabled(trimFileMode);
+}
+
+void NowPlayingOutputPageWidget::updatePreview()
+{
+    const Track track = m_playerController ? m_playerController->currentTrack() : Track{};
+    if(!track.isValid()) {
+        m_preview->clear();
+        return;
+    }
+
+    auto playbackContext = makePlaybackScriptContext(m_playerController, nullptr, TrackListContextPolicy::Placeholder);
+    playbackContext.context.track = &track;
+    m_preview->setPlainText(m_scriptParser.evaluate(m_script->toPlainText(), track, playbackContext.context));
+}
+
+NowPlayingOutputService::UpdateEvents NowPlayingOutputPageWidget::updateEvents() const
+{
+    NowPlayingOutputService::UpdateEvents events;
+    if(m_updateOnTrackChange->isChecked()) {
+        events.setFlag(NowPlayingOutputService::UpdateTrack);
+    }
+    if(m_updateOnPlayPause->isChecked()) {
+        events.setFlag(NowPlayingOutputService::UpdatePlayPause);
+    }
+    if(m_updateOnStop->isChecked()) {
+        events.setFlag(NowPlayingOutputService::UpdateStop);
+    }
+    if(m_updateEverySecond->isChecked()) {
+        events.setFlag(NowPlayingOutputService::UpdateSecond);
+    }
+    return events;
+}
+
+void NowPlayingOutputPageWidget::setUpdateEvents(NowPlayingOutputService::UpdateEvents events)
+{
+    m_updateOnTrackChange->setChecked(events.testFlag(NowPlayingOutputService::UpdateTrack));
+    m_updateOnPlayPause->setChecked(events.testFlag(NowPlayingOutputService::UpdatePlayPause));
+    m_updateOnStop->setChecked(events.testFlag(NowPlayingOutputService::UpdateStop));
+    m_updateEverySecond->setChecked(events.testFlag(NowPlayingOutputService::UpdateSecond));
+}
+
+NowPlayingOutputService::OutputTargets NowPlayingOutputPageWidget::outputTargets() const
+{
+    NowPlayingOutputService::OutputTargets targets;
+    if(m_copyToClipboard->isChecked()) {
+        targets.setFlag(NowPlayingOutputService::OutputClipboard);
+    }
+    if(m_writeToFile->isChecked()) {
+        targets.setFlag(NowPlayingOutputService::OutputFile);
+    }
+    return targets;
+}
+
+void NowPlayingOutputPageWidget::setOutputTargets(NowPlayingOutputService::OutputTargets targets)
+{
+    m_copyToClipboard->setChecked(targets.testFlag(NowPlayingOutputService::OutputClipboard));
+    m_writeToFile->setChecked(targets.testFlag(NowPlayingOutputService::OutputFile));
+}
+
+NowPlayingOutputService::OutputOptions NowPlayingOutputPageWidget::outputOptions() const
+{
+    NowPlayingOutputService::OutputOptions options;
+    if(m_appendToFile->isChecked()) {
+        options.setFlag(NowPlayingOutputService::OutputAppendFile);
+    }
+    return options;
+}
+
+void NowPlayingOutputPageWidget::setOutputOptions(NowPlayingOutputService::OutputOptions options)
+{
+    m_appendToFile->setChecked(options.testFlag(NowPlayingOutputService::OutputAppendFile));
+}
+
+void NowPlayingOutputPageWidget::browseOutputFile()
+{
+    QFileDialog dialog{this, tr("Now Playing"), m_outputFilePath->text(), tr("Text Files (*.txt);;All Files (*)")};
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFileMode(QFileDialog::AnyFile);
+    dialog.setOption(QFileDialog::DontResolveSymlinks);
+
+    if(dialog.exec() == QDialog::Accepted) {
+        if(const auto files = dialog.selectedFiles(); !files.empty()) {
+            m_outputFilePath->setText(files.front());
+        }
+    }
+}
+
+NowPlayingOutputPage::NowPlayingOutputPage(PlayerController* playerController, SettingsManager* settings,
+                                           QObject* parent)
+    : SettingsPage{settings->settingsDialog(), parent}
+{
+    setId(Constants::Page::NowPlaying);
+    setName(tr("Now Playing"));
+    setCategory({tr("Playback"), tr("Now Playing")});
+    setWidgetCreator(
+        [playerController, settings] { return new NowPlayingOutputPageWidget(playerController, settings); });
+}
+} // namespace Fooyin
+
+#include "moc_nowplayingoutputpage.cpp"
+#include "nowplayingoutputpage.moc"

--- a/src/gui/nowplayingoutput/nowplayingoutputpage.h
+++ b/src/gui/nowplayingoutput/nowplayingoutputpage.h
@@ -1,0 +1,35 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/settings/settingspage.h>
+
+namespace Fooyin {
+class PlayerController;
+class SettingsManager;
+
+class NowPlayingOutputPage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    NowPlayingOutputPage(PlayerController* playerController, SettingsManager* settings, QObject* parent = nullptr);
+};
+} // namespace Fooyin

--- a/src/gui/nowplayingoutput/nowplayingoutputservice.cpp
+++ b/src/gui/nowplayingoutput/nowplayingoutputservice.cpp
@@ -1,0 +1,239 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "nowplayingoutputservice.h"
+
+#include "internalguisettings.h"
+
+#include <core/player/playercontroller.h>
+#include <core/scripting/scriptenvironmenthelpers.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QSaveFile>
+#include <QTextStream>
+
+Q_LOGGING_CATEGORY(NOWPLAYINGOUTPUT, "fy.nowplayingoutput")
+
+using namespace Qt::StringLiterals;
+
+namespace {
+void trimOutputFile(const QString& path, int lineLimit)
+{
+    if(lineLimit <= 0) {
+        return;
+    }
+
+    QFile file{path};
+    if(!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to read output file for trimming:" << path << file.errorString();
+        return;
+    }
+
+    QTextStream input{&file};
+    const QString text = input.readAll();
+    if(input.status() != QTextStream::Ok) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to read output file for trimming:" << path;
+        return;
+    }
+
+    QStringList lines = text.split(u'\n');
+    if(text.endsWith(u'\n') && !lines.empty()) {
+        lines.removeLast();
+    }
+    if(lines.size() <= lineLimit) {
+        return;
+    }
+
+    lines = lines.sliced(lines.size() - lineLimit);
+
+    QSaveFile trimmedFile{path};
+    if(!trimmedFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to trim output file:" << path << trimmedFile.errorString();
+        return;
+    }
+
+    QTextStream output{&trimmedFile};
+    output << lines.join(u'\n') << u'\n';
+    if(output.status() != QTextStream::Ok || !trimmedFile.commit()) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to trim output file:" << path << trimmedFile.errorString();
+    }
+}
+} // namespace
+
+namespace Fooyin {
+NowPlayingOutputService::NowPlayingOutputService(PlayerController* playerController, SettingsManager* settings,
+                                                 QObject* parent)
+    : QObject{parent}
+    , m_playerController{playerController}
+    , m_settings{settings}
+    , m_enabled{m_settings->value<Settings::Gui::Internal::NowPlayingOutputEnabled>()}
+    , m_events{m_settings->value<Settings::Gui::Internal::NowPlayingOutputUpdateEvents>()}
+    , m_targets{m_settings->value<Settings::Gui::Internal::NowPlayingOutputTargets>()}
+    , m_options{m_settings->value<Settings::Gui::Internal::NowPlayingOutputOptions>()}
+    , m_filepath{m_settings->value<Settings::Gui::Internal::NowPlayingOutputFilePath>()}
+    , m_script{m_settings->value<Settings::Gui::Internal::NowPlayingOutputScript>()}
+{
+    const auto updateIf = [this](UpdateEvent event) {
+        if(m_events.testFlag(event)) {
+            update();
+        }
+    };
+
+    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this,
+                     [updateIf]() { updateIf(UpdateTrack); });
+    QObject::connect(m_playerController, &PlayerController::currentTrackUpdated, this,
+                     [updateIf]() { updateIf(UpdateTrack); });
+    QObject::connect(m_playerController, &PlayerController::playStateChanged, this,
+                     [updateIf](Player::PlayState state) {
+                         if(state == Player::PlayState::Stopped) {
+                             updateIf(UpdateStop);
+                             return;
+                         }
+                         updateIf(UpdatePlayPause);
+                     });
+    QObject::connect(m_playerController, &PlayerController::positionChangedSeconds, this,
+                     [updateIf]() { updateIf(UpdateSecond); });
+
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputEnabled>(this, [this](bool enabled) {
+        if(std::exchange(m_enabled, enabled) != enabled) {
+            update();
+        }
+    });
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputUpdateEvents>(
+        this, [this](int events) { m_events = UpdateEvents::fromInt(events); });
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputTargets>(
+        this, [this](int events) { m_targets = OutputTargets::fromInt(events); });
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputOptions>(
+        this, [this](int events) { m_options = OutputOptions::fromInt(events); });
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputScript>(this, [this](const QString& script) {
+        if(std::exchange(m_script, script) != script) {
+            update();
+        }
+    });
+    m_settings->subscribe<Settings::Gui::Internal::NowPlayingOutputFilePath>(this, [this](const QString& path) {
+        if(std::exchange(m_filepath, path) != path) {
+            update();
+        }
+    });
+}
+
+NowPlayingOutputService::~NowPlayingOutputService() = default;
+
+void NowPlayingOutputService::update()
+{
+    if(!m_enabled) {
+        return;
+    }
+
+    writeOutput(formattedOutput());
+}
+
+QString NowPlayingOutputService::formattedOutput()
+{
+    const Track track = m_playerController ? m_playerController->currentTrack() : Track{};
+    if(!track.isValid()) {
+        return {};
+    }
+
+    auto playbackContext = makePlaybackScriptContext(m_playerController, nullptr, TrackListContextPolicy::Placeholder);
+    playbackContext.context.track = &track;
+    return m_scriptParser.evaluate(m_script, track, playbackContext.context);
+}
+
+void NowPlayingOutputService::writeOutput(const QString& output)
+{
+    const bool appendToFile = m_options.testFlag(OutputAppendFile);
+    if(!appendToFile && output == m_lastOutput) {
+        return;
+    }
+
+    if(m_targets.testFlag(OutputClipboard)) {
+        writeClipboard(output);
+    }
+    if(m_targets.testFlag(OutputFile)) {
+        writeFile(output);
+    }
+
+    m_lastOutput = output;
+}
+
+void NowPlayingOutputService::writeClipboard(const QString& output) const
+{
+    if(auto* clipboard = QApplication::clipboard()) {
+        clipboard->setText(output);
+    }
+}
+
+void NowPlayingOutputService::writeFile(const QString& output) const
+{
+    if(m_filepath.isEmpty()) {
+        return;
+    }
+
+    const QFileInfo fileInfo{m_filepath};
+    const QDir dir = fileInfo.dir();
+    if(!dir.exists() && !dir.mkpath(u"."_s)) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to create output directory:" << dir.absolutePath();
+        return;
+    }
+
+    if(m_options.testFlag(OutputAppendFile)) {
+        if(output.isEmpty()) {
+            return;
+        }
+
+        QFile file{m_filepath};
+        if(!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+            qCWarning(NOWPLAYINGOUTPUT) << "Failed to open output file for append:" << m_filepath << file.errorString();
+            return;
+        }
+
+        QTextStream stream{&file};
+        stream << output << u'\n';
+        if(stream.status() != QTextStream::Ok) {
+            qCWarning(NOWPLAYINGOUTPUT) << "Failed to append output file:" << m_filepath;
+            return;
+        }
+
+        file.close();
+        trimOutputFile(m_filepath, m_settings->value<Settings::Gui::Internal::NowPlayingOutputAppendLineLimit>());
+        return;
+    }
+
+    QSaveFile file{m_filepath};
+    if(!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to open output file:" << m_filepath << file.errorString();
+        return;
+    }
+
+    QTextStream stream{&file};
+    stream << output;
+    if(stream.status() != QTextStream::Ok || !file.commit()) {
+        qCWarning(NOWPLAYINGOUTPUT) << "Failed to write output file:" << m_filepath << file.errorString();
+    }
+}
+} // namespace Fooyin
+
+#include "moc_nowplayingoutputservice.cpp"

--- a/src/gui/nowplayingoutput/nowplayingoutputservice.h
+++ b/src/gui/nowplayingoutput/nowplayingoutputservice.h
@@ -1,0 +1,93 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/player/playerdefs.h>
+#include <core/scripting/scriptparser.h>
+
+#include <QObject>
+
+namespace Fooyin {
+class PlayerController;
+class SettingsManager;
+
+class NowPlayingOutputService : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum UpdateEvent : uint8_t
+    {
+        UpdateNone      = 0,
+        UpdateTrack     = 1 << 0,
+        UpdatePlayPause = 1 << 1,
+        UpdateStop      = 1 << 2,
+        UpdateSecond    = 1 << 3,
+        DefaultEvents   = UpdateTrack | UpdatePlayPause | UpdateStop
+    };
+    Q_DECLARE_FLAGS(UpdateEvents, UpdateEvent)
+    Q_FLAG(UpdateEvents)
+
+    enum OutputTarget : uint8_t
+    {
+        NoOutput        = 0,
+        OutputClipboard = 1 << 0,
+        OutputFile      = 1 << 1,
+    };
+    Q_DECLARE_FLAGS(OutputTargets, OutputTarget)
+    Q_FLAG(OutputTargets)
+
+    enum OutputOption : uint8_t
+    {
+        NoOptions            = 0,
+        OutputAppendFile     = 1 << 0,
+        OutputDefaultOptions = NoOptions
+    };
+    Q_DECLARE_FLAGS(OutputOptions, OutputOption)
+    Q_FLAG(OutputOptions)
+
+    NowPlayingOutputService(PlayerController* playerController, SettingsManager* settings, QObject* parent = nullptr);
+    ~NowPlayingOutputService() override;
+
+private:
+    void update();
+    [[nodiscard]] QString formattedOutput();
+    void writeOutput(const QString& output);
+    void writeClipboard(const QString& output) const;
+    void writeFile(const QString& output) const;
+
+    PlayerController* m_playerController;
+    SettingsManager* m_settings;
+
+    bool m_enabled;
+    UpdateEvents m_events;
+    OutputTargets m_targets;
+    OutputOptions m_options;
+
+    ScriptParser m_scriptParser;
+    QString m_filepath;
+    QString m_script;
+    QString m_lastOutput;
+};
+} // namespace Fooyin
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Fooyin::NowPlayingOutputService::UpdateEvents)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Fooyin::NowPlayingOutputService::OutputTargets)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Fooyin::NowPlayingOutputService::OutputOptions)

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -41,6 +41,8 @@
 #include "librarytree/librarytreecontroller.h"
 #include "librarytree/librarytreewidget.h"
 #include "mainwindow.h"
+#include "nowplayingoutput/nowplayingoutputpage.h"
+#include "nowplayingoutput/nowplayingoutputservice.h"
 #include "output/outputprofilemanager.h"
 #include "playlist/manager/playlistmanagerwidget.h"
 #include "playlist/organiser/playlistorganiser.h"
@@ -145,6 +147,7 @@ Widgets::Widgets(Application* core, MainWindow* window, GuiApplication* gui, Pla
     , m_dspPresetRegistry{new DspPresetRegistry(m_settings, this)}
     , m_outputProfileManager{new OutputProfileManager(m_core->engine(), m_core->dspChainStore(), m_dspPresetRegistry,
                                                       m_settings, this)}
+    , m_nowPlayingOutputService{new NowPlayingOutputService(m_core->playerController(), m_settings, this)}
     , m_dspSettingsRegistry{std::make_unique<DspSettingsRegistry>()}
     , m_dspSettingsController{std::make_unique<DspSettingsController>(m_core->dspChainStore(),
                                                                       m_dspSettingsRegistry.get(), this)}
@@ -388,6 +391,7 @@ void Widgets::registerPages()
     new LibraryRatingsPage(m_settings, this);
     new LibrarySortingPage(m_core->sortingRegistry(), m_settings, this);
     new PlaybackPage(m_settings, this);
+    new NowPlayingOutputPage(m_core->playerController(), m_settings, this);
     new DspManagerPage(m_core->dspChainStore(), m_dspPresetRegistry, m_dspSettingsRegistry.get(), m_settings, this);
     new FadingPage(m_settings, this);
     new PlaylistGeneralPage(m_settings, this);

--- a/src/gui/widgets.h
+++ b/src/gui/widgets.h
@@ -38,6 +38,7 @@ class FyWidget;
 class GuiApplication;
 class LibraryTreeController;
 class MainWindow;
+class NowPlayingOutputService;
 class OutputProfileManager;
 class PlaylistController;
 class PlaylistInteractor;
@@ -87,6 +88,7 @@ private:
     LibraryTreeController* m_libraryTreeController;
     DspPresetRegistry* m_dspPresetRegistry;
     OutputProfileManager* m_outputProfileManager;
+    NowPlayingOutputService* m_nowPlayingOutputService;
     std::unique_ptr<DspSettingsRegistry> m_dspSettingsRegistry;
     std::unique_ptr<DspSettingsController> m_dspSettingsController;
     std::unique_ptr<PluginSettingsRegistry> m_pluginSettingsRegistry;


### PR DESCRIPTION
Adds `Now Playing` functionality to output the current playing track as text to the clipboard or a file. 

<img width="1025" height="819" alt="image" src="https://github.com/user-attachments/assets/f869a8ed-a431-43ed-b4c9-8e14729e96e2" />

This also adds `%isstopped%` to complete the playback state variables, and `%datetime%`, which returns the current time "now" formatted like: `2026-05-17 14:35:03`.

Closes #1084