### PR TITLE
[core] Reject non-finite ReplayGain values

### DIFF
--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -217,14 +217,14 @@ float parseReplayGain(const QString& gainStr)
 
     bool ok{false};
     const float gain = string.toFloat(&ok);
-    return ok ? gain : Fooyin::Constants::InvalidGain;
+    return (ok && std::isfinite(gain)) ? gain : Fooyin::Constants::InvalidGain;
 }
 
 float parseReplayPeak(const QString& peakStr)
 {
     bool ok{false};
     const float peak = peakStr.toFloat(&ok);
-    return ok ? peak : Fooyin::Constants::InvalidPeak;
+    return (ok && std::isfinite(peak)) ? peak : Fooyin::Constants::InvalidPeak;
 }
 
 enum class TagScope : uint8_t

--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -564,7 +564,7 @@ float gainStringToFloat(const TagLib::String& gainString)
 
     bool ok{false};
     const float gain = string.toFloat(&ok);
-    return ok ? gain : Constants::InvalidGain;
+    return (ok && std::isfinite(gain)) ? gain : Constants::InvalidGain;
 };
 
 QString gainToString(const float gain)
@@ -578,7 +578,7 @@ float peakStringToFloat(const TagLib::String& peakString)
 
     bool ok{false};
     const float peak = string.toFloat(&ok);
-    return ok ? peak : Constants::InvalidPeak;
+    return (ok && std::isfinite(peak)) ? peak : Constants::InvalidPeak;
 };
 
 std::optional<float> opusR128ToReplayGain(const TagLib::String& gainString)

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -953,22 +953,22 @@ bool Track::hasRGInfo() const
 
 bool Track::hasTrackGain() const
 {
-    return p->rgTrackGain != Constants::InvalidGain;
+    return std::isfinite(p->rgTrackGain) && p->rgTrackGain != Constants::InvalidGain;
 }
 
 bool Track::hasAlbumGain() const
 {
-    return p->rgAlbumGain != Constants::InvalidGain;
+    return std::isfinite(p->rgAlbumGain) && p->rgAlbumGain != Constants::InvalidGain;
 }
 
 bool Track::hasTrackPeak() const
 {
-    return p->rgTrackPeak != Constants::InvalidPeak;
+    return std::isfinite(p->rgTrackPeak) && p->rgTrackPeak != Constants::InvalidPeak;
 }
 
 bool Track::hasAlbumPeak() const
 {
-    return p->rgAlbumPeak != Constants::InvalidPeak;
+    return std::isfinite(p->rgAlbumPeak) && p->rgAlbumPeak != Constants::InvalidPeak;
 }
 
 float Track::rgTrackGain() const


### PR DESCRIPTION
One more edge case fix -- hope these aren't getting too much.
I discovered an album (ripped from Tidal) in my library yesterday that had "NaN dB" set for `REPLAYGAIN_ALBUM_GAIN`. This made me realize that we currently accept non-finite RG values. There is a sanity check in the RG processor, but it doesn't catch `+inf` or `-inf` and it seems simpler to treat the values as invalid from the start. Fix: Add `isfinite()` checks to the metadata readers and `Track` RG predicates.

(There are some other `QString::toFloat()` calls in the codebase that might benefit from the same treatment.)