### PR TITLE
[CI] Enable PCH and ccache

### DIFF
--- a/.github/workflows/build-freebsd.yml
+++ b/.github/workflows/build-freebsd.yml
@@ -5,6 +5,11 @@ on:
 
 env:
   BUILD_TESTS: ON
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_MAXSIZE: 1G
+  CCACHE_COMPILERCHECK: content
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 
 jobs:
   freebsd:
@@ -18,6 +23,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: freebsd-${{ env.FREEBSD_VERSION }}-ccache-${{ github.sha }}
+          restore-keys: |
+            freebsd-${{ env.FREEBSD_VERSION }}-ccache-
 
       - name: run VM
         uses: cross-platform-actions/action@v0.32.0

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,6 +5,13 @@ on:
 
 env:
   BUILD_TESTS: ON
+  BUILD_CCACHE: ON
+  BUILD_PCH: ON
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_MAXSIZE: 1G
+  CCACHE_COMPILERCHECK: content
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 
 jobs:
   fedora:
@@ -33,6 +40,15 @@ jobs:
       - name: Dependencies
         run: |
           ./ci/fedora-depends.sh
+
+      - name: Cache ccache
+        if: env.BUILD_CCACHE == 'ON'
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: linux-fedora-${{ matrix.fedora_version }}-${{ matrix.runner.arch }}-ccache-${{ github.sha }}
+          restore-keys: |
+            linux-fedora-${{ matrix.fedora_version }}-${{ matrix.runner.arch }}-ccache-
 
       - name: Build
         run: |
@@ -86,6 +102,15 @@ jobs:
           ln -sf /usr/lib/libgtest.a /usr/local/lib/libgtest.a
           ln -sf /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 
+      - name: Cache ccache
+        if: env.BUILD_CCACHE == 'ON'
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: linux-debian-${{ matrix.debian_version }}-${{ matrix.runner.arch }}-ccache-${{ github.sha }}
+          restore-keys: |
+            linux-debian-${{ matrix.debian_version }}-${{ matrix.runner.arch }}-ccache-
+
       - name: Build
         run: |
           ./ci/ubuntu-build.sh
@@ -138,7 +163,19 @@ jobs:
           ln -sf /usr/lib/libgtest.a /usr/local/lib/libgtest.a
           ln -sf /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 
+      - name: Cache ccache
+        if: ${{ !(matrix.ubuntu_version == 'noble' && matrix.runner.arch == 'amd64') && env.BUILD_CCACHE == 'ON' }}
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: linux-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.runner.arch }}-ccache-${{ github.sha }}
+          restore-keys: |
+            linux-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.runner.arch }}-ccache-
+
       - name: Build
+        env:
+          BUILD_CCACHE: ${{ matrix.ubuntu_version == 'noble' && matrix.runner.arch == 'amd64' && 'OFF' || env.BUILD_CCACHE }}
+          BUILD_PCH: ${{ matrix.ubuntu_version == 'noble' && matrix.runner.arch == 'amd64' && 'OFF' || env.BUILD_PCH }}
         run: |
           ./ci/ubuntu-build.sh
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,6 +5,11 @@ on:
 
 env:
   BUILD_TESTS: ON
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  CCACHE_MAXSIZE: 1G
+  CCACHE_COMPILERCHECK: content
+  CCACHE_SLOPPINESS: pch_defines,time_macros
 
 jobs:
   macOS:
@@ -27,6 +32,14 @@ jobs:
       - name: Dependencies
         run: |
           ./ci/macos-depends.sh
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-ccache-
 
       - name: Build
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: amd64
-            runs-on: macos-15-intel
+#          - arch: amd64
+#            runs-on: macos-15-intel
           - arch: aarch64
             runs-on: macos-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,8 @@ on:
 env:
   QT_VERSION: '6.8.3'
   VCPKG_DISABLE_METRICS: true
+  BUILD_CCACHE: OFF
+  BUILD_PCH: ON
 
 jobs:
   windows:

--- a/ci/fedora-build.sh
+++ b/ci/fedora-build.sh
@@ -1,14 +1,21 @@
 #!/bin/sh
 
 export FOOYIN_DIR=$PWD
+BUILD_CCACHE="${BUILD_CCACHE:-ON}"
+BUILD_PCH="${BUILD_PCH:-ON}"
 
 cmake -S "$FOOYIN_DIR" \
   -G Ninja \
   -B build \
   -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_TESTING=ON
+  -DBUILD_TESTING=ON \
+  -DBUILD_CCACHE="$BUILD_CCACHE" \
+  -DBUILD_PCH="$BUILD_PCH"
 
 cmake --build build
+if [ "$BUILD_CCACHE" = "ON" ]; then
+  ccache --show-stats || true
+fi
 cd build
 cpack -G RPM
 mkdir ../rpm

--- a/ci/fedora-depends.sh
+++ b/ci/fedora-depends.sh
@@ -8,6 +8,8 @@ dnf -y install --skip-broken \
      rpmdevtools \
      tar \
      desktop-file-utils \
+     ccache \
+     zstd \
      cmake \
      ninja-build \
      glib2-devel \

--- a/ci/freebsd-build.sh
+++ b/ci/freebsd-build.sh
@@ -4,6 +4,16 @@ export FOOYIN_DIR=$PWD
 export CC=clang
 export CXX=clang++
 export CXXFLAGS="-fexperimental-library"
+BUILD_CCACHE="${BUILD_CCACHE:-ON}"
+BUILD_PCH="${BUILD_PCH:-ON}"
+
+if [ "$BUILD_CCACHE" = "ON" ]; then
+  export CCACHE_DIR="${CCACHE_DIR:-$FOOYIN_DIR/.ccache}"
+  export CCACHE_BASEDIR="${CCACHE_BASEDIR:-$FOOYIN_DIR}"
+  export CCACHE_COMPILERCHECK="${CCACHE_COMPILERCHECK:-content}"
+  export CCACHE_SLOPPINESS="${CCACHE_SLOPPINESS:-pch_defines,time_macros}"
+  mkdir -p "$CCACHE_DIR"
+fi
 
 cmake -S "$FOOYIN_DIR" \
   -G Ninja \
@@ -11,9 +21,14 @@ cmake -S "$FOOYIN_DIR" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
-  -DBUILD_TESTING=ON
+  -DBUILD_TESTING=ON \
+  -DBUILD_CCACHE="$BUILD_CCACHE" \
+  -DBUILD_PCH="$BUILD_PCH"
 
 cmake --build build
+if [ "$BUILD_CCACHE" = "ON" ]; then
+  ccache --show-stats || true
+fi
 cd build
 cpack -G FREEBSD
 mkdir ../pkg

--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -3,6 +3,7 @@
 sudo pkg update
 sudo pkg upgrade -y
 sudo pkg install -y \
+     ccache \
      cmake-core \
      pkgconf \
      ninja \

--- a/ci/macos-build.sh
+++ b/ci/macos-build.sh
@@ -9,6 +9,8 @@ export CXX=$(brew --prefix llvm)/bin/clang++
 export CXXFLAGS="-fexperimental-library"
 export CMAKE_PREFIX_PATH="$(brew --prefix qt);$(brew --prefix icu4c@78)"
 export PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+BUILD_CCACHE="${BUILD_CCACHE:-ON}"
+BUILD_PCH="${BUILD_PCH:-ON}"
 
 cmake -S "$FOOYIN_DIR" \
   -G Ninja \
@@ -16,9 +18,14 @@ cmake -S "$FOOYIN_DIR" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
   -DCMAKE_OSX_SYSROOT="$SDKROOT" \
-  -DICU_ROOT="$(brew --prefix icu4c@78)"
+  -DICU_ROOT="$(brew --prefix icu4c@78)" \
+  -DBUILD_CCACHE="$BUILD_CCACHE" \
+  -DBUILD_PCH="$BUILD_PCH"
 
 cmake --build build
+if [ "$BUILD_CCACHE" = "ON" ]; then
+  ccache --show-stats || true
+fi
 cd build
 cpack -G DragNDrop
 

--- a/ci/macos-depends.sh
+++ b/ci/macos-depends.sh
@@ -5,6 +5,7 @@ source ci/setup.sh
 export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 brew update
 brew install \
+    ccache \
     cmake \
     ninja \
     qt \

--- a/ci/ubuntu-build.sh
+++ b/ci/ubuntu-build.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+BUILD_CCACHE="${BUILD_CCACHE:-ON}"
+BUILD_PCH="${BUILD_PCH:-ON}"
+
 cmake -S . \
   -G Ninja \
   -B build \
   -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_TESTING=ON
+  -DBUILD_TESTING=ON \
+  -DBUILD_CCACHE="$BUILD_CCACHE" \
+  -DBUILD_PCH="$BUILD_PCH"
 
 cmake --build build
+if [ "$BUILD_CCACHE" = "ON" ]; then
+  ccache --show-stats || true
+fi
 cd build
 cpack -G DEB
 mkdir ../deb

--- a/ci/ubuntu-depends.sh
+++ b/ci/ubuntu-depends.sh
@@ -8,6 +8,8 @@ $SUDO apt-get update -qq
 $SUDO apt-get install -y \
         g++ \
         git \
+        ccache \
+        zstd \
         cmake \
         pkg-config \
         ninja-build \

--- a/ci/windows-build.ps1
+++ b/ci/windows-build.ps1
@@ -10,7 +10,9 @@ if (-not (Test-Path $ARTIFACTS_DIR)) {
 }
 
 Write-Host "Configuring CMake with preset $CMAKE_PRESET..."
-$cmakeArgs = @("--preset", $CMAKE_PRESET, "-DBUILD_TESTING=OFF")
+$BUILD_CCACHE = if ($env:BUILD_CCACHE) { $env:BUILD_CCACHE } else { "OFF" }
+$BUILD_PCH = if ($env:BUILD_PCH) { $env:BUILD_PCH } else { "ON" }
+$cmakeArgs = @("--preset", $CMAKE_PRESET, "-DBUILD_TESTING=OFF", "-DBUILD_CCACHE=$BUILD_CCACHE", "-DBUILD_PCH=$BUILD_PCH")
 
 if ($env:QT_HOST_PATH) {
     $cmakeArgs += "-DQT_HOST_PATH=$env:QT_HOST_PATH"
@@ -28,6 +30,9 @@ Write-Host "Building project in $BUILD_DIR..."
 if ($LASTEXITCODE -ne 0) {
     Write-Error "CMake build failed with exit code $LASTEXITCODE."
     exit $LASTEXITCODE
+}
+if ($BUILD_CCACHE -eq "ON" -and (Get-Command ccache -ErrorAction SilentlyContinue)) {
+    & ccache --show-stats
 }
 
 Write-Host "Packaging project..."

--- a/cmake/macos-hdiutil-retry.sh
+++ b/cmake/macos-hdiutil-retry.sh
@@ -21,6 +21,10 @@ while true; do
   fi
 
   if (( attempt >= max_attempts )); then
+    if [[ "$command" == "detach" ]]; then
+      echo "hdiutil detach failed after ${max_attempts} attempts; retrying with -force" >&2
+      exec /usr/bin/hdiutil detach -force "${@:2}"
+    fi
     exit "$result"
   fi
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ function(fooyin_add_test name)
     add_executable(${name} ${ARGN} testutils.cpp)
     fooyin_set_rpath(${name} ${LIB_INSTALL_DIR})
     target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(${name} PRIVATE FOOYIN_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     target_link_libraries(
             ${name}
             PRIVATE Fooyin::Core

--- a/tests/testutils.cpp
+++ b/tests/testutils.cpp
@@ -48,8 +48,7 @@ QString ratingSettingsPath()
 
 QString testFilePath(const QString& relativePath)
 {
-    const QFileInfo thisFile{QString::fromUtf8(__FILE__)};
-    const QDir testsDir{thisFile.absolutePath()};
+    const QDir testsDir{QStringLiteral(FOOYIN_TEST_SOURCE_DIR)};
     return testsDir.absoluteFilePath(relativePath);
 }
 


### PR DESCRIPTION
Enable PCH across CI and add ccache for Linux, macOS, and FreeBSD, while keeping the Ubuntu noble amd64 job without both to detect missing direct includes.

This also makes test fixture paths independent of `__FILE__` so ccache path rewriting doesn't break tests, and improves macOS DMG cleanup by forcing `hdiutil detach` after repeated detach failures.

The macOS amd64/intel job has also been disabled because the runner is much slower than the Apple Silicon job and was the cause of most packaging failures, and support for this runner will be ending in Fall 2027 anyway.