### PR TITLE
[spectrum] Add a spectrum visualisation plugin

### DIFF
--- a/include/core/engine/pcmframe.h
+++ b/include/core/engine/pcmframe.h
@@ -43,6 +43,7 @@ struct PcmFrame
     AudioFormat format{SampleFormat::F32, 0, 0};
     int frameCount{0};
     uint64_t streamTimeMs{0};
+    uint32_t streamId{0};
     std::chrono::steady_clock::time_point presentationTime;
 
     [[nodiscard]] size_t sampleCount() const

--- a/include/gui/widgets/colourbutton.h
+++ b/include/gui/widgets/colourbutton.h
@@ -40,6 +40,7 @@ public:
 
 Q_SIGNALS:
     void clicked();
+    void colourUpdated(const QColor& colour);
 
 protected:
     void mousePressEvent(QMouseEvent* event) override;

--- a/include/gui/widgets/gradienteditor.h
+++ b/include/gui/widgets/gradienteditor.h
@@ -1,0 +1,63 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include <QColor>
+#include <QWidget>
+
+#include <memory>
+#include <vector>
+
+class QGradient;
+class QLinearGradient;
+class QScrollArea;
+class QVBoxLayout;
+
+namespace Fooyin {
+FYGUI_EXPORT void setGradientColours(QGradient& gradient, const std::vector<QColor>& colours);
+FYGUI_EXPORT QLinearGradient linearGradient(const QRectF& rect, Qt::Orientation orientation,
+                                            const std::vector<QColor>& colours);
+
+class ColourButton;
+class GradientEditorPrivate;
+
+class FYGUI_EXPORT GradientEditor : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit GradientEditor(QWidget* parent = nullptr);
+    ~GradientEditor() override;
+
+    [[nodiscard]] std::vector<QColor> colours() const;
+    [[nodiscard]] Qt::Orientation orientation() const;
+    void setColours(const std::vector<QColor>& colours);
+    void setOrientation(Qt::Orientation orientation);
+
+Q_SIGNALS:
+    void coloursChanged();
+    void orientationChanged(Qt::Orientation orientation);
+
+private:
+    std::unique_ptr<GradientEditorPrivate> p;
+};
+} // namespace Fooyin

--- a/src/core/engine/audioanalysisbus.cpp
+++ b/src/core/engine/audioanalysisbus.cpp
@@ -38,6 +38,7 @@ AudioAnalysisBus::AudioAnalysisBus(size_t slotCapacity)
     , m_hopChannels{0}
     , m_hopSampleRate{0}
     , m_hopStreamTimeMs{0}
+    , m_hopStreamId{0}
 {
     m_worker = std::jthread{[this](std::stop_token stopToken) { run(stopToken); }};
 }
@@ -108,7 +109,7 @@ void AudioAnalysisBus::setPcmReadyHandler(PcmReadyHandler handler)
 }
 
 void AudioAnalysisBus::push(const std::span<const float> samples, AudioFormat format, uint64_t streamTimeMs,
-                            const TimePoint presentationTime)
+                            const uint32_t streamId, const TimePoint presentationTime)
 {
     if(!hasAnyActiveConsumer()) {
         return;
@@ -159,6 +160,7 @@ void AudioAnalysisBus::push(const std::span<const float> samples, AudioFormat fo
         slot->sampleCount         = static_cast<int>(slotSampleCount);
         slot->format              = format;
         slot->streamTimeMs        = streamTimeMs + offsetMs;
+        slot->streamId            = streamId;
         slot->presentationTime    = presentationTime + std::chrono::milliseconds{offsetMs};
         slot->discontinuityBefore = m_discontinuityPending.exchange(false, std::memory_order_relaxed);
         std::copy_n(samples.data() + static_cast<std::ptrdiff_t>(sampleOffset), slotSampleCount, slot->samples.data());
@@ -274,7 +276,8 @@ void AudioAnalysisBus::processSlot(const AudioAnalysisSlot& slot)
         resetHopState();
     }
 
-    if(m_hopFrames > 0 && (m_hopChannels != channelCount || m_hopSampleRate != sampleRate)) {
+    if(m_hopFrames > 0
+       && (m_hopChannels != channelCount || m_hopSampleRate != sampleRate || m_hopStreamId != slot.streamId)) {
         resetHopState();
     }
 
@@ -286,6 +289,7 @@ void AudioAnalysisBus::processSlot(const AudioAnalysisSlot& slot)
             m_hopChannels         = channelCount;
             m_hopSampleRate       = sampleRate;
             m_hopStreamTimeMs     = slot.streamTimeMs + offsetMs;
+            m_hopStreamId         = slot.streamId;
             m_hopPresentationTime = slot.presentationTime + std::chrono::milliseconds{offsetMs};
             m_hopFormat           = slot.format;
         }
@@ -331,6 +335,7 @@ void AudioAnalysisBus::emitCompletedHop()
         frame.format           = m_hopFormat;
         frame.frameCount       = m_hopFrames;
         frame.streamTimeMs     = m_hopStreamTimeMs;
+        frame.streamId         = m_hopStreamId;
         frame.presentationTime = m_hopPresentationTime;
 
         const auto sampleCount = static_cast<size_t>(m_hopFrames) * static_cast<size_t>(m_hopChannels);
@@ -372,6 +377,7 @@ void AudioAnalysisBus::resetHopState()
     m_hopChannels         = 0;
     m_hopSampleRate       = 0;
     m_hopStreamTimeMs     = 0;
+    m_hopStreamId         = 0;
     m_hopPresentationTime = {};
     m_hopFormat           = {};
 }

--- a/src/core/engine/audioanalysisbus.h
+++ b/src/core/engine/audioanalysisbus.h
@@ -99,7 +99,8 @@ public:
         setPcmReadyHandler([receiver, method](const PcmFrame& frame) { std::invoke(method, *receiver, frame); });
     }
 
-    void push(std::span<const float> samples, AudioFormat format, uint64_t streamTimeMs, TimePoint presentationTime);
+    void push(std::span<const float> samples, AudioFormat format, uint64_t streamTimeMs, uint32_t streamId,
+              TimePoint presentationTime);
     //! Drop queued analysis data and request hop-state reset.
     void flush();
 
@@ -113,6 +114,7 @@ private:
         AudioFormat format{SampleFormat::F32, 0, 0};
         int sampleCount{0};
         uint64_t streamTimeMs{0};
+        uint32_t streamId{0};
         TimePoint presentationTime;
         bool discontinuityBefore{false};
     };
@@ -146,6 +148,7 @@ private:
     int m_hopChannels;
     int m_hopSampleRate;
     uint64_t m_hopStreamTimeMs;
+    uint32_t m_hopStreamId;
     TimePoint m_hopPresentationTime;
     AudioFormat m_hopFormat;
 };

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -1314,9 +1314,6 @@ void AudioEngine::logGaplessBoundaryDiagnostic(const char* reason, StreamId trig
 void AudioEngine::publishPosition(uint64_t sourcePositionMs, uint64_t outputDelayMs, double delayToSourceScale,
                                   AudioClock::UpdateMode mode, bool emitNow)
 {
-    m_visualisationBackend->setCurrentTimeMs(
-        AudioClock::presentedFromSource(sourcePositionMs, outputDelayMs, delayToSourceScale));
-
     m_audioClock.applyPosition(sourcePositionMs, outputDelayMs, delayToSourceScale, m_trackGeneration, mode, emitNow);
     if(mode == AudioClock::UpdateMode::Discontinuity) {
         m_positionCoordinator.notePublishedDiscontinuity(sourcePositionMs);
@@ -2187,6 +2184,7 @@ void AudioEngine::updatePosition()
 
     const auto updateMode
         = output.discontinuity ? AudioClock::UpdateMode::Discontinuity : AudioClock::UpdateMode::Continuous;
+
     publishPosition(output.relativePosMs, pipelineDelayMs, delayToSourceScale, updateMode, output.emitNow);
 
     bool boundaryFallbackReached = output.boundaryFallbackReached;
@@ -2279,6 +2277,11 @@ void AudioEngine::onLevelFrameReady(const LevelFrame& frame)
 void AudioEngine::onPcmFrameReady(const PcmFrame& frame)
 {
     m_visualisationBackend->appendFrame(frame);
+    if(frame.streamId != InvalidStreamId && frame.format.sampleRate() > 0 && frame.frameCount > 0) {
+        const auto frameDurationMs = frame.format.durationForFrames(frame.frameCount);
+        m_visualisationBackend->setCurrentTimeMs(frame.streamId, frame.streamTimeMs + frameDurationMs,
+                                                 frame.presentationTime + std::chrono::milliseconds{frameDurationMs});
+    }
 
     auto writer              = m_pcmFrameMailbox.writer();
     const size_t framesWrote = writer.write(&frame, 1, RingBufferOverflowPolicy::OverwriteOldest);

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -2587,14 +2587,12 @@ void AudioEngine::updatePlaybackState(Engine::PlaybackState state)
     if(prevState != state) {
         switch(state) {
             case Engine::PlaybackState::Playing:
-                m_visualisationBackend->setPlaying();
                 m_audioClock.setPlaying(m_audioClock.position());
                 if(!isCrossfading(m_phase) && !isFadingTransport(m_phase) && m_phase != Playback::Phase::Seeking) {
                     setPhase(Playback::Phase::Playing, PhaseChangeReason::PlaybackStatePlaying);
                 }
                 break;
             case Engine::PlaybackState::Paused:
-                m_visualisationBackend->setPaused();
                 m_audioClock.setPaused();
                 setPhase(Playback::Phase::Paused, PhaseChangeReason::PlaybackStatePaused);
                 break;

--- a/src/core/engine/pipeline/pipelinerenderer.cpp
+++ b/src/core/engine/pipeline/pipelinerenderer.cpp
@@ -220,7 +220,7 @@ PipelineRenderer::RenderResult PipelineRenderer::render(int framesToProcess, Out
 
     result.fadeCompletion = outputFader.takeCompletion();
 
-    tapAnalysis(analysisBus, playbackDelayMs);
+    tapAnalysis(analysisBus, playbackDelayMs, mixerRead.primaryStreamId);
 
     return result;
 }
@@ -762,7 +762,7 @@ void PipelineRenderer::rebuildProcessChunksFromMixerRead(const AudioMixer::ReadR
     }
 }
 
-void PipelineRenderer::tapAnalysis(AudioAnalysisBus* analysisBus, uint64_t playbackDelayMs)
+void PipelineRenderer::tapAnalysis(AudioAnalysisBus* analysisBus, uint64_t playbackDelayMs, const StreamId streamId)
 {
     if(!analysisBus
        || (!analysisBus->hasSubscription(Engine::AnalysisDataType::LevelFrameData)
@@ -842,6 +842,6 @@ void PipelineRenderer::tapAnalysis(AudioAnalysisBus* analysisBus, uint64_t playb
 
     const auto presentationTime = AudioAnalysisBus::Clock::now() + std::chrono::milliseconds{playbackDelayMs};
     analysisBus->push(std::span<const float>{m_analysisScratch.data(), writeOffset}, analysisFormat, streamTimeMs,
-                      presentationTime);
+                      streamId, presentationTime);
 }
 } // namespace Fooyin

--- a/src/core/engine/pipeline/pipelinerenderer.h
+++ b/src/core/engine/pipeline/pipelinerenderer.h
@@ -143,7 +143,7 @@ private:
     void setWorkingFormats(const AudioFormat& input, const AudioFormat& output);
     void clearFormats();
     void rebuildProcessChunksFromMixerRead(const AudioMixer::ReadResult& readResult, int framesRead);
-    void tapAnalysis(AudioAnalysisBus* analysisBus, uint64_t playbackDelayMs);
+    void tapAnalysis(AudioAnalysisBus* analysisBus, uint64_t playbackDelayMs, StreamId streamId);
 
     Engine::DspChain m_perTrackChainDefs;
 

--- a/src/core/engine/visualisationbackend.cpp
+++ b/src/core/engine/visualisationbackend.cpp
@@ -24,11 +24,13 @@
 
 #include <functional>
 #include <mutex>
+#include <ranges>
 #include <utility>
 
 constexpr uint64_t BacklogPaddingMs       = 100;
 constexpr uint64_t ContinuityToleranceMs  = 100;
 constexpr uint64_t DefaultBacklogDuration = 250;
+constexpr uint64_t TimelineResetAlignMs   = 500;
 
 namespace {
 int previousPowerOfTwo(int value)
@@ -92,6 +94,7 @@ VisualisationBackend::VisualisationBackend()
     , m_startStreamFrame{0}
     , m_nextStreamFrame{0}
     , m_currentTimeMs{0}
+    , m_currentTimePublished{false}
 { }
 
 bool VisualisationBackend::unregisterSession(SessionToken token)
@@ -116,7 +119,24 @@ bool VisualisationBackend::hasActiveSessions() const
 
 void VisualisationBackend::setCurrentTimeMs(uint64_t currentTimeMs)
 {
+    if(currentTimeMs == 0 && m_currentTimePublished.load(std::memory_order_relaxed)
+       && m_currentTimeMs.load(std::memory_order_relaxed) > 0) {
+        const std::unique_lock lock{m_mutex};
+        const int sampleRate = m_format.sampleRate();
+        const uint64_t toleranceFrames
+            = sampleRate > 0 ? std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate)) : 0;
+        const uint64_t previousTimeMs        = m_currentTimeMs.load(std::memory_order_relaxed);
+        const uint64_t previousFrame         = msToFrames(previousTimeMs, sampleRate);
+        const bool previousTimeInsideBacklog = m_frameCount > 0 && sampleRate > 0
+                                            && previousFrame + toleranceFrames >= m_startStreamFrame
+                                            && previousFrame <= m_nextStreamFrame + toleranceFrames;
+        if(previousTimeInsideBacklog) {
+            return;
+        }
+    }
+
     m_currentTimeMs.store(currentTimeMs, std::memory_order_relaxed);
+    m_currentTimePublished.store(true, std::memory_order_relaxed);
 }
 
 uint64_t VisualisationBackend::currentTimeMs() const
@@ -127,6 +147,7 @@ uint64_t VisualisationBackend::currentTimeMs() const
 void VisualisationBackend::setStopped()
 {
     m_currentTimeMs.store(0, std::memory_order_relaxed);
+    m_currentTimePublished.store(false, std::memory_order_relaxed);
 }
 
 void VisualisationBackend::appendFrame(const PcmFrame& frame)
@@ -152,28 +173,54 @@ void VisualisationBackend::appendFrame(const PcmFrame& frame)
     }
 
     bool resetBacklog{false};
+
+    const uint64_t reportedStartFrame = msToFrames(frame.streamTimeMs, sampleRate);
+    uint64_t resetStartFrame{reportedStartFrame};
+
     if(m_format != format) {
         resetBacklog = true;
     }
 
-    const uint64_t reportedStartFrame = msToFrames(frame.streamTimeMs, sampleRate);
     if(m_frameCount == 0) {
         m_startStreamFrame = reportedStartFrame;
         m_nextStreamFrame  = reportedStartFrame;
     }
     else {
-        const uint64_t toleranceFrames = std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate));
-        if(reportedStartFrame + toleranceFrames < m_nextStreamFrame
-           || reportedStartFrame > m_nextStreamFrame + toleranceFrames) {
-            resetBacklog = true;
+        const uint64_t toleranceFrames   = std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate));
+        const bool sourceTimestampBehind = reportedStartFrame + toleranceFrames < m_nextStreamFrame;
+        const bool sourceTimestampAhead  = reportedStartFrame > m_nextStreamFrame + toleranceFrames;
+
+        if(sourceTimestampBehind || sourceTimestampAhead) {
+            const uint64_t visualTimeMs         = currentTimeMs();
+            const uint64_t visualTimeFrame      = msToFrames(visualTimeMs, sampleRate);
+            const bool visualClockInsideBacklog = visualTimeMs > 0
+                                               && visualTimeFrame + toleranceFrames >= m_startStreamFrame
+                                               && visualTimeFrame <= m_nextStreamFrame + toleranceFrames;
+
+            if(visualClockInsideBacklog && m_format == format) {
+                if(sourceTimestampBehind) {
+                    m_timelineFrameOffset = static_cast<int64_t>(m_nextStreamFrame - reportedStartFrame);
+                }
+            }
+            else {
+                resetBacklog = true;
+                if(visualTimeMs > 0) {
+                    const uint64_t reportedMs = (reportedStartFrame * 1000ULL) / static_cast<uint64_t>(sampleRate);
+                    const uint64_t deltaMs
+                        = visualTimeMs > reportedMs ? (visualTimeMs - reportedMs) : (reportedMs - visualTimeMs);
+                    if(deltaMs <= TimelineResetAlignMs) {
+                        resetStartFrame = visualTimeFrame;
+                    }
+                }
+            }
         }
     }
 
     if(resetBacklog) {
         resetLocked();
         m_format           = format;
-        m_startStreamFrame = reportedStartFrame;
-        m_nextStreamFrame  = reportedStartFrame;
+        m_startStreamFrame = resetStartFrame;
+        m_nextStreamFrame  = resetStartFrame;
     }
 
     const size_t requiredFrames = std::max<size_t>(
@@ -181,6 +228,14 @@ void VisualisationBackend::appendFrame(const PcmFrame& frame)
     ensureCapacity(requiredFrames);
     appendFrames(std::span<const float>{frame.samples.data(), sampleCount}, static_cast<size_t>(frameCount),
                  channelCount, m_nextStreamFrame);
+
+    const uint64_t availableEndMs = (m_nextStreamFrame * 1000ULL) / static_cast<uint64_t>(sampleRate);
+    if(availableEndMs > 0 && m_currentTimePublished.load(std::memory_order_relaxed)
+       && m_currentTimeMs.load(std::memory_order_relaxed) == 0) {
+        uint64_t expectedZero{0};
+        m_currentTimeMs.compare_exchange_strong(expectedZero, availableEndMs, std::memory_order_relaxed,
+                                                std::memory_order_relaxed);
+    }
 }
 
 void VisualisationBackend::reset()
@@ -207,7 +262,7 @@ bool VisualisationBackend::resolveWindow(WindowRange& out, uint64_t timeMs, int 
         return false;
     }
 
-    const uint64_t timeFrame = msToFrames(timeMs, m_format.sampleRate());
+    const uint64_t timeFrame = msToFrames(mappedTimeMs(timeMs), m_format.sampleRate());
     uint64_t startFrame{0};
 
     if(anchor == WindowAnchor::Center) {
@@ -238,7 +293,7 @@ bool VisualisationBackend::resolveSpectrumWindowEndingAt(WindowRange& out, uint6
 
     const uint64_t availableStartFrame = m_startStreamFrame;
     const uint64_t availableEndFrame   = m_nextStreamFrame;
-    const uint64_t timeFrame           = msToFrames(endTimeMs, m_format.sampleRate());
+    const uint64_t timeFrame           = msToFrames(mappedTimeMs(endTimeMs), m_format.sampleRate());
     const uint64_t clampedEndFrame     = std::clamp(timeFrame, availableStartFrame, availableEndFrame);
 
     if(clampedEndFrame <= availableStartFrame) {
@@ -259,6 +314,27 @@ bool VisualisationBackend::resolveSpectrumWindowEndingAt(WindowRange& out, uint6
     out.startFrame          = clampedEndFrame - windowFrames;
     out.frameCount          = frameCount;
     return true;
+}
+
+uint64_t VisualisationBackend::mappedTimeMs(uint64_t timeMs) const
+{
+    if(!m_timelineFrameOffset.has_value() || !m_format.isValid() || m_format.sampleRate() <= 0) {
+        return timeMs;
+    }
+
+    const int sampleRate      = m_format.sampleRate();
+    const auto timeFrame      = static_cast<int64_t>(msToFrames(timeMs, sampleRate));
+    const int64_t mappedFrame = timeFrame + m_timelineFrameOffset.value();
+    if(mappedFrame < 0) {
+        return timeMs;
+    }
+
+    const auto mappedFrameValue = static_cast<uint64_t>(mappedFrame);
+    if(mappedFrameValue < m_startStreamFrame || mappedFrameValue > m_nextStreamFrame) {
+        return timeMs;
+    }
+
+    return (mappedFrameValue * 1000ULL) / static_cast<uint64_t>(sampleRate);
 }
 
 bool VisualisationBackend::getPcmWindow(VisualisationSession::PcmWindow& out, uint64_t centerTimeMs,
@@ -517,11 +593,12 @@ uint64_t VisualisationBackend::msToFrames(uint64_t ms, int sampleRate)
 
 void VisualisationBackend::resetLocked()
 {
-    m_headFrame        = 0;
-    m_frameCount       = 0;
-    m_startStreamFrame = 0;
-    m_nextStreamFrame  = 0;
-    m_format           = AudioFormat{SampleFormat::F32, 0, 0};
+    m_headFrame           = 0;
+    m_frameCount          = 0;
+    m_startStreamFrame    = 0;
+    m_nextStreamFrame     = 0;
+    m_timelineFrameOffset = std::nullopt;
+    m_format              = AudioFormat{SampleFormat::F32, 0, 0};
 }
 
 void VisualisationBackend::ensureCapacity(size_t requiredFrames)
@@ -553,8 +630,7 @@ void VisualisationBackend::ensureCapacity(size_t requiredFrames)
 size_t VisualisationBackend::requestedBacklogFrames(int sampleRate) const
 {
     uint64_t requestedBacklogMs{DefaultBacklogDuration};
-    for(const auto& [token, backlogMs] : m_backlogRequests) {
-        Q_UNUSED(token);
+    for(const auto& backlogMs : m_backlogRequests | std::views::values) {
         requestedBacklogMs = std::max(requestedBacklogMs, backlogMs);
     }
 

--- a/src/core/engine/visualisationbackend.cpp
+++ b/src/core/engine/visualisationbackend.cpp
@@ -22,24 +22,51 @@
 #include <algorithm>
 #include <numbers>
 
-#include <algorithm>
-#include <chrono>
+#include <functional>
 #include <mutex>
 #include <utility>
 
 constexpr uint64_t BacklogPaddingMs       = 100;
-constexpr uint64_t ContinuityToleranceMs  = 10;
+constexpr uint64_t ContinuityToleranceMs  = 100;
 constexpr uint64_t DefaultBacklogDuration = 250;
 
 namespace {
-int64_t nowNs()
+int previousPowerOfTwo(int value)
 {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-        .count();
+    int power{1};
+    while(power <= value / 2) {
+        power *= 2;
+    }
+    return power;
 }
+
+float spectrumWindowGain(Fooyin::VisualisationSession::SpectrumWindowFunction windowFunction, float phase)
+{
+    using WindowFunction = Fooyin::VisualisationSession::SpectrumWindowFunction;
+
+    switch(windowFunction) {
+        case WindowFunction::BlackmanHarris:
+            return 0.35875F - (0.48829F * std::cos(phase)) + (0.14128F * std::cos(2.0F * phase))
+                 - (0.01168F * std::cos(3.0F * phase));
+        case WindowFunction::Hann:
+            return 0.5F * (1.0F - std::cos(phase));
+        case WindowFunction::None:
+            return 1.0F;
+    }
+
+    return 1.0F;
+}
+
 } // namespace
 
 namespace Fooyin {
+size_t VisualisationBackend::WindowCacheKeyHash::operator()(const WindowCacheKey& key) const
+{
+    const auto fftHash      = std::hash<int>{}(key.fftSize);
+    const auto functionHash = std::hash<int>{}(static_cast<int>(key.function));
+    return fftHash ^ (functionHash + 0x9e3779b9U + (fftHash << 6U) + (fftHash >> 2U));
+}
+
 VisualisationBackend::SessionToken VisualisationBackend::registerSession()
 {
     const std::unique_lock lock{m_mutex};
@@ -65,8 +92,6 @@ VisualisationBackend::VisualisationBackend()
     , m_startStreamFrame{0}
     , m_nextStreamFrame{0}
     , m_currentTimeMs{0}
-    , m_timeAnchorNs{0}
-    , m_isPlaying{false}
 { }
 
 bool VisualisationBackend::unregisterSession(SessionToken token)
@@ -92,44 +117,16 @@ bool VisualisationBackend::hasActiveSessions() const
 void VisualisationBackend::setCurrentTimeMs(uint64_t currentTimeMs)
 {
     m_currentTimeMs.store(currentTimeMs, std::memory_order_relaxed);
-    m_timeAnchorNs.store(nowNs(), std::memory_order_relaxed);
 }
 
 uint64_t VisualisationBackend::currentTimeMs() const
 {
-    const uint64_t baseTimeMs = m_currentTimeMs.load(std::memory_order_relaxed);
-    if(!m_isPlaying.load(std::memory_order_relaxed)) {
-        return baseTimeMs;
-    }
-
-    const int64_t anchorNs = m_timeAnchorNs.load(std::memory_order_relaxed);
-    const int64_t deltaNs  = nowNs() - anchorNs;
-    if(deltaNs <= 0) {
-        return baseTimeMs;
-    }
-
-    return baseTimeMs + static_cast<uint64_t>(deltaNs / 1'000'000LL);
-}
-
-void VisualisationBackend::setPlaying()
-{
-    m_currentTimeMs.store(currentTimeMs(), std::memory_order_relaxed);
-    m_timeAnchorNs.store(nowNs(), std::memory_order_relaxed);
-    m_isPlaying.store(true, std::memory_order_relaxed);
-}
-
-void VisualisationBackend::setPaused()
-{
-    m_currentTimeMs.store(currentTimeMs(), std::memory_order_relaxed);
-    m_timeAnchorNs.store(nowNs(), std::memory_order_relaxed);
-    m_isPlaying.store(false, std::memory_order_relaxed);
+    return m_currentTimeMs.load(std::memory_order_relaxed);
 }
 
 void VisualisationBackend::setStopped()
 {
     m_currentTimeMs.store(0, std::memory_order_relaxed);
-    m_timeAnchorNs.store(nowNs(), std::memory_order_relaxed);
-    m_isPlaying.store(false, std::memory_order_relaxed);
 }
 
 void VisualisationBackend::appendFrame(const PcmFrame& frame)
@@ -229,6 +226,41 @@ bool VisualisationBackend::resolveWindow(WindowRange& out, uint64_t timeMs, int 
     return true;
 }
 
+bool VisualisationBackend::resolveSpectrumWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
+                                                         int minimumFrameCount) const
+{
+    // Keep startup/track change windows anchored to playback time. The generic end-window resolver clamps to
+    // the first full window, which makes larger FFT sizes appear frozen until playback catches up.
+    if(std::cmp_less(m_frameCount, minimumFrameCount) || !m_format.isValid() || m_format.sampleRate() <= 0
+       || m_format.channelCount() <= 0 || requestedFrameCount < minimumFrameCount) {
+        return false;
+    }
+
+    const uint64_t availableStartFrame = m_startStreamFrame;
+    const uint64_t availableEndFrame   = m_nextStreamFrame;
+    const uint64_t timeFrame           = msToFrames(endTimeMs, m_format.sampleRate());
+    const uint64_t clampedEndFrame     = std::clamp(timeFrame, availableStartFrame, availableEndFrame);
+
+    if(clampedEndFrame <= availableStartFrame) {
+        return false;
+    }
+
+    const uint64_t availableWindowFrames = clampedEndFrame - availableStartFrame;
+    int frameCount                       = requestedFrameCount;
+    if(std::cmp_less(availableWindowFrames, requestedFrameCount)) {
+        frameCount = previousPowerOfTwo(static_cast<int>(availableWindowFrames));
+    }
+
+    if(frameCount < minimumFrameCount) {
+        return false;
+    }
+
+    const auto windowFrames = static_cast<uint64_t>(frameCount);
+    out.startFrame          = clampedEndFrame - windowFrames;
+    out.frameCount          = frameCount;
+    return true;
+}
+
 bool VisualisationBackend::getPcmWindow(VisualisationSession::PcmWindow& out, uint64_t centerTimeMs,
                                         uint64_t durationMs, const ChannelSelection& selection) const
 {
@@ -284,12 +316,13 @@ bool VisualisationBackend::getSpectrumWindowEndingAt(VisualisationSession::Spect
                                                      SpectrumWindowFunction windowFunction) const
 {
     VisualisationSession::PcmWindow window;
+    const int startupFrameCount = std::min(fftSize, 4096);
 
     {
         const std::shared_lock lock{m_mutex};
 
         WindowRange range;
-        if(!resolveWindow(range, endTimeMs, fftSize, 2, WindowAnchor::End)) {
+        if(!resolveSpectrumWindowEndingAt(range, endTimeMs, fftSize, startupFrameCount)) {
             return false;
         }
 
@@ -421,9 +454,31 @@ bool VisualisationBackend::fillSpectrumWindow(VisualisationSession::SpectrumWind
     const int channelCount = window.format.channelCount();
 
     const int transformChannelCount = selection.mixMode == ChannelSelection::MixMode::AllChannels ? channelCount : 1;
+    const bool applyWindow          = window.frameCount > 2 && windowFunction != SpectrumWindowFunction::None;
+
+    float magnitudeScale{1.0F};
+    std::vector<float> windowGains;
+
+    if(applyWindow) {
+        windowGains.resize(static_cast<size_t>(window.frameCount), 1.0F);
+
+        float gainSum{0.0F};
+        const auto denom = static_cast<float>(window.frameCount - 1);
+
+        for(int frameIndex{0}; frameIndex < window.frameCount; ++frameIndex) {
+            const float phase = (static_cast<float>(frameIndex) * 2.0F * std::numbers::pi_v<float>) / denom;
+            const float gain  = spectrumWindowGain(windowFunction, phase);
+            windowGains[static_cast<size_t>(frameIndex)] = gain;
+            gainSum += gain;
+        }
+
+        if(gainSum > 0.0F) {
+            magnitudeScale = static_cast<float>(window.frameCount) / gainSum;
+        }
+    }
 
     for(int channel{0}; channel < transformChannelCount; ++channel) {
-        if(window.frameCount == 2 || windowFunction == SpectrumWindowFunction::None) {
+        if(!applyWindow) {
             for(int frameIndex{0}; frameIndex < window.frameCount; ++frameIndex) {
                 const size_t sampleIndex = (static_cast<size_t>(frameIndex) * static_cast<size_t>(channelCount))
                                          + static_cast<size_t>(channel);
@@ -431,26 +486,11 @@ bool VisualisationBackend::fillSpectrumWindow(VisualisationSession::SpectrumWind
             }
         }
         else {
-            const auto denom = static_cast<float>(window.frameCount - 1);
             for(int frameIndex{0}; frameIndex < window.frameCount; ++frameIndex) {
-                const float phase = (static_cast<float>(frameIndex) * 2.0F * std::numbers::pi_v<float>) / denom;
-                float windowGain{1.0};
-
-                switch(windowFunction) {
-                    case SpectrumWindowFunction::Hann:
-                        windowGain = 0.5F * (1.0F - std::cos(phase));
-                        break;
-                    case SpectrumWindowFunction::BlackmanHarris:
-                        windowGain = 0.35875F - (0.48829F * std::cos(phase)) + (0.14128F * std::cos(2.0F * phase))
-                                   - (0.01168F * std::cos(3.0F * phase));
-                        break;
-                    case SpectrumWindowFunction::None:
-                        break;
-                }
-
                 const size_t sampleIndex = (static_cast<size_t>(frameIndex) * static_cast<size_t>(channelCount))
                                          + static_cast<size_t>(channel);
-                fftInput[static_cast<size_t>(frameIndex)] = samples[sampleIndex] * windowGain;
+                fftInput[static_cast<size_t>(frameIndex)]
+                    = samples[sampleIndex] * windowGains[static_cast<size_t>(frameIndex)];
             }
         }
 
@@ -459,7 +499,7 @@ bool VisualisationBackend::fillSpectrumWindow(VisualisationSession::SpectrumWind
         }
 
         for(size_t bin{0}; bin < out.magnitudes.size(); ++bin) {
-            out.magnitudes[bin] = std::max(out.magnitudes[bin], magnitudes[bin]);
+            out.magnitudes[bin] = std::max(out.magnitudes[bin], magnitudes[bin] * magnitudeScale);
         }
     }
 

--- a/src/core/engine/visualisationbackend.cpp
+++ b/src/core/engine/visualisationbackend.cpp
@@ -20,6 +20,7 @@
 #include "visualisationbackend.h"
 
 #include <algorithm>
+#include <chrono>
 #include <numbers>
 
 #include <functional>
@@ -30,9 +31,30 @@
 constexpr uint64_t BacklogPaddingMs       = 100;
 constexpr uint64_t ContinuityToleranceMs  = 100;
 constexpr uint64_t DefaultBacklogDuration = 250;
-constexpr uint64_t TimelineResetAlignMs   = 500;
+constexpr int MinimumSpectrumFrameCount   = 256;
 
 namespace {
+int64_t steadyClockMs()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+int64_t steadyClockMs(std::chrono::steady_clock::time_point time)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch()).count();
+}
+
+uint64_t addSignedOffset(uint64_t value, int64_t offset)
+{
+    if(offset >= 0) {
+        return value + static_cast<uint64_t>(offset);
+    }
+
+    const auto delta = static_cast<uint64_t>(-offset);
+    return value > delta ? value - delta : 0;
+}
+
 int previousPowerOfTwo(int value)
 {
     int power{1};
@@ -93,8 +115,11 @@ VisualisationBackend::VisualisationBackend()
     , m_frameCount{0}
     , m_startStreamFrame{0}
     , m_nextStreamFrame{0}
+    , m_currentStreamId{0}
     , m_currentTimeMs{0}
+    , m_currentTimeReferenceClockMs{0}
     , m_currentTimePublished{false}
+    , m_currentTimeHasPresentationClock{false}
 { }
 
 bool VisualisationBackend::unregisterSession(SessionToken token)
@@ -119,35 +144,61 @@ bool VisualisationBackend::hasActiveSessions() const
 
 void VisualisationBackend::setCurrentTimeMs(uint64_t currentTimeMs)
 {
-    if(currentTimeMs == 0 && m_currentTimePublished.load(std::memory_order_relaxed)
-       && m_currentTimeMs.load(std::memory_order_relaxed) > 0) {
-        const std::unique_lock lock{m_mutex};
-        const int sampleRate = m_format.sampleRate();
-        const uint64_t toleranceFrames
-            = sampleRate > 0 ? std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate)) : 0;
-        const uint64_t previousTimeMs        = m_currentTimeMs.load(std::memory_order_relaxed);
-        const uint64_t previousFrame         = msToFrames(previousTimeMs, sampleRate);
-        const bool previousTimeInsideBacklog = m_frameCount > 0 && sampleRate > 0
-                                            && previousFrame + toleranceFrames >= m_startStreamFrame
-                                            && previousFrame <= m_nextStreamFrame + toleranceFrames;
-        if(previousTimeInsideBacklog) {
-            return;
-        }
+    setCurrentTimeMs(0, currentTimeMs);
+}
+
+void VisualisationBackend::setCurrentTimeMs(uint32_t streamId, uint64_t currentTimeMs)
+{
+    uint64_t visualTimeMs{currentTimeMs};
+
+    {
+        const std::shared_lock lock{m_mutex};
+        visualTimeMs = mapSourceTimeToVisualTime(streamId, currentTimeMs);
     }
 
-    m_currentTimeMs.store(currentTimeMs, std::memory_order_relaxed);
+    m_currentTimeMs.store(visualTimeMs, std::memory_order_relaxed);
+    m_currentTimeReferenceClockMs.store(0, std::memory_order_relaxed);
     m_currentTimePublished.store(true, std::memory_order_relaxed);
+    m_currentTimeHasPresentationClock.store(false, std::memory_order_relaxed);
+}
+
+void VisualisationBackend::setCurrentTimeMs(uint32_t streamId, uint64_t currentTimeMs,
+                                            std::chrono::steady_clock::time_point presentationTime)
+{
+    setCurrentTimeMs(streamId, currentTimeMs);
+    m_currentTimeReferenceClockMs.store(steadyClockMs(presentationTime), std::memory_order_relaxed);
+    m_currentTimeHasPresentationClock.store(true, std::memory_order_relaxed);
 }
 
 uint64_t VisualisationBackend::currentTimeMs() const
 {
-    return m_currentTimeMs.load(std::memory_order_relaxed);
+    const uint64_t currentTimeMs = m_currentTimeMs.load(std::memory_order_relaxed);
+    if(currentTimeMs == 0 || !m_currentTimeHasPresentationClock.load(std::memory_order_relaxed)) {
+        return currentTimeMs;
+    }
+
+    const int64_t referenceClockMs = m_currentTimeReferenceClockMs.load(std::memory_order_relaxed);
+    if(referenceClockMs <= 0) {
+        return currentTimeMs;
+    }
+
+    const int64_t elapsedMs = steadyClockMs() - referenceClockMs;
+    if(elapsedMs >= 0) {
+        return currentTimeMs + static_cast<uint64_t>(elapsedMs);
+    }
+
+    const auto earlyMs = static_cast<uint64_t>(-elapsedMs);
+    return currentTimeMs > earlyMs ? currentTimeMs - earlyMs : 0;
 }
 
 void VisualisationBackend::setStopped()
 {
     m_currentTimeMs.store(0, std::memory_order_relaxed);
+    m_currentTimeReferenceClockMs.store(0, std::memory_order_relaxed);
     m_currentTimePublished.store(false, std::memory_order_relaxed);
+    m_currentTimeHasPresentationClock.store(false, std::memory_order_relaxed);
+    const std::unique_lock lock{m_mutex};
+    m_currentStreamId = 0;
 }
 
 void VisualisationBackend::appendFrame(const PcmFrame& frame)
@@ -172,76 +223,77 @@ void VisualisationBackend::appendFrame(const PcmFrame& frame)
         return;
     }
 
-    bool resetBacklog{false};
-
+    const uint32_t sourceKey          = frame.streamId;
     const uint64_t reportedStartFrame = msToFrames(frame.streamTimeMs, sampleRate);
-    uint64_t resetStartFrame{reportedStartFrame};
+    const uint64_t reportedNextFrame  = reportedStartFrame + static_cast<uint64_t>(frameCount);
+    bool resetBacklog                 = false;
+    const bool formatChanged          = m_format.isValid() && m_format != format;
 
-    if(m_format != format) {
+    if(formatChanged) {
         resetBacklog = true;
     }
+    else if(m_frameCount > 0) {
+        if(const auto it = m_sourceTimelines.find(sourceKey); it != m_sourceTimelines.end()) {
+            const uint64_t toleranceFrames   = std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate));
+            const bool sourceTimestampBehind = reportedStartFrame + toleranceFrames < it->second.nextFrame;
+            const bool sourceTimestampAhead  = reportedStartFrame > it->second.nextFrame + toleranceFrames;
 
-    if(m_frameCount == 0) {
-        m_startStreamFrame = reportedStartFrame;
-        m_nextStreamFrame  = reportedStartFrame;
-    }
-    else {
-        const uint64_t toleranceFrames   = std::max<uint64_t>(1, msToFrames(ContinuityToleranceMs, sampleRate));
-        const bool sourceTimestampBehind = reportedStartFrame + toleranceFrames < m_nextStreamFrame;
-        const bool sourceTimestampAhead  = reportedStartFrame > m_nextStreamFrame + toleranceFrames;
-
-        if(sourceTimestampBehind || sourceTimestampAhead) {
-            const uint64_t visualTimeMs         = currentTimeMs();
-            const uint64_t visualTimeFrame      = msToFrames(visualTimeMs, sampleRate);
-            const bool visualClockInsideBacklog = visualTimeMs > 0
-                                               && visualTimeFrame + toleranceFrames >= m_startStreamFrame
-                                               && visualTimeFrame <= m_nextStreamFrame + toleranceFrames;
-
-            if(visualClockInsideBacklog && m_format == format) {
-                if(sourceTimestampBehind) {
-                    m_timelineFrameOffset = static_cast<int64_t>(m_nextStreamFrame - reportedStartFrame);
-                }
-            }
-            else {
+            if(sourceTimestampBehind || sourceTimestampAhead) {
                 resetBacklog = true;
-                if(visualTimeMs > 0) {
-                    const uint64_t reportedMs = (reportedStartFrame * 1000ULL) / static_cast<uint64_t>(sampleRate);
-                    const uint64_t deltaMs
-                        = visualTimeMs > reportedMs ? (visualTimeMs - reportedMs) : (reportedMs - visualTimeMs);
-                    if(deltaMs <= TimelineResetAlignMs) {
-                        resetStartFrame = visualTimeFrame;
-                    }
-                }
             }
         }
     }
 
     if(resetBacklog) {
         resetLocked();
-        m_format           = format;
-        m_startStreamFrame = resetStartFrame;
-        m_nextStreamFrame  = resetStartFrame;
+        m_currentTimeMs.store(0, std::memory_order_relaxed);
+        m_currentTimeReferenceClockMs.store(0, std::memory_order_relaxed);
+        m_currentTimePublished.store(false, std::memory_order_relaxed);
+        m_currentTimeHasPresentationClock.store(false, std::memory_order_relaxed);
+    }
+
+    if(!m_format.isValid()) {
+        m_format = format;
+    }
+
+    if(m_frameCount == 0) {
+        m_startStreamFrame = 0;
+        m_nextStreamFrame  = 0;
+    }
+
+    const uint64_t visualStartFrame = m_nextStreamFrame;
+    const uint64_t visualStartMs    = (visualStartFrame * 1000ULL) / static_cast<uint64_t>(sampleRate);
+
+    auto& sourceTimeline              = m_sourceTimelines[sourceKey];
+    sourceTimeline.nextFrame          = reportedNextFrame;
+    sourceTimeline.visualTimeOffsetMs = static_cast<int64_t>(visualStartMs) - static_cast<int64_t>(frame.streamTimeMs);
+
+    if(frame.streamId != 0) {
+        m_currentStreamId = frame.streamId;
     }
 
     const size_t requiredFrames = std::max<size_t>(
         static_cast<size_t>(frameCount), requestedBacklogFrames(sampleRate) + static_cast<size_t>(frameCount));
     ensureCapacity(requiredFrames);
     appendFrames(std::span<const float>{frame.samples.data(), sampleCount}, static_cast<size_t>(frameCount),
-                 channelCount, m_nextStreamFrame);
+                 channelCount, visualStartFrame);
 
     const uint64_t availableEndMs = (m_nextStreamFrame * 1000ULL) / static_cast<uint64_t>(sampleRate);
-    if(availableEndMs > 0 && m_currentTimePublished.load(std::memory_order_relaxed)
-       && m_currentTimeMs.load(std::memory_order_relaxed) == 0) {
-        uint64_t expectedZero{0};
-        m_currentTimeMs.compare_exchange_strong(expectedZero, availableEndMs, std::memory_order_relaxed,
-                                                std::memory_order_relaxed);
+    if(availableEndMs > 0
+       && (!m_currentTimePublished.load(std::memory_order_relaxed)
+           || m_currentTimeMs.load(std::memory_order_relaxed) == 0)) {
+        m_currentTimeMs.store(availableEndMs, std::memory_order_relaxed);
+        m_currentTimePublished.store(true, std::memory_order_relaxed);
+        m_currentTimeHasPresentationClock.store(false, std::memory_order_relaxed);
     }
 }
 
 void VisualisationBackend::reset()
 {
-    const std::unique_lock lock{m_mutex};
-    resetLocked();
+    {
+        const std::unique_lock lock{m_mutex};
+        resetLocked();
+    }
     setStopped();
 }
 
@@ -262,7 +314,7 @@ bool VisualisationBackend::resolveWindow(WindowRange& out, uint64_t timeMs, int 
         return false;
     }
 
-    const uint64_t timeFrame = msToFrames(mappedTimeMs(timeMs), m_format.sampleRate());
+    const uint64_t timeFrame = msToFrames(timeMs, m_format.sampleRate());
     uint64_t startFrame{0};
 
     if(anchor == WindowAnchor::Center) {
@@ -293,7 +345,7 @@ bool VisualisationBackend::resolveSpectrumWindowEndingAt(WindowRange& out, uint6
 
     const uint64_t availableStartFrame = m_startStreamFrame;
     const uint64_t availableEndFrame   = m_nextStreamFrame;
-    const uint64_t timeFrame           = msToFrames(mappedTimeMs(endTimeMs), m_format.sampleRate());
+    const uint64_t timeFrame           = msToFrames(endTimeMs, m_format.sampleRate());
     const uint64_t clampedEndFrame     = std::clamp(timeFrame, availableStartFrame, availableEndFrame);
 
     if(clampedEndFrame <= availableStartFrame) {
@@ -314,27 +366,6 @@ bool VisualisationBackend::resolveSpectrumWindowEndingAt(WindowRange& out, uint6
     out.startFrame          = clampedEndFrame - windowFrames;
     out.frameCount          = frameCount;
     return true;
-}
-
-uint64_t VisualisationBackend::mappedTimeMs(uint64_t timeMs) const
-{
-    if(!m_timelineFrameOffset.has_value() || !m_format.isValid() || m_format.sampleRate() <= 0) {
-        return timeMs;
-    }
-
-    const int sampleRate      = m_format.sampleRate();
-    const auto timeFrame      = static_cast<int64_t>(msToFrames(timeMs, sampleRate));
-    const int64_t mappedFrame = timeFrame + m_timelineFrameOffset.value();
-    if(mappedFrame < 0) {
-        return timeMs;
-    }
-
-    const auto mappedFrameValue = static_cast<uint64_t>(mappedFrame);
-    if(mappedFrameValue < m_startStreamFrame || mappedFrameValue > m_nextStreamFrame) {
-        return timeMs;
-    }
-
-    return (mappedFrameValue * 1000ULL) / static_cast<uint64_t>(sampleRate);
 }
 
 bool VisualisationBackend::getPcmWindow(VisualisationSession::PcmWindow& out, uint64_t centerTimeMs,
@@ -392,13 +423,12 @@ bool VisualisationBackend::getSpectrumWindowEndingAt(VisualisationSession::Spect
                                                      SpectrumWindowFunction windowFunction) const
 {
     VisualisationSession::PcmWindow window;
-    const int startupFrameCount = std::min(fftSize, 4096);
 
     {
         const std::shared_lock lock{m_mutex};
 
         WindowRange range;
-        if(!resolveSpectrumWindowEndingAt(range, endTimeMs, fftSize, startupFrameCount)) {
+        if(!resolveSpectrumWindowEndingAt(range, endTimeMs, fftSize, MinimumSpectrumFrameCount)) {
             return false;
         }
 
@@ -410,14 +440,26 @@ bool VisualisationBackend::getSpectrumWindowEndingAt(VisualisationSession::Spect
     return fillSpectrumWindow(out, window, selection, windowFunction);
 }
 
+uint64_t VisualisationBackend::mapSourceTimeToVisualTime(uint32_t streamId, uint64_t sourceTimeMs) const
+{
+    if(const auto it = m_sourceTimelines.find(streamId); it != m_sourceTimelines.end()) {
+        return addSignedOffset(sourceTimeMs, it->second.visualTimeOffsetMs);
+    }
+
+    if(m_format.isValid() && m_format.sampleRate() > 0 && m_nextStreamFrame > m_startStreamFrame) {
+        return (m_nextStreamFrame * 1000ULL) / static_cast<uint64_t>(m_format.sampleRate());
+    }
+
+    return sourceTimeMs;
+}
+
 bool VisualisationBackend::fillWindow(VisualisationSession::PcmWindow& out, uint64_t startFrame, int frameCount,
                                       const ChannelSelection& selection) const
 {
     out.format = m_format;
 
-    const auto selectionMode       = selection.mixMode;
-    const bool outputSingleChannel = selectionMode != ChannelSelection::MixMode::AllChannels;
-    if(outputSingleChannel) {
+    const auto selectionMode = selection.mixMode;
+    if(selectionMode != ChannelSelection::MixMode::AllChannels) {
         out.format.setChannelCount(1);
         out.format.clearChannelLayout();
     }
@@ -430,7 +472,7 @@ bool VisualisationBackend::fillWindow(VisualisationSession::PcmWindow& out, uint
 
     const int sourceChannels = m_format.channelCount();
 
-    const auto relativeStart = static_cast<size_t>(startFrame - m_startStreamFrame);
+    const auto relativeStart = startFrame - m_startStreamFrame;
     if(selectionMode == ChannelSelection::MixMode::MonoAverage) {
         for(int frameIndex{0}; frameIndex < frameCount; ++frameIndex) {
             const size_t sourceFrame
@@ -593,12 +635,13 @@ uint64_t VisualisationBackend::msToFrames(uint64_t ms, int sampleRate)
 
 void VisualisationBackend::resetLocked()
 {
-    m_headFrame           = 0;
-    m_frameCount          = 0;
-    m_startStreamFrame    = 0;
-    m_nextStreamFrame     = 0;
-    m_timelineFrameOffset = std::nullopt;
-    m_format              = AudioFormat{SampleFormat::F32, 0, 0};
+    m_headFrame        = 0;
+    m_frameCount       = 0;
+    m_startStreamFrame = 0;
+    m_nextStreamFrame  = 0;
+    m_currentStreamId  = 0;
+    m_format           = AudioFormat{SampleFormat::F32, 0, 0};
+    m_sourceTimelines.clear();
 }
 
 void VisualisationBackend::ensureCapacity(size_t requiredFrames)

--- a/src/core/engine/visualisationbackend.h
+++ b/src/core/engine/visualisationbackend.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -96,6 +97,7 @@ private:
                                      WindowAnchor anchor) const;
     [[nodiscard]] bool resolveSpectrumWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
                                                      int minimumFrameCount) const;
+    [[nodiscard]] uint64_t mappedTimeMs(uint64_t timeMs) const;
     [[nodiscard]] bool fillWindow(VisualisationSession::PcmWindow& out, uint64_t startFrame, int frameCount,
                                   const ChannelSelection& selection) const;
     [[nodiscard]] bool fillSpectrumWindow(VisualisationSession::SpectrumWindow& out,
@@ -118,8 +120,10 @@ private:
     size_t m_frameCount;
     uint64_t m_startStreamFrame;
     uint64_t m_nextStreamFrame;
+    std::optional<int64_t> m_timelineFrameOffset;
 
     std::atomic<uint64_t> m_currentTimeMs;
+    std::atomic_bool m_currentTimePublished;
 
     mutable std::mutex m_fftMutex;
     mutable std::unordered_map<int, Dsp::RealFft> m_fftCache;

--- a/src/core/engine/visualisationbackend.h
+++ b/src/core/engine/visualisationbackend.h
@@ -26,8 +26,8 @@
 #include <core/engine/visualisationservice.h>
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
-#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -48,6 +48,9 @@ public:
     [[nodiscard]] bool hasActiveSessions() const;
 
     void setCurrentTimeMs(uint64_t currentTimeMs);
+    void setCurrentTimeMs(uint32_t streamId, uint64_t currentTimeMs);
+    void setCurrentTimeMs(uint32_t streamId, uint64_t currentTimeMs,
+                          std::chrono::steady_clock::time_point presentationTime);
     [[nodiscard]] uint64_t currentTimeMs() const;
     void setStopped();
 
@@ -97,13 +100,14 @@ private:
                                      WindowAnchor anchor) const;
     [[nodiscard]] bool resolveSpectrumWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
                                                      int minimumFrameCount) const;
-    [[nodiscard]] uint64_t mappedTimeMs(uint64_t timeMs) const;
+    [[nodiscard]] uint64_t mapSourceTimeToVisualTime(uint32_t streamId, uint64_t sourceTimeMs) const;
     [[nodiscard]] bool fillWindow(VisualisationSession::PcmWindow& out, uint64_t startFrame, int frameCount,
                                   const ChannelSelection& selection) const;
     [[nodiscard]] bool fillSpectrumWindow(VisualisationSession::SpectrumWindow& out,
                                           const VisualisationSession::PcmWindow& window,
                                           const ChannelSelection& selection,
                                           SpectrumWindowFunction windowFunction) const;
+
     void resetLocked();
     void ensureCapacity(size_t requiredFrames);
     [[nodiscard]] size_t requestedBacklogFrames(int sampleRate) const;
@@ -120,10 +124,19 @@ private:
     size_t m_frameCount;
     uint64_t m_startStreamFrame;
     uint64_t m_nextStreamFrame;
-    std::optional<int64_t> m_timelineFrameOffset;
+    uint32_t m_currentStreamId;
+
+    struct SourceTimeline
+    {
+        uint64_t nextFrame{0};
+        int64_t visualTimeOffsetMs{0};
+    };
+    std::unordered_map<uint32_t, SourceTimeline> m_sourceTimelines;
 
     std::atomic<uint64_t> m_currentTimeMs;
+    std::atomic<int64_t> m_currentTimeReferenceClockMs;
     std::atomic_bool m_currentTimePublished;
+    std::atomic_bool m_currentTimeHasPresentationClock;
 
     mutable std::mutex m_fftMutex;
     mutable std::unordered_map<int, Dsp::RealFft> m_fftCache;

--- a/src/core/engine/visualisationbackend.h
+++ b/src/core/engine/visualisationbackend.h
@@ -40,16 +40,14 @@ public:
 
     VisualisationBackend();
 
-    [[nodiscard]] SessionToken registerSession();
-    [[nodiscard]] bool unregisterSession(SessionToken token);
+    SessionToken registerSession();
+    bool unregisterSession(SessionToken token);
     void requestBacklog(SessionToken token, uint64_t durationMs);
 
     [[nodiscard]] bool hasActiveSessions() const;
 
     void setCurrentTimeMs(uint64_t currentTimeMs);
     [[nodiscard]] uint64_t currentTimeMs() const;
-    void setPlaying();
-    void setPaused();
     void setStopped();
 
     void appendFrame(const PcmFrame& frame);
@@ -80,9 +78,24 @@ private:
         int frameCount{0};
     };
 
+    struct WindowCacheKey
+    {
+        int fftSize{0};
+        SpectrumWindowFunction function{SpectrumWindowFunction::Hann};
+
+        [[nodiscard]] bool operator==(const WindowCacheKey&) const = default;
+    };
+
+    struct WindowCacheKeyHash
+    {
+        [[nodiscard]] size_t operator()(const WindowCacheKey& key) const;
+    };
+
     [[nodiscard]] static uint64_t msToFrames(uint64_t ms, int sampleRate);
     [[nodiscard]] bool resolveWindow(WindowRange& out, uint64_t timeMs, int requestedFrameCount, int minimumFrameCount,
                                      WindowAnchor anchor) const;
+    [[nodiscard]] bool resolveSpectrumWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
+                                                     int minimumFrameCount) const;
     [[nodiscard]] bool fillWindow(VisualisationSession::PcmWindow& out, uint64_t startFrame, int frameCount,
                                   const ChannelSelection& selection) const;
     [[nodiscard]] bool fillSpectrumWindow(VisualisationSession::SpectrumWindow& out,
@@ -107,10 +120,11 @@ private:
     uint64_t m_nextStreamFrame;
 
     std::atomic<uint64_t> m_currentTimeMs;
-    std::atomic<int64_t> m_timeAnchorNs;
-    std::atomic<bool> m_isPlaying;
 
     mutable std::mutex m_fftMutex;
     mutable std::unordered_map<int, Dsp::RealFft> m_fftCache;
+    mutable std::unordered_map<WindowCacheKey, std::vector<float>, WindowCacheKeyHash> m_windowCache;
+    mutable std::vector<float> m_fftInputScratch;
+    mutable std::vector<float> m_magnitudeScratch;
 };
 } // namespace Fooyin

--- a/src/core/engine/visualisationservice.cpp
+++ b/src/core/engine/visualisationservice.cpp
@@ -42,7 +42,7 @@ public:
     ~VisualisationSessionPrivate()
     {
         if(backend && token != 0) {
-            (void)backend->unregisterSession(token);
+            backend->unregisterSession(token);
         }
         if(service) {
             Q_EMIT service->sessionActivityChanged();

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/expandingcombobox.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/extendabletableview.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/fontbutton.h
+    ${CMAKE_SOURCE_DIR}/include/gui/widgets/gradienteditor.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/lineediteditor.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/metadatacompleter.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/multilinedelegate.h
@@ -486,6 +487,7 @@ set(SOURCES
     widgets/expandingcombobox.cpp
     widgets/extendabletableview.cpp
     widgets/fontbutton.cpp
+    widgets/gradienteditor.cpp
     widgets/hovermenu.cpp
     widgets/hovermenu.h
     widgets/lineediteditor.cpp

--- a/src/gui/widgets/colourbutton.cpp
+++ b/src/gui/widgets/colourbutton.cpp
@@ -52,8 +52,12 @@ bool ColourButton::colourChanged() const
 
 void ColourButton::setColour(const QColor& colour)
 {
-    m_colour = colour;
+    if(std::exchange(m_colour, colour) == colour) {
+        return;
+    }
+
     update();
+    Q_EMIT colourUpdated(m_colour);
 }
 
 void ColourButton::mousePressEvent(QMouseEvent* event)

--- a/src/gui/widgets/gradienteditor.cpp
+++ b/src/gui/widgets/gradienteditor.cpp
@@ -1,0 +1,292 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gui/widgets/gradienteditor.h>
+
+#include <gui/widgets/colourbutton.h>
+
+#include <QComboBox>
+#include <QFrame>
+#include <QGradient>
+#include <QHBoxLayout>
+#include <QLinearGradient>
+#include <QPainter>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QSizePolicy>
+#include <QVBoxLayout>
+
+constexpr auto PreviewWidth  = 36;
+constexpr auto PreviewHeight = 120;
+constexpr auto MinStopHeight = 20;
+
+namespace Fooyin {
+void setGradientColours(QGradient& gradient, const std::vector<QColor>& colours)
+{
+    if(colours.empty()) {
+        gradient.setColorAt(0.0, Qt::transparent);
+        gradient.setColorAt(1.0, Qt::transparent);
+        return;
+    }
+    if(colours.size() == 1) {
+        gradient.setColorAt(0.0, colours.front());
+        gradient.setColorAt(1.0, colours.front());
+        return;
+    }
+
+    const double step = 1.0 / static_cast<double>(colours.size() - 1);
+
+    for(qsizetype index{0}; std::cmp_less(index, colours.size()); ++index) {
+        gradient.setColorAt(static_cast<double>(index) * step, colours.at(index));
+    }
+}
+
+QLinearGradient linearGradient(const QRectF& rect, Qt::Orientation orientation, const std::vector<QColor>& colours)
+{
+    QLinearGradient gradient = orientation == Qt::Vertical ? QLinearGradient{0.0, rect.top(), 0.0, rect.bottom()}
+                                                           : QLinearGradient{rect.left(), 0.0, rect.right(), 0.0};
+    setGradientColours(gradient, colours);
+    return gradient;
+}
+
+class GradientEditorPreview : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit GradientEditorPreview(QWidget* parent = nullptr)
+        : QWidget{parent}
+    {
+        setFixedWidth(PreviewWidth);
+        setMinimumHeight(PreviewHeight);
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    }
+
+    void setColours(const std::vector<QColor>& colours)
+    {
+        m_colours = colours;
+        update();
+    }
+
+    void setOrientation(Qt::Orientation orientation)
+    {
+        m_orientation = orientation;
+        update();
+    }
+
+protected:
+    void paintEvent(QPaintEvent* event) override
+    {
+        QWidget::paintEvent(event);
+
+        QPainter painter{this};
+        const QRectF bounds = rect().adjusted(1, 1, -1, -1);
+        painter.fillRect(bounds, linearGradient(bounds, m_orientation, m_colours));
+        painter.setPen(palette().mid().color());
+        painter.drawRect(rect().adjusted(0, 0, -1, -1));
+    }
+
+private:
+    std::vector<QColor> m_colours;
+    Qt::Orientation m_orientation{Qt::Vertical};
+};
+
+class GradientEditorPrivate
+{
+public:
+    explicit GradientEditorPrivate(GradientEditor* self)
+        : m_self{self}
+        , m_coloursWidget{new QWidget(m_self)}
+        , m_coloursLayout{new QVBoxLayout()}
+        , m_coloursScroll{new QScrollArea(m_self)}
+        , m_preview{new GradientEditorPreview(m_self)}
+        , m_orientation{new QComboBox(m_self)}
+    {
+        m_coloursWidget->setLayout(m_coloursLayout);
+        m_coloursLayout->setContentsMargins({});
+
+        m_coloursScroll->setWidget(m_coloursWidget);
+        m_coloursScroll->setWidgetResizable(true);
+        m_coloursScroll->setFrameShape(QFrame::NoFrame);
+        m_coloursScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        m_coloursScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        m_coloursScroll->setMinimumHeight(PreviewHeight);
+        m_coloursScroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+        m_orientation->addItem(GradientEditor::tr("Vertical"), static_cast<int>(Qt::Vertical));
+        m_orientation->addItem(GradientEditor::tr("Horizontal"), static_cast<int>(Qt::Horizontal));
+        m_orientation->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    }
+
+    void addColour(const QColor& colour)
+    {
+        if(colour.isValid()) {
+            m_colours.emplace_back(colour);
+        }
+        else {
+            m_colours.emplace_back(!m_colours.empty() ? m_colours.back() : m_self->palette().highlight().color());
+        }
+
+        rebuildColourButtons();
+        updatePreview();
+        Q_EMIT m_self->coloursChanged();
+    }
+
+    void removeColour()
+    {
+        if(m_colours.size() <= 1) {
+            return;
+        }
+
+        m_colours.pop_back();
+        rebuildColourButtons();
+        updatePreview();
+        Q_EMIT m_self->coloursChanged();
+    }
+
+    void reverseColours()
+    {
+        std::ranges::reverse(m_colours);
+        rebuildColourButtons();
+        updatePreview();
+        Q_EMIT m_self->coloursChanged();
+    }
+
+    void rebuildColourButtons()
+    {
+        m_coloursWidget->setMinimumHeight(0);
+
+        while(const auto* item = m_coloursLayout->takeAt(0)) {
+            if(QWidget* widget = item->widget()) {
+                widget->deleteLater();
+            }
+            delete item;
+        }
+
+        for(qsizetype index{0}; std::cmp_less(index, m_colours.size()); ++index) {
+            auto* button = new ColourButton(m_colours.at(index), m_coloursWidget);
+            button->setMinimumHeight(MinStopHeight);
+            button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            m_coloursLayout->addWidget(button, 1);
+
+            QObject::connect(button, &ColourButton::colourUpdated, m_self, [this, button, index]() {
+                m_colours[index] = button->colour();
+                updatePreview();
+                Q_EMIT m_self->coloursChanged();
+            });
+        }
+
+        const auto stopCount    = static_cast<int>(m_colours.size());
+        const int spacing       = stopCount > 1 ? m_coloursLayout->spacing() * (stopCount - 1) : 0;
+        const int contentHeight = (stopCount * MinStopHeight) + spacing;
+        m_coloursWidget->setMinimumHeight(std::max(PreviewHeight, contentHeight));
+    }
+
+    void updatePreview() const
+    {
+        m_preview->setColours(m_colours);
+    }
+
+    [[nodiscard]] Qt::Orientation orientation() const
+    {
+        return static_cast<Qt::Orientation>(m_orientation->currentData().toInt());
+    }
+
+    void setOrientation(Qt::Orientation orientation)
+    {
+        const int index = m_orientation->findData(static_cast<int>(orientation));
+        m_orientation->setCurrentIndex(index >= 0 ? index : m_orientation->findData(static_cast<int>(Qt::Vertical)));
+    }
+
+    GradientEditor* m_self;
+
+    std::vector<QColor> m_colours;
+    QWidget* m_coloursWidget;
+    QVBoxLayout* m_coloursLayout;
+    QScrollArea* m_coloursScroll;
+    GradientEditorPreview* m_preview;
+    QComboBox* m_orientation;
+};
+
+GradientEditor::GradientEditor(QWidget* parent)
+    : QWidget{parent}
+    , p{std::make_unique<GradientEditorPrivate>(this)}
+{
+    auto* addButton     = new QPushButton(tr("Add"), this);
+    auto* removeButton  = new QPushButton(tr("Remove"), this);
+    auto* reverseButton = new QPushButton(tr("Reverse"), this);
+
+    auto* buttonLayout = new QVBoxLayout();
+    buttonLayout->addWidget(addButton);
+    buttonLayout->addWidget(removeButton);
+    buttonLayout->addWidget(reverseButton);
+    buttonLayout->addWidget(p->m_orientation, 0, Qt::AlignBottom);
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins({});
+    layout->addWidget(p->m_preview);
+    layout->addWidget(p->m_coloursScroll);
+    layout->addLayout(buttonLayout);
+
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+
+    QObject::connect(addButton, &QPushButton::clicked, this, [this]() { p->addColour({}); });
+    QObject::connect(removeButton, &QPushButton::clicked, this, [this]() { p->removeColour(); });
+    QObject::connect(reverseButton, &QPushButton::clicked, this, [this]() { p->reverseColours(); });
+    QObject::connect(p->m_orientation, &QComboBox::currentIndexChanged, this, [this]() {
+        const Qt::Orientation orientation = p->orientation();
+        p->m_preview->setOrientation(orientation);
+        Q_EMIT orientationChanged(orientation);
+    });
+}
+
+GradientEditor::~GradientEditor() = default;
+
+std::vector<QColor> GradientEditor::colours() const
+{
+    return p->m_colours;
+}
+
+void GradientEditor::setColours(const std::vector<QColor>& colours)
+{
+    p->m_colours.clear();
+
+    for(const QColor& colour : colours) {
+        if(colour.isValid()) {
+            p->m_colours.emplace_back(colour);
+        }
+    }
+
+    p->rebuildColourButtons();
+    p->updatePreview();
+}
+
+Qt::Orientation GradientEditor::orientation() const
+{
+    return p->orientation();
+}
+
+void GradientEditor::setOrientation(Qt::Orientation orientation)
+{
+    p->setOrientation(orientation);
+}
+} // namespace Fooyin
+
+#include "gui/widgets/gradienteditor.moc"
+#include "gui/widgets/moc_gradienteditor.cpp"

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
     scrobbler
     sdl
     sndfile
+    spectrum
     soundtouch
     soxresampler
     tageditor
@@ -47,6 +48,7 @@ set(
     scrobbler
     sdl
     sndfile
+    spectrum
     soundtouch
     soxresampler
     tageditor
@@ -110,6 +112,7 @@ fooyin_add_selected_plugin(rgscanner)
 fooyin_add_selected_plugin(sdl)
 fooyin_add_selected_plugin(scrobbler)
 fooyin_add_selected_plugin(sndfile)
+fooyin_add_selected_plugin(spectrum)
 fooyin_add_selected_plugin(tageditor)
 fooyin_add_selected_plugin(soundtouch)
 fooyin_add_selected_plugin(soxresampler)

--- a/src/plugins/spectrum/CMakeLists.txt
+++ b/src/plugins/spectrum/CMakeLists.txt
@@ -1,0 +1,16 @@
+create_fooyin_plugin_internal(
+    spectrum
+    DEPENDS Fooyin::Gui
+    SOURCES spectrumaxisrenderer.cpp
+            spectrumaxisrenderer.h
+            spectrumcolours.h
+            spectrumconfigwidget.cpp
+            spectrumconfigwidget.h
+            spectrumplugin.cpp
+            spectrumplugin.h
+            spectrumsettings.h
+            spectrumview.cpp
+            spectrumview.h
+            spectrumwidget.cpp
+            spectrumwidget.h
+)

--- a/src/plugins/spectrum/spectrum.json.in
+++ b/src/plugins/spectrum/spectrum.json.in
@@ -1,0 +1,15 @@
+{
+    "Name" : "Spectrum",
+    "Version" : "${FOOYIN_VERSION}",
+    "Author" : "fooyin",
+    "Copyright" : "Copyright © 2026, Luke Taylor <luket@pm.me>",
+    "License" : [ "Fooyin is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
+                  "",
+                  "Fooyin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.",
+                  "",
+                  "You should have received a copy of the GNU General Public License along with Fooyin.  If not, see <http://www.gnu.org/licenses/>"
+                ],
+    "Category" : "Widgets",
+    "Description" : "Adds spectrum visualisations",
+    "Url" : "https://github.com/ludouzi/fooyin"
+}

--- a/src/plugins/spectrum/spectrumaxisrenderer.cpp
+++ b/src/plugins/spectrum/spectrumaxisrenderer.cpp
@@ -1,0 +1,691 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "spectrumaxisrenderer.h"
+
+#include "spectrumcolours.h"
+
+#include <QFont>
+#include <QFontMetrics>
+#include <QPainter>
+#include <QPalette>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <utility>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto LabelPadding                   = 6;
+constexpr auto GridLineCount                  = 6;
+constexpr auto PlotHeadroomPx                 = 12;
+constexpr auto A4NoteIndex                    = 57;
+constexpr auto HighestHorizontalLabelPriority = 2;
+
+namespace Fooyin::Spectrum {
+namespace {
+QString noteNameForSemitone(int semitone)
+{
+    static constexpr std::array<const char*, 12> NoteNames
+        = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+    return QString::fromLatin1(NoteNames[std::clamp(semitone, 0, 11)]);
+}
+
+bool isFullStep(int semitone)
+{
+    switch(semitone) {
+        case 0:
+        case 2:
+        case 4:
+        case 5:
+        case 7:
+        case 9:
+        case 11:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool isBlackKey(int semitone)
+{
+    return !isFullStep(semitone);
+}
+
+int equalSectionPlotHeight(int height, int sectionCount, int spacing)
+{
+    sectionCount = std::max(1, sectionCount);
+    spacing      = std::max(0, spacing);
+
+    while(sectionCount > 1 && (height - (spacing * (sectionCount - 1))) < sectionCount) {
+        --sectionCount;
+    }
+
+    if(sectionCount <= 1) {
+        return height;
+    }
+
+    const int sectionHeight = std::max(1, (height - (spacing * (sectionCount - 1))) / sectionCount);
+    return (sectionHeight * sectionCount) + (spacing * (sectionCount - 1));
+}
+
+bool horizontalLabelsFit(const QFontMetrics& metrics, const QRect& spectrumRect,
+                         std::span<const SpectrumHorizontalLabel> labels, int stride)
+{
+    int previousRight = spectrumRect.left() - 1;
+
+    for(int index{0}; std::cmp_less(index, labels.size()); index += stride) {
+        const auto& label = labels[static_cast<size_t>(index)];
+        const int width   = metrics.horizontalAdvance(label.text);
+        const int left = std::clamp(label.centerX - (width / 2), spectrumRect.left(), spectrumRect.right() - width + 1);
+        const int right       = left + width - 1;
+        const int requiredGap = previousRight < spectrumRect.left() ? 0 : LabelPadding;
+
+        if(right > spectrumRect.right() || left <= previousRight + requiredGap) {
+            return false;
+        }
+
+        previousRight = right;
+    }
+
+    return true;
+}
+} // namespace
+
+struct SpectrumAxisRenderer::AmplitudeLabel
+{
+    QString text;
+    int baseline{0};
+};
+
+void SpectrumAxisRenderer::setConfig(const SpectrumWidget::ConfigData& config)
+{
+    m_config = config;
+}
+
+SpectrumPlotGeometry SpectrumAxisRenderer::layout(const QRect& widgetRect, const QFont& axisFont, int bandCount) const
+{
+    SpectrumPlotGeometry geometry;
+    bandCount = std::max(1, bandCount);
+    if(widgetRect.width() <= 0 || widgetRect.height() <= 0 || bandCount <= 0) {
+        return geometry;
+    }
+
+    const QFontMetrics metrics{axisFont};
+    const int labelHeight = metrics.height() + LabelPadding;
+    const int dbWidth     = metrics.horizontalAdvance(u"-120 dB"_s) + LabelPadding;
+
+    const bool requestedAmplitudeLabels  = m_config.showLeftLabels || m_config.showRightLabels;
+    const bool requestedHorizontalLabels = m_config.showTopLabels || m_config.showBottomLabels;
+    geometry.drawAmplitudeLabels         = requestedAmplitudeLabels;
+    bool drawHorizontalLabels            = requestedHorizontalLabels;
+
+    for(int pass{0}; pass < 3; ++pass) {
+        QRect fitRect = widgetRect;
+        fitRect.adjust(m_config.showLeftLabels && geometry.drawAmplitudeLabels ? dbWidth : 0,
+                       m_config.showTopLabels && drawHorizontalLabels ? labelHeight : 0,
+                       m_config.showRightLabels && geometry.drawAmplitudeLabels ? -dbWidth : 0,
+                       m_config.showBottomLabels && drawHorizontalLabels ? -labelHeight : 0);
+        const QRect fitPlotRect = plotRectForSpectrumRect(fitRect);
+
+        const bool drawAmplitudeLabels
+            = requestedAmplitudeLabels && !amplitudeLabels(metrics, widgetRect.height(), fitPlotRect).empty();
+        const bool nextDrawHorizontalLabels
+            = requestedHorizontalLabels
+           && !horizontalLabels(metrics, fitRect, fitPlotRect, bandCount, HighestHorizontalLabelPriority).empty();
+
+        if(drawAmplitudeLabels == geometry.drawAmplitudeLabels && nextDrawHorizontalLabels == drawHorizontalLabels) {
+            break;
+        }
+
+        geometry.drawAmplitudeLabels = drawAmplitudeLabels;
+        drawHorizontalLabels         = nextDrawHorizontalLabels;
+    }
+
+    geometry.spectrumRect = widgetRect;
+    geometry.spectrumRect.adjust(m_config.showLeftLabels && geometry.drawAmplitudeLabels ? dbWidth : 0,
+                                 m_config.showTopLabels && drawHorizontalLabels ? labelHeight : 0,
+                                 m_config.showRightLabels && geometry.drawAmplitudeLabels ? -dbWidth : 0,
+                                 m_config.showBottomLabels && drawHorizontalLabels ? -labelHeight : 0);
+    geometry.plotRect = plotRectForSpectrumRect(geometry.spectrumRect);
+
+    if(geometry.plotRect.width() <= 0 || geometry.plotRect.height() <= 0) {
+        geometry.drawAmplitudeLabels = false;
+        return geometry;
+    }
+
+    SpectrumPlotGeometry barGeometry = barGeometryForPlotRect(geometry.plotRect, bandCount);
+    geometry.barRects                = std::move(barGeometry.barRects);
+    geometry.sourceBands             = std::move(barGeometry.sourceBands);
+    geometry.horizontalLabels = drawHorizontalLabels
+                                  ? horizontalLabels(metrics, geometry.spectrumRect, geometry.plotRect, bandCount,
+                                                     HighestHorizontalLabelPriority)
+                                  : std::vector<SpectrumHorizontalLabel>{};
+    return geometry;
+}
+
+void SpectrumAxisRenderer::paint(QPainter& painter, const SpectrumPlotGeometry& geometry, const QSize& size,
+                                 const QPalette& palette, const QFont& axisFont) const
+{
+    const Colours customColours = m_config.colours.isValid() && m_config.colours.canConvert<Colours>()
+                                    ? m_config.colours.value<Colours>()
+                                    : Colours{};
+    painter.fillRect(QRect{QPoint{0, 0}, size}, customColours.colour(Colours::Type::Background, palette));
+
+    if(geometry.spectrumRect.isEmpty() || geometry.plotRect.isEmpty()) {
+        return;
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setFont(axisFont);
+
+    const QColor textColour         = customColours.colour(Colours::Type::Text, palette);
+    const QColor gridColour         = customColours.colour(Colours::Type::HorizontalGrid, palette);
+    const QColor verticalGridColour = m_config.labelMode == LabelMode::Notes
+                                        ? customColours.colour(Colours::Type::OctaveGrid, palette)
+                                        : customColours.colour(Colours::Type::VerticalGrid, palette);
+
+    drawKeyBackgrounds(painter, geometry, palette);
+
+    if(m_config.showHorizontalGrid) {
+        painter.setPen(gridColour);
+        for(int index{0}; index <= GridLineCount; ++index) {
+            const int y
+                = geometry.plotRect.top() + ((geometry.plotRect.height() - 1) * index / std::max(1, GridLineCount));
+            painter.drawLine(geometry.plotRect.left(), y, geometry.plotRect.right(), y);
+        }
+    }
+
+    if(m_config.showVerticalGrid) {
+        painter.setPen(verticalGridColour);
+        if(m_config.labelMode == LabelMode::Notes) {
+            for(int note{m_config.minNote}; note <= m_config.maxNote; ++note) {
+                const int semitone = ((note % 12) + 12) % 12;
+                if(note != m_config.minNote && semitone != 0) {
+                    continue;
+                }
+
+                const int x = noteCenterX(note, geometry.plotRect);
+                painter.drawLine(x, geometry.plotRect.top(), x, geometry.plotRect.bottom());
+            }
+        }
+        else if(!geometry.horizontalLabels.empty()) {
+            for(const auto& label : geometry.horizontalLabels) {
+                painter.drawLine(label.centerX, geometry.plotRect.top(), label.centerX, geometry.plotRect.bottom());
+            }
+        }
+        else {
+            const auto frequencies = verticalGridFrequencies();
+            for(const auto& frequency : frequencies) {
+                const int x = frequencyToX(frequency, geometry.plotRect);
+                painter.drawLine(x, geometry.plotRect.top(), x, geometry.plotRect.bottom());
+            }
+        }
+    }
+
+    const QFontMetrics metrics{painter.font()};
+    painter.setPen(textColour);
+
+    if(!geometry.horizontalLabels.empty()) {
+        for(const auto& label : geometry.horizontalLabels) {
+            const int textWidth = metrics.horizontalAdvance(label.text);
+            const int x         = std::clamp(label.centerX - (textWidth / 2), geometry.spectrumRect.left(),
+                                             geometry.spectrumRect.right() - textWidth + 1);
+
+            if(m_config.showTopLabels) {
+                painter.drawText(x, std::max(metrics.ascent(), geometry.spectrumRect.top() - (LabelPadding / 2)),
+                                 label.text);
+            }
+            if(m_config.showBottomLabels) {
+                painter.drawText(x, geometry.plotRect.bottom() + LabelPadding + metrics.ascent(), label.text);
+            }
+        }
+    }
+
+    if(geometry.drawAmplitudeLabels) {
+        for(const auto& label : amplitudeLabels(metrics, size.height(), geometry.plotRect)) {
+            if(m_config.showLeftLabels) {
+                painter.drawText(0, label.baseline, label.text);
+            }
+            if(m_config.showRightLabels) {
+                painter.drawText(geometry.spectrumRect.right() + LabelPadding, label.baseline, label.text);
+            }
+        }
+    }
+}
+
+QFont SpectrumAxisRenderer::defaultAxisFont(const QFont& baseFont)
+{
+    QFont font{baseFont};
+    if(font.pointSize() > 0) {
+        font.setPointSize(std::max(7, font.pointSize() - 3));
+    }
+    else if(font.pixelSize() > 0) {
+        font.setPixelSize(std::max(7, font.pixelSize() - 3));
+    }
+    return font;
+}
+
+float SpectrumAxisRenderer::effectiveMinFrequencyHz() const
+{
+    if(m_config.labelMode == LabelMode::Notes) {
+        return frequencyForNote(m_config.minNote, m_config.pitchHz, m_config.transpose);
+    }
+    return static_cast<float>(m_config.minFrequencyHz);
+}
+
+float SpectrumAxisRenderer::effectiveMaxFrequencyHz() const
+{
+    if(m_config.labelMode == LabelMode::Notes) {
+        return frequencyForNote(m_config.maxNote, m_config.pitchHz, m_config.transpose);
+    }
+    return static_cast<float>(m_config.maxFrequencyHz);
+}
+
+float SpectrumAxisRenderer::frequencyForBand(int band, int bandCount) const
+{
+    bandCount = std::max(1, bandCount);
+    if(m_config.labelMode == LabelMode::Notes) {
+        const double noteCount = std::max(1, m_config.maxNote - m_config.minNote + 1);
+        const double note      = static_cast<double>(m_config.minNote)
+                               + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
+        return frequencyForNote(static_cast<int>(std::round(note)), m_config.pitchHz, m_config.transpose);
+    }
+
+    const float minFreq = effectiveMinFrequencyHz();
+    const float maxFreq = std::max(minFreq + 1.0F, effectiveMaxFrequencyHz());
+    const double t      = bandCount > 1 ? static_cast<double>(band) / static_cast<double>(bandCount - 1) : 0.0;
+    return minFreq * std::pow(maxFreq / minFreq, static_cast<float>(t));
+}
+
+int SpectrumAxisRenderer::noteForBand(int band, int bandCount) const
+{
+    bandCount              = std::max(1, bandCount);
+    const double noteCount = std::max(1, m_config.maxNote - m_config.minNote + 1);
+    const double note      = static_cast<double>(m_config.minNote)
+                           + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
+    return static_cast<int>(std::round(note));
+}
+
+QString SpectrumAxisRenderer::formatFrequencyLabel(float frequencyHz)
+{
+    if(frequencyHz >= 1000.0F) {
+        const float khz = frequencyHz / 1000.0F;
+        return khz >= 10.0F ? QString::number(std::round(khz)) + u"k"_s : QString::number(khz, 'f', 1) + u"k"_s;
+    }
+
+    return QString::number(std::round(frequencyHz));
+}
+
+QString SpectrumAxisRenderer::formatTooltipFrequency(float frequencyHz)
+{
+    return QString::number(std::round(frequencyHz)) + u" Hz"_s;
+}
+
+QString SpectrumAxisRenderer::formatNoteLabel(int noteIndex)
+{
+    const int octave   = noteIndex / 12;
+    const int semitone = ((noteIndex % 12) + 12) % 12;
+    return noteNameForSemitone(semitone) + QString::number(octave);
+}
+
+float SpectrumAxisRenderer::frequencyForNote(int noteIndex, int pitchHz, int transpose)
+{
+    return static_cast<float>(pitchHz)
+         * std::pow(2.0F, (static_cast<float>(noteIndex) - static_cast<float>(A4NoteIndex + transpose)) / 12.0F);
+}
+
+int SpectrumAxisRenderer::noteCenterX(int note, const QRect& plotRect) const
+{
+    const int startNote    = m_config.minNote;
+    const int endNote      = m_config.maxNote;
+    const int noteCount    = std::max(1, endNote - startNote + 1);
+    const double noteWidth = static_cast<double>(plotRect.width()) / static_cast<double>(noteCount);
+    const double center
+        = static_cast<double>(plotRect.left()) + ((static_cast<double>(note - startNote) + 0.5) * noteWidth);
+    return std::clamp(static_cast<int>(std::round(center)), plotRect.left(), plotRect.right());
+}
+
+int SpectrumAxisRenderer::frequencyToX(float frequencyHz, const QRect& plotRect) const
+{
+    if(plotRect.width() <= 0) {
+        return 0;
+    }
+
+    const float minFreq  = effectiveMinFrequencyHz();
+    const float maxFreq  = std::max(minFreq + 1.0F, effectiveMaxFrequencyHz());
+    const float clamped  = std::clamp(frequencyHz, minFreq, maxFreq);
+    const float position = (std::log(clamped) - std::log(minFreq)) / (std::log(maxFreq) - std::log(minFreq));
+    return plotRect.left()
+         + static_cast<int>(std::round(position * static_cast<float>(std::max(0, plotRect.width() - 1))));
+}
+
+std::vector<float> SpectrumAxisRenderer::verticalGridFrequencies() const
+{
+    const float minFreq = effectiveMinFrequencyHz();
+    const float maxFreq = std::max(minFreq + 1.0F, effectiveMaxFrequencyHz());
+
+    static constexpr std::array FrequencyMarkers
+        = {20.0F, 31.25F, 62.5F, 125.0F, 250.0F, 500.0F, 1000.0F, 2000.0F, 4000.0F, 8000.0F, 16000.0F, 20000.0F};
+    std::vector<float> markers;
+    markers.reserve(FrequencyMarkers.size());
+    for(const float frequencyHz : FrequencyMarkers) {
+        if(frequencyHz >= minFreq && frequencyHz <= maxFreq) {
+            markers.emplace_back(frequencyHz);
+        }
+    }
+
+    return markers;
+}
+
+QRect SpectrumAxisRenderer::plotRectForSpectrumRect(const QRect& spectrumRect) const
+{
+    QRect plotRect = spectrumRect.adjusted(0, PlotHeadroomPx, 0, 0);
+    if(plotRect.width() <= 0 || plotRect.height() <= 0) {
+        return plotRect;
+    }
+
+    const int plotHeight
+        = equalSectionPlotHeight(plotRect.height(), std::clamp(m_config.barSections, MinBarSections, MaxBarSections),
+                                 std::clamp(m_config.sectionSpacing, MinSectionSpacing, MaxSectionSpacing));
+    if(plotHeight < plotRect.height()) {
+        plotRect.setTop(plotRect.bottom() - plotHeight + 1);
+    }
+
+    return plotRect;
+}
+
+SpectrumPlotGeometry SpectrumAxisRenderer::barGeometryForPlotRect(const QRect& plotRect, int bandCount) const
+{
+    SpectrumPlotGeometry geometry;
+    if(plotRect.width() <= 0 || plotRect.height() <= 0 || bandCount <= 0) {
+        return geometry;
+    }
+
+    if(m_config.labelMode == LabelMode::Notes) {
+        const int visibleBarCount = std::max(1, bandCount);
+        const double noteWidth    = static_cast<double>(plotRect.width()) / static_cast<double>(visibleBarCount);
+        const int gap = (noteWidth <= 1.0) ? 0
+                                           : std::min(std::clamp(m_config.barSpacing, MinBarSpacing, MaxBarSpacing),
+                                                      static_cast<int>(std::floor(noteWidth - 1.0)));
+        geometry.barRects.reserve(visibleBarCount);
+        geometry.sourceBands.reserve(visibleBarCount);
+
+        for(int index{0}; index < visibleBarCount; ++index) {
+            const double cellLeft = static_cast<double>(plotRect.left()) + (static_cast<double>(index) * noteWidth);
+            const double cellRight
+                = static_cast<double>(plotRect.left()) + (static_cast<double>(index + 1) * noteWidth);
+            const double x     = cellLeft + (static_cast<double>(gap) / 2.0);
+            const double width = std::max(1.0, (cellRight - cellLeft) - static_cast<double>(gap));
+            geometry.barRects.emplace_back(x, static_cast<double>(plotRect.top()), width,
+                                           static_cast<double>(plotRect.height()));
+            geometry.sourceBands.emplace_back(index);
+        }
+
+        return geometry;
+    }
+
+    const int requestedBarCount = std::clamp(bandCount, 1, std::max(1, plotRect.width()));
+    int gap                     = std::clamp(m_config.barSpacing, MinBarSpacing, MaxBarSpacing);
+    if((requestedBarCount + (gap * std::max(0, requestedBarCount - 1))) > plotRect.width()) {
+        gap = 0;
+    }
+
+    const auto desiredCellWidth = static_cast<double>(plotRect.width()) / static_cast<double>(requestedBarCount);
+    const int cellWidth         = std::max(gap + 1, static_cast<int>(std::round(desiredCellWidth)));
+    const int visibleBarCount   = std::clamp(plotRect.width() / cellWidth, 1, std::max(1, plotRect.width()));
+    const int barWidth          = std::max(1, cellWidth - gap);
+    const int usedWidth         = ((visibleBarCount - 1) * cellWidth) + barWidth;
+    const int left              = plotRect.left() + (std::max(0, plotRect.width() - usedWidth) / 2);
+    geometry.barRects.reserve(visibleBarCount);
+    geometry.sourceBands.reserve(visibleBarCount);
+    if(visibleBarCount == 1) {
+        geometry.barRects.emplace_back(plotRect);
+        geometry.sourceBands.emplace_back(0);
+        return geometry;
+    }
+
+    for(int index{0}; index < visibleBarCount; ++index) {
+        const int x = left + (index * (barWidth + gap));
+        geometry.barRects.emplace_back(static_cast<double>(x), static_cast<double>(plotRect.top()),
+                                       static_cast<double>(barWidth), static_cast<double>(plotRect.height()));
+        const double sourcePosition = static_cast<double>(index) * static_cast<double>(bandCount - 1)
+                                    / static_cast<double>(visibleBarCount - 1);
+        geometry.sourceBands.emplace_back(std::clamp(static_cast<int>(std::round(sourcePosition)), 0, bandCount - 1));
+    }
+
+    return geometry;
+}
+
+std::vector<SpectrumHorizontalLabel>
+SpectrumAxisRenderer::horizontalLabelCandidates(const SpectrumPlotGeometry& geometry, const QRect& plotRect,
+                                                int bandCount, int maxPriority) const
+{
+    std::vector<SpectrumHorizontalLabel> labels;
+
+    if(m_config.labelMode == LabelMode::Notes) {
+        const int startNote = m_config.minNote;
+        const int endNote   = m_config.maxNote;
+        const int noteCount = std::max(1, endNote - startNote + 1);
+        labels.reserve(static_cast<size_t>(noteCount));
+
+        for(int note = startNote; note <= endNote; ++note) {
+            const int semitone = ((note % 12) + 12) % 12;
+            QString text;
+            int priority{0};
+            if(note == m_config.minNote || semitone == 0) {
+                text = formatNoteLabel(note);
+            }
+            else if(isFullStep(semitone)) {
+                text     = noteNameForSemitone(semitone);
+                priority = 1;
+            }
+            else {
+                text     = noteNameForSemitone(semitone);
+                priority = 2;
+            }
+            if(!text.isEmpty() && priority <= maxPriority) {
+                labels.push_back({.text = text, .centerX = noteCenterX(note, plotRect)});
+            }
+        }
+
+        return labels;
+    }
+
+    const auto count = static_cast<int>(std::min(geometry.barRects.size(), geometry.sourceBands.size()));
+    labels.reserve(static_cast<size_t>(count));
+
+    for(int index{0}; index < count; ++index) {
+        const int band     = geometry.sourceBands[index];
+        const QString text = formatFrequencyLabel(frequencyForBand(band, bandCount));
+
+        if(!text.isEmpty()) {
+            labels.push_back(
+                {.text = text, .centerX = static_cast<int>(std::round(geometry.barRects[index].center().x()))});
+        }
+    }
+
+    return labels;
+}
+
+std::vector<SpectrumHorizontalLabel> SpectrumAxisRenderer::horizontalLabels(const QFontMetrics& metrics,
+                                                                            const QRect& spectrumRect,
+                                                                            const QRect& plotRect, int bandCount,
+                                                                            int maxPriority) const
+{
+    const SpectrumPlotGeometry geometry = barGeometryForPlotRect(plotRect, bandCount);
+    if(geometry.barRects.empty() || geometry.sourceBands.empty()) {
+        return {};
+    }
+
+    if(m_config.labelMode == LabelMode::Notes) {
+        for(int priority = maxPriority; priority >= 0; --priority) {
+            const std::vector<SpectrumHorizontalLabel> candidates
+                = horizontalLabelCandidates(geometry, plotRect, bandCount, priority);
+            if(!candidates.empty() && horizontalLabelsFit(metrics, spectrumRect, candidates, 1)) {
+                return candidates;
+            }
+        }
+
+        const std::vector<SpectrumHorizontalLabel> octaveCandidates
+            = horizontalLabelCandidates(geometry, plotRect, bandCount, 0);
+        for(int stride{2}; std::cmp_less_equal(stride, octaveCandidates.size()); ++stride) {
+            if(!horizontalLabelsFit(metrics, spectrumRect, octaveCandidates, stride)) {
+                continue;
+            }
+
+            std::vector<SpectrumHorizontalLabel> labels;
+            labels.reserve((octaveCandidates.size() + static_cast<size_t>(stride) - 1) / static_cast<size_t>(stride));
+            for(int index{0}; std::cmp_less(index, octaveCandidates.size()); index += stride) {
+                labels.push_back(octaveCandidates[static_cast<size_t>(index)]);
+            }
+            return labels;
+        }
+
+        return {};
+    }
+
+    while(maxPriority >= 0) {
+        const std::vector<SpectrumHorizontalLabel> candidates
+            = horizontalLabelCandidates(geometry, plotRect, bandCount, maxPriority);
+        if(candidates.empty()) {
+            --maxPriority;
+            continue;
+        }
+
+        for(int stride{1}; std::cmp_less_equal(stride, candidates.size()); ++stride) {
+            for(int offset{0}; offset < stride; ++offset) {
+                const std::span offsetCandidates{candidates.data() + offset,
+                                                 candidates.size() - static_cast<size_t>(offset)};
+                if(!horizontalLabelsFit(metrics, spectrumRect, offsetCandidates, stride)) {
+                    continue;
+                }
+
+                std::vector<SpectrumHorizontalLabel> labels;
+                labels.reserve((offsetCandidates.size() + static_cast<size_t>(stride) - 1)
+                               / static_cast<size_t>(stride));
+                for(int index{0}; std::cmp_less(index, offsetCandidates.size()); index += stride) {
+                    labels.push_back(offsetCandidates[static_cast<size_t>(index)]);
+                }
+                return labels;
+            }
+        }
+
+        --maxPriority;
+    }
+
+    return {};
+}
+
+std::vector<SpectrumAxisRenderer::AmplitudeLabel>
+SpectrumAxisRenderer::amplitudeLabels(const QFontMetrics& metrics, int height, const QRect& plotRect) const
+{
+    if(height <= 0 || plotRect.isEmpty()) {
+        return {};
+    }
+
+    std::vector<AmplitudeLabel> labels;
+    labels.reserve(GridLineCount + 1);
+
+    int previousBottom{-1};
+
+    const int minBaseline = metrics.ascent();
+    const int maxBaseline = height - metrics.descent();
+    if(maxBaseline < minBaseline) {
+        return {};
+    }
+
+    for(int index{0}; index <= GridLineCount; ++index) {
+        const float t     = static_cast<float>(index) / static_cast<float>(std::max(1, GridLineCount));
+        const int dbValue = static_cast<int>(
+            std::round(static_cast<float>(m_config.amplitudeMaxDb)
+                       - (static_cast<float>(m_config.amplitudeMaxDb - m_config.amplitudeMinDb) * t)));
+        const int gridY    = plotRect.top() + ((plotRect.height() - 1) * index / std::max(1, GridLineCount));
+        const int baseline = std::clamp(gridY + ((metrics.ascent() - metrics.descent()) / 2), minBaseline, maxBaseline);
+        const int top      = baseline - metrics.ascent();
+        const int bottom   = baseline + metrics.descent();
+        if(top <= previousBottom || top < 0 || bottom > height) {
+            return {};
+        }
+
+        labels.push_back({.text = QString::number(dbValue) + u" dB"_s, .baseline = baseline});
+        previousBottom = bottom;
+    }
+
+    return labels;
+}
+
+void SpectrumAxisRenderer::drawKeyBackgrounds(QPainter& painter, const SpectrumPlotGeometry& geometry,
+                                              const QPalette& palette) const
+{
+    if(m_config.labelMode != LabelMode::Notes || geometry.plotRect.isEmpty()) {
+        return;
+    }
+
+    const bool showWhiteKeys = m_config.showWhiteKeys;
+    const bool showBlackKeys = m_config.showBlackKeys;
+    if(!showWhiteKeys && !showBlackKeys) {
+        return;
+    }
+
+    const Colours customColours  = m_config.colours.isValid() && m_config.colours.canConvert<Colours>()
+                                     ? m_config.colours.value<Colours>()
+                                     : Colours{};
+    const QColor whiteKeyColour  = customColours.colour(Colours::Type::WhiteKey, palette);
+    const QColor blackKeyColour  = customColours.colour(Colours::Type::BlackKey, palette);
+    const QColor separatorColour = customColours.colour(Colours::Type::Background, palette).darker(130);
+
+    const int startNote    = m_config.minNote;
+    const int endNote      = m_config.maxNote;
+    const int noteCount    = std::max(1, endNote - startNote + 1);
+    const double noteWidth = static_cast<double>(geometry.plotRect.width()) / static_cast<double>(noteCount);
+    const int top          = geometry.spectrumRect.top();
+
+    const QRect keyRect{geometry.plotRect.left(), top, geometry.plotRect.width(), geometry.plotRect.bottom() - top + 1};
+    if(keyRect.isEmpty()) {
+        return;
+    }
+
+    for(int note = startNote; note <= endNote; ++note) {
+        const int semitone = ((note % 12) + 12) % 12;
+        const bool black   = isBlackKey(semitone);
+        if((black && !showBlackKeys) || (!black && !showWhiteKeys)) {
+            continue;
+        }
+
+        const double left
+            = static_cast<double>(geometry.plotRect.left()) + (static_cast<double>(note - startNote) * noteWidth);
+        const double right
+            = static_cast<double>(geometry.plotRect.left()) + (static_cast<double>(note - startNote + 1) * noteWidth);
+        const QRectF rect{left, static_cast<double>(keyRect.top()), std::max(1.0, right - left),
+                          static_cast<double>(keyRect.height())};
+        painter.fillRect(rect, black ? blackKeyColour : whiteKeyColour);
+    }
+
+    if(noteWidth > 2.0) {
+        painter.setPen(separatorColour);
+        for(int note = startNote + 1; note <= endNote; ++note) {
+            const int x = geometry.plotRect.left()
+                        + static_cast<int>(std::round(static_cast<double>(note - startNote) * noteWidth));
+            painter.drawLine(x, keyRect.top(), x, keyRect.bottom());
+        }
+    }
+}
+} // namespace Fooyin::Spectrum

--- a/src/plugins/spectrum/spectrumaxisrenderer.cpp
+++ b/src/plugins/spectrum/spectrumaxisrenderer.cpp
@@ -69,6 +69,21 @@ bool isBlackKey(int semitone)
     return !isFullStep(semitone);
 }
 
+int noteEdgeX(const QRect& plotRect, int noteIndex, int noteCount)
+{
+    noteCount = std::max(1, noteCount);
+    return plotRect.left()
+         + static_cast<int>(std::round(static_cast<double>(noteIndex) * static_cast<double>(plotRect.width())
+                                       / static_cast<double>(noteCount)));
+}
+
+QRect noteCellRect(const QRect& rect, int noteIndex, int noteCount)
+{
+    const int left  = noteEdgeX(rect, noteIndex, noteCount);
+    const int right = noteEdgeX(rect, noteIndex + 1, noteCount);
+    return {left, rect.top(), std::max(1, right - left), rect.height()};
+}
+
 int equalSectionPlotHeight(int height, int sectionCount, int spacing)
 {
     sectionCount = std::max(1, sectionCount);
@@ -304,8 +319,10 @@ float SpectrumAxisRenderer::frequencyForBand(int band, int bandCount) const
     bandCount = std::max(1, bandCount);
     if(m_config.labelMode == LabelMode::Notes) {
         const double noteCount = std::max(1, m_config.maxNote - m_config.minNote + 1);
-        const double note      = static_cast<double>(m_config.minNote)
-                               + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
+        const double note = bandCount == static_cast<int>(noteCount)
+                              ? static_cast<double>(m_config.minNote + band)
+                              : static_cast<double>(m_config.minNote)
+                                    + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
         return frequencyForNote(static_cast<int>(std::round(note)), m_config.pitchHz, m_config.transpose);
     }
 
@@ -319,8 +336,10 @@ int SpectrumAxisRenderer::noteForBand(int band, int bandCount) const
 {
     bandCount              = std::max(1, bandCount);
     const double noteCount = std::max(1, m_config.maxNote - m_config.minNote + 1);
-    const double note      = static_cast<double>(m_config.minNote)
-                           + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
+    const double note      = bandCount == static_cast<int>(noteCount)
+                               ? static_cast<double>(m_config.minNote + band)
+                               : static_cast<double>(m_config.minNote)
+                                     + ((static_cast<double>(band) + 0.5) * noteCount / static_cast<double>(bandCount));
     return static_cast<int>(std::round(note));
 }
 
@@ -354,13 +373,11 @@ float SpectrumAxisRenderer::frequencyForNote(int noteIndex, int pitchHz, int tra
 
 int SpectrumAxisRenderer::noteCenterX(int note, const QRect& plotRect) const
 {
-    const int startNote    = m_config.minNote;
-    const int endNote      = m_config.maxNote;
-    const int noteCount    = std::max(1, endNote - startNote + 1);
-    const double noteWidth = static_cast<double>(plotRect.width()) / static_cast<double>(noteCount);
-    const double center
-        = static_cast<double>(plotRect.left()) + ((static_cast<double>(note - startNote) + 0.5) * noteWidth);
-    return std::clamp(static_cast<int>(std::round(center)), plotRect.left(), plotRect.right());
+    const int startNote  = m_config.minNote;
+    const int endNote    = m_config.maxNote;
+    const int noteCount  = std::max(1, endNote - startNote + 1);
+    const QRect cellRect = noteCellRect(plotRect, note - startNote, noteCount);
+    return std::clamp(cellRect.center().x(), plotRect.left(), plotRect.right());
 }
 
 int SpectrumAxisRenderer::frequencyToX(float frequencyHz, const QRect& plotRect) const
@@ -429,13 +446,14 @@ SpectrumPlotGeometry SpectrumAxisRenderer::barGeometryForPlotRect(const QRect& p
         geometry.sourceBands.reserve(visibleBarCount);
 
         for(int index{0}; index < visibleBarCount; ++index) {
-            const double cellLeft = static_cast<double>(plotRect.left()) + (static_cast<double>(index) * noteWidth);
-            const double cellRight
-                = static_cast<double>(plotRect.left()) + (static_cast<double>(index + 1) * noteWidth);
-            const double x     = cellLeft + (static_cast<double>(gap) / 2.0);
-            const double width = std::max(1.0, (cellRight - cellLeft) - static_cast<double>(gap));
-            geometry.barRects.emplace_back(x, static_cast<double>(plotRect.top()), width,
-                                           static_cast<double>(plotRect.height()));
+            const QRect cellRect = noteCellRect(plotRect, index, visibleBarCount);
+            const int cellGap    = std::min(gap, std::max(0, cellRect.width() - 1));
+            const int leftGap    = (cellGap + 1) / 2;
+            const int rightGap   = cellGap - leftGap;
+            const int x          = cellRect.left() + leftGap;
+            const int width      = std::max(1, cellRect.width() - leftGap - rightGap);
+            geometry.barRects.emplace_back(static_cast<double>(x), static_cast<double>(plotRect.top()),
+                                           static_cast<double>(width), static_cast<double>(plotRect.height()));
             geometry.sourceBands.emplace_back(index);
         }
 
@@ -670,20 +688,14 @@ void SpectrumAxisRenderer::drawKeyBackgrounds(QPainter& painter, const SpectrumP
             continue;
         }
 
-        const double left
-            = static_cast<double>(geometry.plotRect.left()) + (static_cast<double>(note - startNote) * noteWidth);
-        const double right
-            = static_cast<double>(geometry.plotRect.left()) + (static_cast<double>(note - startNote + 1) * noteWidth);
-        const QRectF rect{left, static_cast<double>(keyRect.top()), std::max(1.0, right - left),
-                          static_cast<double>(keyRect.height())};
+        const QRect rect = noteCellRect(keyRect, note - startNote, noteCount);
         painter.fillRect(rect, black ? blackKeyColour : whiteKeyColour);
     }
 
     if(noteWidth > 2.0) {
         painter.setPen(separatorColour);
         for(int note = startNote + 1; note <= endNote; ++note) {
-            const int x = geometry.plotRect.left()
-                        + static_cast<int>(std::round(static_cast<double>(note - startNote) * noteWidth));
+            const int x = noteEdgeX(geometry.plotRect, note - startNote, noteCount);
             painter.drawLine(x, keyRect.top(), x, keyRect.bottom());
         }
     }

--- a/src/plugins/spectrum/spectrumaxisrenderer.h
+++ b/src/plugins/spectrum/spectrumaxisrenderer.h
@@ -1,0 +1,95 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "spectrumwidget.h"
+
+#include <QRect>
+#include <QRectF>
+#include <QString>
+
+#include <span>
+#include <vector>
+
+class QFont;
+class QFontMetrics;
+class QPainter;
+class QPalette;
+class QSize;
+
+namespace Fooyin::Spectrum {
+struct SpectrumHorizontalLabel
+{
+    QString text;
+    int centerX{0};
+};
+
+struct SpectrumPlotGeometry
+{
+    QRect spectrumRect;
+    QRect plotRect;
+    std::vector<QRectF> barRects;
+    std::vector<int> sourceBands;
+    std::vector<SpectrumHorizontalLabel> horizontalLabels;
+    bool drawAmplitudeLabels{false};
+};
+
+class SpectrumAxisRenderer
+{
+public:
+    void setConfig(const SpectrumWidget::ConfigData& config);
+
+    [[nodiscard]] SpectrumPlotGeometry layout(const QRect& rect, const QFont& axisFont, int bandCount) const;
+    void paint(QPainter& painter, const SpectrumPlotGeometry& geometry, const QSize& size, const QPalette& palette,
+               const QFont& axisFont) const;
+
+    static QFont defaultAxisFont(const QFont& baseFont);
+    [[nodiscard]] float effectiveMinFrequencyHz() const;
+    [[nodiscard]] float effectiveMaxFrequencyHz() const;
+    [[nodiscard]] float frequencyForBand(int band, int bandCount) const;
+    [[nodiscard]] int noteForBand(int band, int bandCount) const;
+
+    [[nodiscard]] static QString formatFrequencyLabel(float frequencyHz);
+    [[nodiscard]] static QString formatTooltipFrequency(float frequencyHz);
+    [[nodiscard]] static QString formatNoteLabel(int noteIndex);
+    [[nodiscard]] static float frequencyForNote(int noteIndex, int pitchHz, int transpose);
+
+private:
+    struct AmplitudeLabel;
+
+    [[nodiscard]] int noteCenterX(int note, const QRect& plotRect) const;
+    [[nodiscard]] int frequencyToX(float frequencyHz, const QRect& plotRect) const;
+    [[nodiscard]] std::vector<float> verticalGridFrequencies() const;
+    [[nodiscard]] QRect plotRectForSpectrumRect(const QRect& spectrumRect) const;
+    [[nodiscard]] SpectrumPlotGeometry barGeometryForPlotRect(const QRect& plotRect, int bandCount) const;
+    [[nodiscard]] std::vector<SpectrumHorizontalLabel> horizontalLabelCandidates(const SpectrumPlotGeometry& geometry,
+                                                                                 const QRect& plotRect, int bandCount,
+                                                                                 int maxPriority) const;
+    [[nodiscard]] std::vector<SpectrumHorizontalLabel> horizontalLabels(const QFontMetrics& metrics,
+                                                                        const QRect& spectrumRect,
+                                                                        const QRect& plotRect, int bandCount,
+                                                                        int maxPriority) const;
+    [[nodiscard]] std::vector<AmplitudeLabel> amplitudeLabels(const QFontMetrics& metrics, int height,
+                                                              const QRect& plotRect) const;
+    void drawKeyBackgrounds(QPainter& painter, const SpectrumPlotGeometry& geometry, const QPalette& palette) const;
+
+    SpectrumWidget::ConfigData m_config;
+};
+} // namespace Fooyin::Spectrum

--- a/src/plugins/spectrum/spectrumcolours.h
+++ b/src/plugins/spectrum/spectrumcolours.h
@@ -1,0 +1,258 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/datastream.h>
+
+#include <QColor>
+#include <QDataStream>
+#include <QList>
+#include <QMetaType>
+#include <QPalette>
+
+namespace Fooyin::Spectrum {
+class Colours
+{
+public:
+    static constexpr qint32 Magic   = 0x5350434F;
+    static constexpr qint32 Version = 1;
+
+    enum class Type : uint8_t
+    {
+        Background = 0,
+        BarGradient,
+        Peaks,
+        Text,
+        HorizontalGrid,
+        VerticalGrid,
+        OctaveGrid,
+        WhiteKey,
+        BlackKey
+    };
+
+    void setColour(Type type, const QColor& colour)
+    {
+        switch(type) {
+            case Type::Background:
+                m_background = colour;
+                break;
+            case Type::BarGradient:
+                setGradient({colour});
+                break;
+            case Type::Peaks:
+                m_peaks = colour;
+                break;
+            case Type::Text:
+                m_text = colour;
+                break;
+            case Type::HorizontalGrid:
+                m_horizontalGrid = colour;
+                break;
+            case Type::VerticalGrid:
+                m_verticalGrid = colour;
+                break;
+            case Type::OctaveGrid:
+                m_octaveGrid = colour;
+                break;
+            case Type::WhiteKey:
+                m_whiteKey = colour;
+                break;
+            case Type::BlackKey:
+                m_blackKey = colour;
+                break;
+        }
+    }
+
+    void setGradient(const std::vector<QColor>& colours)
+    {
+        m_barGradient.clear();
+        for(const QColor& colour : colours) {
+            if(colour.isValid()) {
+                m_barGradient.push_back(colour);
+            }
+        }
+    }
+
+    static std::vector<QColor> defaultGradient(const QPalette& palette)
+    {
+        const QColor highlight       = palette.color(QPalette::Active, QPalette::Highlight);
+        const QColor highlightedText = palette.color(QPalette::Active, QPalette::HighlightedText);
+        const QColor window          = palette.color(QPalette::Active, QPalette::Window);
+        QColor low                   = blendColours(highlight, window, 0.55);
+        low.setAlpha(210);
+
+        return {blendColours(highlight, highlightedText, 0.25), highlight, low};
+    }
+
+    [[nodiscard]] std::vector<QColor> gradient(const QPalette& palette) const
+    {
+        return m_barGradient.empty() ? defaultGradient(palette) : m_barGradient;
+    }
+
+    [[nodiscard]] const std::vector<QColor>& customGradient() const
+    {
+        return m_barGradient;
+    }
+
+    [[nodiscard]] QColor customColour(Type type) const
+    {
+        switch(type) {
+            case Type::Background:
+                return m_background;
+            case Type::BarGradient:
+                return m_barGradient.empty() ? QColor{} : m_barGradient.front();
+            case Type::Peaks:
+                return m_peaks;
+            case Type::Text:
+                return m_text;
+            case Type::HorizontalGrid:
+                return m_horizontalGrid;
+            case Type::VerticalGrid:
+                return m_verticalGrid;
+            case Type::OctaveGrid:
+                return m_octaveGrid;
+            case Type::WhiteKey:
+                return m_whiteKey;
+            case Type::BlackKey:
+                return m_blackKey;
+        }
+
+        return {};
+    }
+
+    [[nodiscard]] QColor defaultWhiteKeyColour(const QPalette& palette) const
+    {
+        const QColor window = palette.color(QPalette::Active, QPalette::Window);
+        const QColor light  = palette.color(QPalette::Active, QPalette::Light);
+        return blendColours(window, light, 0.75);
+    }
+
+    [[nodiscard]] QColor defaultBlackKeyColour(const QPalette& palette) const
+    {
+        const QColor window = palette.color(QPalette::Active, QPalette::Window);
+        const QColor dark   = palette.color(QPalette::Active, QPalette::Dark);
+        return blendColours(window, dark, 0.75);
+    }
+
+    [[nodiscard]] QColor colour(Type type, const QPalette& palette) const
+    {
+        switch(type) {
+            case Type::Background:
+                return m_background.isValid() ? m_background : palette.color(QPalette::Window);
+            case Type::BarGradient:
+                return gradient(palette).front();
+            case Type::Peaks:
+                return m_peaks.isValid() ? m_peaks : QColor{190, 40, 10};
+            case Type::Text:
+                return m_text.isValid() ? m_text : palette.color(QPalette::Text);
+            case Type::HorizontalGrid:
+                return m_horizontalGrid.isValid() ? m_horizontalGrid : palette.color(QPalette::Mid);
+            case Type::VerticalGrid:
+                return m_verticalGrid.isValid() ? m_verticalGrid : palette.color(QPalette::Midlight);
+            case Type::OctaveGrid:
+                return m_octaveGrid.isValid() ? m_octaveGrid : palette.color(QPalette::Midlight);
+            case Type::WhiteKey:
+                return m_whiteKey.isValid() ? m_whiteKey : defaultWhiteKeyColour(palette);
+            case Type::BlackKey:
+                return m_blackKey.isValid() ? m_blackKey : defaultBlackKeyColour(palette);
+        }
+
+        return {};
+    }
+
+    [[nodiscard]] bool isEmpty() const
+    {
+        return !m_background.isValid() && m_barGradient.empty() && !m_peaks.isValid() && !m_text.isValid()
+            && !m_horizontalGrid.isValid() && !m_verticalGrid.isValid() && !m_octaveGrid.isValid()
+            && !m_whiteKey.isValid() && !m_blackKey.isValid();
+    }
+
+    friend QDataStream& operator<<(QDataStream& stream, const Colours& colours)
+    {
+        stream << Magic;
+        stream << Version;
+        stream << colours.m_background;
+        DataStream::writeContainer(stream, colours.m_barGradient);
+        stream << colours.m_peaks;
+        stream << colours.m_text;
+        stream << colours.m_horizontalGrid;
+        stream << colours.m_verticalGrid;
+        stream << colours.m_octaveGrid;
+        stream << colours.m_whiteKey;
+        stream << colours.m_blackKey;
+        return stream;
+    }
+
+    friend QDataStream& operator>>(QDataStream& stream, Colours& colours)
+    {
+        qint32 magic{0};
+        qint32 version{0};
+
+        stream.startTransaction();
+        stream >> magic;
+        stream >> version;
+
+        if(magic != Magic || version != Version) {
+            stream.rollbackTransaction();
+            colours = {};
+            return stream;
+        }
+
+        stream >> colours.m_background;
+        DataStream::readContainer(stream, colours.m_barGradient);
+        stream >> colours.m_peaks;
+        stream >> colours.m_text;
+        stream >> colours.m_horizontalGrid;
+        stream >> colours.m_verticalGrid;
+        stream >> colours.m_octaveGrid;
+        stream >> colours.m_whiteKey;
+        stream >> colours.m_blackKey;
+
+        if(!stream.commitTransaction()) {
+            colours = {};
+        }
+
+        return stream;
+    }
+
+private:
+    [[nodiscard]] static QColor blendColours(const QColor& base, const QColor& accent, qreal accentRatio)
+    {
+        const auto blend = [accentRatio](int baseChannel, int accentChannel) {
+            return static_cast<int>((baseChannel * (1.0 - accentRatio)) + (accentChannel * accentRatio));
+        };
+
+        return QColor{blend(base.red(), accent.red()), blend(base.green(), accent.green()),
+                      blend(base.blue(), accent.blue()), blend(base.alpha(), accent.alpha())};
+    }
+
+    QColor m_background;
+    std::vector<QColor> m_barGradient;
+    QColor m_peaks;
+    QColor m_text;
+    QColor m_horizontalGrid;
+    QColor m_verticalGrid;
+    QColor m_octaveGrid;
+    QColor m_whiteKey;
+    QColor m_blackKey;
+};
+} // namespace Fooyin::Spectrum
+
+Q_DECLARE_METATYPE(Fooyin::Spectrum::Colours)

--- a/src/plugins/spectrum/spectrumconfigwidget.cpp
+++ b/src/plugins/spectrum/spectrumconfigwidget.cpp
@@ -23,6 +23,7 @@
 #include "spectrumcolours.h"
 #include "spectrumsettings.h"
 
+#include <gui/framerate.h>
 #include <gui/guiutils.h>
 #include <gui/widgets/colourbutton.h>
 #include <gui/widgets/fontbutton.h>
@@ -168,7 +169,7 @@ SpectrumConfigDialog::SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* pa
     , m_peaksGroup{new QGroupBox(tr("Peaks"), this)}
     , m_peakHoldTime{new QSpinBox(this)}
     , m_peakGravity{new QSpinBox(this)}
-    , m_updateFps{new QSpinBox(this)}
+    , m_updateFps{new QComboBox(this)}
     , m_fftSize{new QComboBox(this)}
     , m_windowFunction{new QComboBox(this)}
     , m_drawStyle{new QComboBox(this)}
@@ -241,9 +242,11 @@ SpectrumConfigDialog::SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* pa
     m_peakGravity->setRange(MinPeakGravity, MaxPeakGravity);
     m_peakGravity->setSingleStep(10);
     m_peakGravity->setSuffix(u" dB/s"_s);
-    m_updateFps->setRange(MinUpdateFps, MaxUpdateFps);
-    m_updateFps->setSingleStep(5);
-    m_updateFps->setSuffix(u" fps"_s);
+
+    for(const auto preset : Gui::FrameRate::Presets) {
+        const int fps = Gui::FrameRate::toFps(preset);
+        m_updateFps->addItem(tr("%1 fps").arg(fps), fps);
+    }
 
     for(const int fftSize : {256, 512, 1024, 2048, 4096, 8192, 16384}) {
         m_fftSize->addItem(QString::number(fftSize), fftSize);
@@ -500,7 +503,7 @@ SpectrumWidget::ConfigData SpectrumConfigDialog::config() const
         .peaksEnabled        = m_peaksGroup->isChecked(),
         .peakHoldTimeMs      = m_peakHoldTime->value(),
         .peakGravity         = m_peakGravity->value(),
-        .updateFps           = m_updateFps->value(),
+        .updateFps           = m_updateFps->currentData().toInt(),
         .fftSize             = m_fftSize->currentData().toInt(),
         .windowFunction      = static_cast<WindowFunction>(m_windowFunction->currentData().toInt()),
         .gradientOrientation = m_barGradient->orientation() == Qt::Vertical ? GradientOrientation::Vertical
@@ -561,7 +564,13 @@ void SpectrumConfigDialog::setConfig(const SpectrumWidget::ConfigData& config)
     m_peaksGroup->setChecked(config.peaksEnabled);
     m_peakHoldTime->setValue(config.peakHoldTimeMs);
     m_peakGravity->setValue(config.peakGravity);
-    m_updateFps->setValue(config.updateFps);
+
+    const int nearestFps = Gui::FrameRate::nearestPresetFps(config.updateFps);
+    int fpsIndex         = m_updateFps->findData(nearestFps);
+    if(fpsIndex < 0) {
+        fpsIndex = m_updateFps->findData(DefaultUpdateFps);
+    }
+    m_updateFps->setCurrentIndex(fpsIndex);
 
     int fftIndex = m_fftSize->findData(config.fftSize);
     if(fftIndex < 0) {

--- a/src/plugins/spectrum/spectrumconfigwidget.cpp
+++ b/src/plugins/spectrum/spectrumconfigwidget.cpp
@@ -1,0 +1,630 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "spectrumconfigwidget.h"
+
+#include "spectrumaxisrenderer.h"
+#include "spectrumcolours.h"
+#include "spectrumsettings.h"
+
+#include <gui/guiutils.h>
+#include <gui/widgets/colourbutton.h>
+#include <gui/widgets/fontbutton.h>
+#include <gui/widgets/gradienteditor.h>
+
+#include <QAbstractSpinBox>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFont>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QSizePolicy>
+#include <QSpinBox>
+#include <QStackedWidget>
+#include <QTabWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <array>
+#include <optional>
+#include <utility>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Spectrum {
+namespace {
+QFont fontFromString(const QString& fontString)
+{
+    QFont font;
+    if(!fontString.isEmpty()) {
+        font.fromString(fontString);
+    }
+    return font;
+}
+
+QString formatMidiNote(int midiNote)
+{
+    static constexpr std::array<const char*, 12> NoteNames
+        = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+    const int semitone = ((midiNote % 12) + 12) % 12;
+    const int octave   = midiNote / 12;
+    return QString::fromLatin1(NoteNames[semitone]) + QString::number(octave);
+}
+
+std::optional<int> parseMidiNote(const QString& text)
+{
+    const QString trimmed = text.trimmed().toUpper();
+
+    static constexpr std::array<const char*, 12> NoteNames
+        = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+
+    for(int semitone = 0; std::cmp_less(semitone, NoteNames.size()); ++semitone) {
+        const QString note = QString::fromLatin1(NoteNames[semitone]);
+        if(!trimmed.startsWith(note)) {
+            continue;
+        }
+
+        bool ok          = false;
+        const int octave = trimmed.mid(note.size()).toInt(&ok);
+        if(ok) {
+            return (octave * 12) + semitone;
+        }
+    }
+
+    return {};
+}
+
+class NoteSpinBox : public QSpinBox
+{
+    Q_OBJECT
+
+public:
+    explicit NoteSpinBox(QWidget* parent = nullptr)
+        : QSpinBox(parent)
+    { }
+
+protected:
+    [[nodiscard]] QString textFromValue(int value) const override
+    {
+        return formatMidiNote(value);
+    }
+
+    [[nodiscard]] int valueFromText(const QString& text) const override
+    {
+        return parseMidiNote(text).value_or(value());
+    }
+
+    QValidator::State validate(QString& input, int& /*pos*/) const override
+    {
+        if(input.trimmed().isEmpty()) {
+            return QValidator::Intermediate;
+        }
+        return parseMidiNote(input).has_value() ? QValidator::Acceptable : QValidator::Intermediate;
+    }
+};
+
+void addGridRow(QGridLayout* layout, int& row, const QString& label, QWidget* widget, QWidget* parent,
+                Qt::Alignment align = {})
+{
+    auto* labelWidget = new QLabel(label, parent);
+    labelWidget->setToolTip(widget->toolTip());
+    layout->addWidget(labelWidget, row, 0, align);
+    layout->addWidget(widget, row++, 1);
+    layout->setColumnStretch(1, 1);
+}
+
+void addGridRow(QGridLayout* layout, int row, int column, const QString& label, QWidget* widget, QWidget* parent,
+                Qt::Alignment align = {})
+{
+    auto* labelWidget = new QLabel(label, parent);
+    labelWidget->setToolTip(widget->toolTip());
+    layout->addWidget(labelWidget, row, column, align);
+    layout->addWidget(widget, row, column + 1);
+    layout->setColumnStretch(column + 1, 1);
+}
+
+void addGridSection(QGridLayout* layout, int row, int column, const QString& text, QWidget* parent)
+{
+    layout->addWidget(Gui::createSectionHeader(text, parent), row, column, 1, 2);
+}
+} // namespace
+
+SpectrumConfigDialog::SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* parent)
+    : WidgetConfigDialog{spectrum, tr("Spectrum Settings"), parent}
+    , m_bandCount{new QSpinBox(this)}
+    , m_barSpacing{new QSpinBox(this)}
+    , m_barSections{new QSpinBox(this)}
+    , m_sectionSpacing{new QSpinBox(this)}
+    , m_labelMode{new QComboBox(this)}
+    , m_minFrequency{new QSpinBox(this)}
+    , m_maxFrequency{new QSpinBox(this)}
+    , m_minNote{new NoteSpinBox(this)}
+    , m_maxNote{new NoteSpinBox(this)}
+    , m_pitchHz{new QSpinBox(this)}
+    , m_transpose{new QSpinBox(this)}
+    , m_amplitudesGroup{new QGroupBox(tr("Amplitudes"), this)}
+    , m_amplitudeMinDb{new QSpinBox(this)}
+    , m_amplitudeMaxDb{new QSpinBox(this)}
+    , m_amplitudeHoldTime{new QSpinBox(this)}
+    , m_decayTime{new QSpinBox(this)}
+    , m_peaksGroup{new QGroupBox(tr("Peaks"), this)}
+    , m_peakHoldTime{new QSpinBox(this)}
+    , m_peakGravity{new QSpinBox(this)}
+    , m_updateFps{new QSpinBox(this)}
+    , m_fftSize{new QComboBox(this)}
+    , m_windowFunction{new QComboBox(this)}
+    , m_drawStyle{new QComboBox(this)}
+    , m_showTopLabels{new QCheckBox(tr("Top labels"), this)}
+    , m_showBottomLabels{new QCheckBox(tr("Bottom labels"), this)}
+    , m_showLeftLabels{new QCheckBox(tr("Left labels"), this)}
+    , m_showRightLabels{new QCheckBox(tr("Right labels"), this)}
+    , m_showHorizontalGrid{new QCheckBox(tr("Horizontal gridlines"), this)}
+    , m_showVerticalGrid{new QCheckBox(tr("Vertical gridlines"), this)}
+    , m_showWhiteKeys{new QCheckBox(tr("White keys"), this)}
+    , m_showBlackKeys{new QCheckBox(tr("Black keys"), this)}
+    , m_showTooltip{new QCheckBox(tr("Tooltip"), this)}
+    , m_fillSpectrum{new QCheckBox(tr("Fill spectrum"), this)}
+    , m_interpolate{new QCheckBox(tr("Interpolate"), this)}
+    , m_axisFont{new FontButton(this)}
+    , m_colourGroup{new QGroupBox(tr("Custom colours"), this)}
+    , m_textColour{new ColourButton(this)}
+    , m_backgroundColour{new ColourButton(this)}
+    , m_barGradient{new GradientEditor(this)}
+    , m_peaksColour{new ColourButton(this)}
+    , m_horizontalGridColour{new ColourButton(this)}
+    , m_verticalGridColour{new ColourButton(this)}
+    , m_octaveGridColour{new ColourButton(this)}
+    , m_whiteKeyColour{new ColourButton(this)}
+    , m_blackKeyColour{new ColourButton(this)}
+{
+    auto* spectrumGroup    = new QGroupBox(tr("Scale"), this);
+    auto* spectrumLayout   = new QGridLayout(spectrumGroup);
+    auto* analysisGroup    = new QGroupBox(tr("Analysis"), this);
+    auto* analysisLayout   = new QGridLayout(analysisGroup);
+    auto* amplitudesLayout = new QGridLayout(m_amplitudesGroup);
+    auto* peaksLayout      = new QGridLayout(m_peaksGroup);
+    auto* axesGroup        = new QGroupBox(tr("Axes"), this);
+    auto* axesLayout       = new QVBoxLayout(axesGroup);
+    auto* displayGroup     = new QGroupBox(tr("Display"), this);
+    auto* displayLayout    = new QVBoxLayout(displayGroup);
+
+    m_bandCount->setRange(MinBandCount, MaxBandCount);
+    m_bandCount->setSingleStep(10);
+    m_barSpacing->setRange(MinBarSpacing, MaxBarSpacing);
+    m_barSpacing->setSuffix(u" px"_s);
+    m_barSections->setRange(MinBarSections, MaxBarSections);
+    m_sectionSpacing->setRange(MinSectionSpacing, MaxSectionSpacing);
+    m_sectionSpacing->setSuffix(u" px"_s);
+    m_minFrequency->setRange(MinFrequencyHz, MaxFrequencyHz);
+    m_minFrequency->setSingleStep(10);
+    m_minFrequency->setSuffix(u" Hz"_s);
+    m_maxFrequency->setRange(MinFrequencyHz, MaxFrequencyHz);
+    m_maxFrequency->setSingleStep(1000);
+    m_maxFrequency->setSuffix(u" Hz"_s);
+    m_minNote->setRange(MinNote, MaxNote - 12);
+    m_maxNote->setRange(MinNote + 12, MaxNote);
+    m_pitchHz->setRange(MinPitchHz, MaxPitchHz);
+    m_pitchHz->setSuffix(u" Hz"_s);
+    m_transpose->setRange(MinTranspose, MaxTranspose);
+    m_transpose->setSuffix(u" st"_s);
+    m_amplitudeMinDb->setRange(MinAmplitudeDb, MaxAmplitudeDb);
+    m_amplitudeMinDb->setSuffix(u" dB"_s);
+    m_amplitudeMaxDb->setRange(MinAmplitudeDb, MaxAmplitudeDb);
+    m_amplitudeMaxDb->setSuffix(u" dB"_s);
+    m_amplitudeHoldTime->setRange(MinAmplitudeHoldTimeMs, MaxAmplitudeHoldTimeMs);
+    m_amplitudeHoldTime->setSingleStep(100);
+    m_amplitudeHoldTime->setSuffix(u" ms"_s);
+    m_decayTime->setRange(MinAmplitudeGravity, MaxAmplitudeGravity);
+    m_decayTime->setSingleStep(10);
+    m_decayTime->setSuffix(u" dB/s"_s);
+    m_peakHoldTime->setRange(MinPeakHoldTimeMs, MaxPeakHoldTimeMs);
+    m_peakHoldTime->setSingleStep(100);
+    m_peakHoldTime->setSuffix(u" ms"_s);
+    m_peakGravity->setRange(MinPeakGravity, MaxPeakGravity);
+    m_peakGravity->setSingleStep(10);
+    m_peakGravity->setSuffix(u" dB/s"_s);
+    m_updateFps->setRange(MinUpdateFps, MaxUpdateFps);
+    m_updateFps->setSingleStep(5);
+    m_updateFps->setSuffix(u" fps"_s);
+
+    for(const int fftSize : {256, 512, 1024, 2048, 4096, 8192, 16384}) {
+        m_fftSize->addItem(QString::number(fftSize), fftSize);
+    }
+
+    m_windowFunction->addItem(tr("Blackman-Harris"), static_cast<int>(WindowFunction::BlackmanHarris));
+    m_windowFunction->addItem(tr("Hann"), static_cast<int>(WindowFunction::Hann));
+    m_windowFunction->addItem(tr("None"), static_cast<int>(WindowFunction::None));
+
+    m_labelMode->addItem(tr("Frequencies"), static_cast<int>(LabelMode::Frequency));
+    m_labelMode->addItem(tr("Notes"), static_cast<int>(LabelMode::Notes));
+    m_drawStyle->addItem(tr("Bars"), static_cast<int>(DrawStyle::Bars));
+    m_drawStyle->addItem(tr("Curve"), static_cast<int>(DrawStyle::Curve));
+
+    m_labelMode->setToolTip(tr("Choose whether bands are spaced by frequency or by musical note"));
+    m_minFrequency->setToolTip(tr("Lowest frequency shown"));
+    m_maxFrequency->setToolTip(tr("Highest frequency"));
+    m_minNote->setToolTip(tr("Lowest note shown"));
+    m_maxNote->setToolTip(tr("Highest note shown"));
+    m_amplitudeMinDb->setToolTip(tr("Signal level mapped to the bottom of the spectrum"));
+    m_amplitudeMaxDb->setToolTip(tr("Signal level mapped to the top of the spectrum"));
+    m_bandCount->setToolTip(tr("Number of frequency bands to draw"));
+    m_fftSize->setToolTip(tr("Number of samples analysed per spectrum frame; higher values improve frequency "
+                             "detail but respond more slowly"));
+    m_windowFunction->setToolTip(tr("Window applied before FFT analysis"));
+    m_pitchHz->setToolTip(tr("Reference frequency for A4"));
+    m_transpose->setToolTip(tr("Shift note labels and note-based bands by semitones"));
+    m_amplitudesGroup->setToolTip(tr("Enable smoothing for falling bar levels"));
+    m_amplitudeHoldTime->setToolTip(tr("How long a raised bar level is held before it starts falling"));
+    m_decayTime->setToolTip(tr("How quickly bar levels fall after the hold time"));
+    m_peaksGroup->setToolTip(tr("Show peak markers above the current bar levels"));
+    m_peakHoldTime->setToolTip(tr("How long each peak marker is held before it starts falling"));
+    m_peakGravity->setToolTip(tr("How quickly peak markers fall after the hold time"));
+    m_updateFps->setToolTip(tr("Maximum spectrum refresh rate"));
+    m_showWhiteKeys->setToolTip(tr("Highlight white piano-key note ranges behind the spectrum"));
+    m_showBlackKeys->setToolTip(tr("Highlight black piano-key note ranges behind the spectrum"));
+    m_showTooltip->setToolTip(tr("Show frequency or note and level when hovering over the spectrum"));
+    m_fillSpectrum->setToolTip(tr("Fill the spectrum area instead of drawing only the outline"));
+    m_interpolate->setToolTip(tr("Smooth low-frequency bands when several bands map to the same FFT bin"));
+    m_barSpacing->setToolTip(tr("Horizontal gap between adjacent bars"));
+    m_barSections->setToolTip(tr("Split each bar into this many vertical segments"));
+    m_sectionSpacing->setToolTip(tr("Vertical gap between bar segments"));
+    m_drawStyle->setToolTip(tr("Choose whether to draw separate bars or a continuous curve"));
+    m_axisFont->setToolTip(tr("Font used for spectrum axis labels"));
+    m_barGradient->setToolTip(tr("Colour gradient used for bars and filled curves"));
+    m_peaksColour->setToolTip(tr("Colour used for peak markers"));
+    m_octaveGridColour->setToolTip(tr("Colour used for octave gridlines in note mode"));
+
+    for(QAbstractSpinBox* spinBox :
+        {m_minFrequency, m_maxFrequency, m_minNote, m_maxNote, m_amplitudeMinDb, m_amplitudeMaxDb}) {
+        spinBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    }
+
+    for(ColourButton* button : {m_textColour, m_backgroundColour, m_peaksColour, m_horizontalGridColour,
+                                m_verticalGridColour, m_octaveGridColour, m_whiteKeyColour, m_blackKeyColour}) {
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    }
+    m_barGradient->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    auto* frequencyRange  = new QWidget(this);
+    auto* frequencyLayout = new QHBoxLayout(frequencyRange);
+    frequencyRange->setToolTip(m_minFrequency->toolTip());
+    frequencyLayout->addWidget(m_minFrequency);
+    frequencyLayout->addWidget(new QLabel(u"-"_s, this));
+    frequencyLayout->addWidget(m_maxFrequency);
+    frequencyLayout->addStretch(1);
+
+    auto* noteRange  = new QWidget(this);
+    auto* noteLayout = new QHBoxLayout(noteRange);
+    noteRange->setToolTip(m_minNote->toolTip());
+    noteLayout->addWidget(m_minNote);
+    noteLayout->addWidget(new QLabel(u"-"_s, this));
+    noteLayout->addWidget(m_maxNote);
+    noteLayout->addStretch(1);
+
+    auto* scaleStack = new QStackedWidget(this);
+    scaleStack->addWidget(frequencyRange);
+    scaleStack->addWidget(noteRange);
+    scaleStack->setToolTip(tr("Frequency or note range covered by the spectrum"));
+    scaleStack->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    auto* amplitudeRange  = new QWidget(this);
+    auto* amplitudeLayout = new QHBoxLayout(amplitudeRange);
+    amplitudeRange->setToolTip(tr("Decibel range mapped to the spectrum height"));
+
+    amplitudeLayout->addWidget(m_amplitudeMinDb);
+    amplitudeLayout->addWidget(new QLabel(u"-"_s, this));
+    amplitudeLayout->addWidget(m_amplitudeMaxDb);
+    amplitudeLayout->addStretch(1);
+
+    int row{0};
+    addGridRow(spectrumLayout, row, tr("Axis") + ":"_L1, m_labelMode, this);
+    addGridRow(spectrumLayout, row, tr("Range") + ":"_L1, scaleStack, this);
+    addGridRow(spectrumLayout, row, tr("Amplitude") + ":"_L1, amplitudeRange, this);
+    addGridRow(spectrumLayout, row, tr("Bands") + ":"_L1, m_bandCount, this);
+
+    row = 0;
+    addGridRow(analysisLayout, row, tr("FFT size") + ":"_L1, m_fftSize, this);
+    addGridRow(analysisLayout, row, tr("Window") + ":"_L1, m_windowFunction, this);
+    addGridRow(analysisLayout, row, tr("Pitch (A4)") + ":"_L1, m_pitchHz, this);
+    addGridRow(analysisLayout, row, tr("Transpose") + ":"_L1, m_transpose, this);
+
+    const auto updateScaleControls = [this, scaleStack]() {
+        const auto mode  = static_cast<LabelMode>(m_labelMode->currentData().toInt());
+        const bool notes = mode == LabelMode::Notes;
+        scaleStack->setCurrentIndex(notes ? 1 : 0);
+        m_bandCount->setEnabled(!notes);
+        m_pitchHz->setEnabled(notes);
+        m_transpose->setEnabled(notes);
+        m_showWhiteKeys->setEnabled(notes);
+        m_showBlackKeys->setEnabled(notes);
+    };
+
+    QObject::connect(m_labelMode, &QComboBox::currentIndexChanged, this, updateScaleControls);
+    QObject::connect(m_minNote, qOverload<int>(&QSpinBox::valueChanged), this,
+                     [this](int value) { m_maxNote->setMinimum(std::min(MaxNote, value + 12)); });
+    QObject::connect(m_maxNote, qOverload<int>(&QSpinBox::valueChanged), this,
+                     [this](int value) { m_minNote->setMaximum(std::max(MinNote, value - 12)); });
+    m_amplitudesGroup->setCheckable(true);
+
+    row = 0;
+    addGridRow(amplitudesLayout, row, tr("Hold time") + ":"_L1, m_amplitudeHoldTime, this);
+    addGridRow(amplitudesLayout, row, tr("Falloff") + ":"_L1, m_decayTime, this);
+
+    m_peaksGroup->setCheckable(true);
+    row = 0;
+    addGridRow(peaksLayout, row, tr("Hold time") + ":"_L1, m_peakHoldTime, this);
+    addGridRow(peaksLayout, row, tr("Falloff") + ":"_L1, m_peakGravity, this);
+
+    axesLayout->addWidget(m_showTopLabels);
+    axesLayout->addWidget(m_showBottomLabels);
+    axesLayout->addWidget(m_showLeftLabels);
+    axesLayout->addWidget(m_showRightLabels);
+    axesLayout->addWidget(m_showHorizontalGrid);
+    axesLayout->addWidget(m_showVerticalGrid);
+    axesLayout->addWidget(m_showWhiteKeys);
+    axesLayout->addWidget(m_showBlackKeys);
+
+    displayLayout->addWidget(m_showTooltip);
+    displayLayout->addWidget(m_fillSpectrum);
+    displayLayout->addWidget(m_interpolate);
+
+    auto* barLayout = new QGridLayout();
+    row             = 0;
+    addGridRow(barLayout, row, tr("Update FPS") + ":"_L1, m_updateFps, this);
+    addGridRow(barLayout, row, tr("Bar spacing") + ":"_L1, m_barSpacing, this);
+    addGridRow(barLayout, row, tr("Sections") + ":"_L1, m_barSections, this);
+    addGridRow(barLayout, row, tr("Section spacing") + ":"_L1, m_sectionSpacing, this);
+    addGridRow(barLayout, row, tr("Style") + ":"_L1, m_drawStyle, this);
+    addGridRow(barLayout, row, tr("Axis font") + ":"_L1, m_axisFont, this);
+    displayLayout->addLayout(barLayout);
+
+    m_colourGroup->setTitle(tr("Colors"));
+    m_colourGroup->setCheckable(true);
+
+    auto* coloursLayout      = new QGridLayout(m_colourGroup);
+    auto* leftColoursColumn  = new QWidget(m_colourGroup);
+    auto* rightColoursColumn = new QWidget(m_colourGroup);
+    auto* leftColoursLayout  = new QGridLayout(leftColoursColumn);
+    auto* rightColoursLayout = new QGridLayout(rightColoursColumn);
+    leftColoursLayout->setContentsMargins({});
+    rightColoursLayout->setContentsMargins({});
+
+    addGridSection(leftColoursLayout, 0, 0, tr("General"), this);
+    addGridRow(leftColoursLayout, 1, 0, tr("Text colour") + ":"_L1, m_textColour, this);
+    addGridRow(leftColoursLayout, 2, 0, tr("Background colour") + ":"_L1, m_backgroundColour, this);
+    addGridSection(leftColoursLayout, 3, 0, tr("Grid"), this);
+    addGridRow(leftColoursLayout, 4, 0, tr("Horizontal gridlines") + ":"_L1, m_horizontalGridColour, this);
+    addGridRow(leftColoursLayout, 5, 0, tr("Vertical gridlines") + ":"_L1, m_verticalGridColour, this);
+    addGridRow(leftColoursLayout, 6, 0, tr("Octave gridlines") + ":"_L1, m_octaveGridColour, this);
+    addGridSection(leftColoursLayout, 7, 0, tr("Keys"), this);
+    addGridRow(leftColoursLayout, 8, 0, tr("White keys") + ":"_L1, m_whiteKeyColour, this);
+    addGridRow(leftColoursLayout, 9, 0, tr("Black keys") + ":"_L1, m_blackKeyColour, this);
+
+    addGridSection(rightColoursLayout, 0, 0, tr("Bars"), this);
+    addGridRow(rightColoursLayout, 1, 0, tr("Bar gradient") + ":"_L1, m_barGradient, this, Qt::AlignTop);
+    addGridRow(rightColoursLayout, 2, 0, tr("Peaks colour") + ":"_L1, m_peaksColour, this);
+    rightColoursLayout->setRowStretch(1, 1);
+
+    const int coloursColumnWidth
+        = std::max(leftColoursColumn->sizeHint().width(), rightColoursColumn->sizeHint().width());
+    leftColoursColumn->setMinimumWidth(coloursColumnWidth);
+    rightColoursColumn->setMinimumWidth(coloursColumnWidth);
+    coloursLayout->addWidget(leftColoursColumn, 0, 0);
+    coloursLayout->addWidget(rightColoursColumn, 0, 1);
+    coloursLayout->setColumnStretch(0, 1);
+    coloursLayout->setColumnStretch(1, 1);
+
+    auto* spectrumPage       = new QWidget(this);
+    auto* spectrumPageLayout = new QGridLayout(spectrumPage);
+
+    row = 0;
+    spectrumPageLayout->addWidget(spectrumGroup, row, 0);
+    spectrumPageLayout->addWidget(analysisGroup, row++, 1);
+    spectrumPageLayout->addWidget(m_amplitudesGroup, row, 0);
+    spectrumPageLayout->addWidget(m_peaksGroup, row++, 1);
+    spectrumPageLayout->setRowStretch(spectrumPageLayout->rowCount(), 1);
+
+    auto* appearancePage       = new QWidget(this);
+    auto* appearancePageLayout = new QGridLayout(appearancePage);
+    appearancePageLayout->addWidget(axesGroup, 0, 0);
+    appearancePageLayout->addWidget(displayGroup, 0, 1);
+    appearancePageLayout->setRowStretch(1, 1);
+
+    auto* coloursPage       = new QWidget(this);
+    auto* coloursPageLayout = new QGridLayout(coloursPage);
+    coloursPageLayout->addWidget(m_colourGroup, 0, 0);
+    coloursPageLayout->setRowStretch(1, 1);
+
+    const int tabColumnWidth = std::max({spectrumGroup->sizeHint().width(), analysisGroup->sizeHint().width(),
+                                         axesGroup->sizeHint().width(), displayGroup->sizeHint().width()});
+    for(QWidget* group : {spectrumGroup, analysisGroup, m_peaksGroup, m_amplitudesGroup, axesGroup, displayGroup}) {
+        group->setMinimumWidth(tabColumnWidth);
+    }
+    spectrumGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    analysisGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    axesGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    displayGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    m_colourGroup->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+    auto* tabs = new QTabWidget(this);
+    tabs->addTab(spectrumPage, tr("General"));
+    tabs->addTab(appearancePage, tr("Display"));
+    tabs->addTab(coloursPage, tr("Colours"));
+
+    auto* layout{contentLayout()};
+    layout->addWidget(tabs, 0, 0);
+    layout->setColumnStretch(0, 1);
+
+    loadCurrentConfig();
+}
+
+SpectrumWidget::ConfigData SpectrumConfigDialog::config() const
+{
+    const QFont axisFont        = m_axisFont->buttonFont();
+    const QFont defaultAxisFont = SpectrumAxisRenderer::defaultAxisFont(widget()->font());
+
+    SpectrumWidget::ConfigData config{
+        .bandCount           = m_bandCount->value(),
+        .barSpacing          = m_barSpacing->value(),
+        .barSections         = m_barSections->value(),
+        .sectionSpacing      = m_sectionSpacing->value(),
+        .minFrequencyHz      = m_minFrequency->value(),
+        .maxFrequencyHz      = m_maxFrequency->value(),
+        .minNote             = m_minNote->value(),
+        .maxNote             = m_maxNote->value(),
+        .pitchHz             = m_pitchHz->value(),
+        .transpose           = m_transpose->value(),
+        .amplitudeMinDb      = m_amplitudeMinDb->value(),
+        .amplitudeMaxDb      = m_amplitudeMaxDb->value(),
+        .amplitudesEnabled   = m_amplitudesGroup->isChecked(),
+        .amplitudeHoldTimeMs = m_amplitudeHoldTime->value(),
+        .amplitudeGravity    = m_decayTime->value(),
+        .peaksEnabled        = m_peaksGroup->isChecked(),
+        .peakHoldTimeMs      = m_peakHoldTime->value(),
+        .peakGravity         = m_peakGravity->value(),
+        .updateFps           = m_updateFps->value(),
+        .fftSize             = m_fftSize->currentData().toInt(),
+        .windowFunction      = static_cast<WindowFunction>(m_windowFunction->currentData().toInt()),
+        .gradientOrientation = m_barGradient->orientation() == Qt::Vertical ? GradientOrientation::Vertical
+                                                                            : GradientOrientation::Horizontal,
+        .labelMode           = static_cast<LabelMode>(m_labelMode->currentData().toInt()),
+        .drawStyle           = static_cast<DrawStyle>(m_drawStyle->currentData().toInt()),
+        .showTopLabels       = m_showTopLabels->isChecked(),
+        .showBottomLabels    = m_showBottomLabels->isChecked(),
+        .showLeftLabels      = m_showLeftLabels->isChecked(),
+        .showRightLabels     = m_showRightLabels->isChecked(),
+        .showHorizontalGrid  = m_showHorizontalGrid->isChecked(),
+        .showVerticalGrid    = m_showVerticalGrid->isChecked(),
+        .showWhiteKeys       = m_showWhiteKeys->isChecked(),
+        .showBlackKeys       = m_showBlackKeys->isChecked(),
+        .showTooltip         = m_showTooltip->isChecked(),
+        .fillSpectrum        = m_fillSpectrum->isChecked(),
+        .interpolate         = m_interpolate->isChecked(),
+        .axisFont            = axisFont == defaultAxisFont ? QString{} : axisFont.toString(),
+        .colours             = QVariant{},
+    };
+
+    if(m_colourGroup->isChecked()) {
+        Colours colours;
+        colours.setColour(Colours::Type::Text, m_textColour->colour());
+        colours.setColour(Colours::Type::Background, m_backgroundColour->colour());
+        colours.setGradient(m_barGradient->colours());
+        colours.setColour(Colours::Type::Peaks, m_peaksColour->colour());
+        colours.setColour(Colours::Type::HorizontalGrid, m_horizontalGridColour->colour());
+        colours.setColour(Colours::Type::VerticalGrid, m_verticalGridColour->colour());
+        colours.setColour(Colours::Type::OctaveGrid, m_octaveGridColour->colour());
+        colours.setColour(Colours::Type::WhiteKey, m_whiteKeyColour->colour());
+        colours.setColour(Colours::Type::BlackKey, m_blackKeyColour->colour());
+        config.colours = QVariant::fromValue(colours);
+    }
+
+    return config;
+}
+
+void SpectrumConfigDialog::setConfig(const SpectrumWidget::ConfigData& config)
+{
+    m_bandCount->setValue(config.bandCount);
+    m_barSpacing->setValue(config.barSpacing);
+    m_barSections->setValue(config.barSections);
+    m_sectionSpacing->setValue(config.sectionSpacing);
+    m_minFrequency->setValue(config.minFrequencyHz);
+    m_maxFrequency->setValue(config.maxFrequencyHz);
+    m_minNote->setValue(config.minNote);
+    m_maxNote->setValue(config.maxNote);
+    m_maxNote->setMinimum(std::min(MaxNote, config.minNote + 12));
+    m_minNote->setMaximum(std::max(MinNote, config.maxNote - 12));
+    m_pitchHz->setValue(config.pitchHz);
+    m_transpose->setValue(config.transpose);
+    m_amplitudeMinDb->setValue(config.amplitudeMinDb);
+    m_amplitudeMaxDb->setValue(config.amplitudeMaxDb);
+    m_amplitudesGroup->setChecked(config.amplitudesEnabled);
+    m_amplitudeHoldTime->setValue(config.amplitudeHoldTimeMs);
+    m_decayTime->setValue(config.amplitudeGravity);
+    m_peaksGroup->setChecked(config.peaksEnabled);
+    m_peakHoldTime->setValue(config.peakHoldTimeMs);
+    m_peakGravity->setValue(config.peakGravity);
+    m_updateFps->setValue(config.updateFps);
+
+    int fftIndex = m_fftSize->findData(config.fftSize);
+    if(fftIndex < 0) {
+        fftIndex = m_fftSize->findData(DefaultFftSize);
+    }
+    m_fftSize->setCurrentIndex(fftIndex);
+
+    int windowIndex = m_windowFunction->findData(static_cast<int>(config.windowFunction));
+    if(windowIndex < 0) {
+        windowIndex = m_windowFunction->findData(static_cast<int>(WindowFunction::Hann));
+    }
+    m_windowFunction->setCurrentIndex(windowIndex);
+
+    int drawStyleIndex = m_drawStyle->findData(static_cast<int>(config.drawStyle));
+    if(drawStyleIndex < 0) {
+        drawStyleIndex = m_drawStyle->findData(static_cast<int>(DrawStyle::Bars));
+    }
+    m_drawStyle->setCurrentIndex(drawStyleIndex);
+
+    int labelModeIndex = m_labelMode->findData(static_cast<int>(config.labelMode));
+    if(labelModeIndex < 0) {
+        labelModeIndex = m_labelMode->findData(static_cast<int>(LabelMode::Frequency));
+    }
+    m_labelMode->setCurrentIndex(labelModeIndex);
+
+    const auto mode = static_cast<LabelMode>(m_labelMode->currentData().toInt());
+    m_bandCount->setEnabled(mode != LabelMode::Notes);
+    m_pitchHz->setEnabled(mode == LabelMode::Notes);
+    m_transpose->setEnabled(mode == LabelMode::Notes);
+    m_showWhiteKeys->setEnabled(mode == LabelMode::Notes);
+    m_showBlackKeys->setEnabled(mode == LabelMode::Notes);
+    m_showTopLabels->setChecked(config.showTopLabels);
+    m_showBottomLabels->setChecked(config.showBottomLabels);
+    m_showLeftLabels->setChecked(config.showLeftLabels);
+    m_showRightLabels->setChecked(config.showRightLabels);
+    m_showHorizontalGrid->setChecked(config.showHorizontalGrid);
+    m_showVerticalGrid->setChecked(config.showVerticalGrid);
+    m_showWhiteKeys->setChecked(config.showWhiteKeys);
+    m_showBlackKeys->setChecked(config.showBlackKeys);
+    m_showTooltip->setChecked(config.showTooltip);
+    m_fillSpectrum->setChecked(config.fillSpectrum);
+    m_interpolate->setChecked(config.interpolate);
+    m_axisFont->setButtonFont(config.axisFont.isEmpty() ? SpectrumAxisRenderer::defaultAxisFont(widget()->font())
+                                                        : fontFromString(config.axisFont));
+
+    const bool customColours = config.colours.isValid() && config.colours.canConvert<Colours>()
+                            && !config.colours.value<Colours>().isEmpty();
+    const Colours colours    = customColours ? config.colours.value<Colours>() : Colours{};
+
+    m_colourGroup->setChecked(customColours);
+    m_textColour->setColour(colours.colour(Colours::Type::Text, widget()->palette()));
+    m_backgroundColour->setColour(colours.colour(Colours::Type::Background, widget()->palette()));
+    m_barGradient->setColours(colours.gradient(widget()->palette()));
+    m_barGradient->setOrientation(config.gradientOrientation == GradientOrientation::Vertical ? Qt::Vertical
+                                                                                              : Qt::Horizontal);
+    m_peaksColour->setColour(colours.colour(Colours::Type::Peaks, widget()->palette()));
+    m_horizontalGridColour->setColour(colours.colour(Colours::Type::HorizontalGrid, widget()->palette()));
+    m_verticalGridColour->setColour(colours.colour(Colours::Type::VerticalGrid, widget()->palette()));
+    m_octaveGridColour->setColour(colours.colour(Colours::Type::OctaveGrid, widget()->palette()));
+    m_whiteKeyColour->setColour(colours.colour(Colours::Type::WhiteKey, widget()->palette()));
+    m_blackKeyColour->setColour(colours.colour(Colours::Type::BlackKey, widget()->palette()));
+}
+} // namespace Fooyin::Spectrum
+
+#include "moc_spectrumconfigwidget.cpp"
+#include "spectrumconfigwidget.moc"

--- a/src/plugins/spectrum/spectrumconfigwidget.h
+++ b/src/plugins/spectrum/spectrumconfigwidget.h
@@ -1,0 +1,95 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "spectrumwidget.h"
+
+#include <gui/configdialog.h>
+
+class QComboBox;
+class QCheckBox;
+class QGroupBox;
+class QSpinBox;
+
+namespace Fooyin {
+class ColourButton;
+class FontButton;
+class GradientEditor;
+
+namespace Spectrum {
+class SpectrumConfigDialog : public WidgetConfigDialog<SpectrumWidget, SpectrumWidget::ConfigData>
+{
+    Q_OBJECT
+
+public:
+    explicit SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* parent = nullptr);
+
+private:
+    [[nodiscard]] SpectrumWidget::ConfigData config() const override;
+    void setConfig(const SpectrumWidget::ConfigData& config) override;
+
+    QSpinBox* m_bandCount;
+    QSpinBox* m_barSpacing;
+    QSpinBox* m_barSections;
+    QSpinBox* m_sectionSpacing;
+    QComboBox* m_labelMode;
+    QSpinBox* m_minFrequency;
+    QSpinBox* m_maxFrequency;
+    QSpinBox* m_minNote;
+    QSpinBox* m_maxNote;
+    QSpinBox* m_pitchHz;
+    QSpinBox* m_transpose;
+    QGroupBox* m_amplitudesGroup;
+    QSpinBox* m_amplitudeMinDb;
+    QSpinBox* m_amplitudeMaxDb;
+    QSpinBox* m_amplitudeHoldTime;
+    QSpinBox* m_decayTime;
+    QGroupBox* m_peaksGroup;
+    QSpinBox* m_peakHoldTime;
+    QSpinBox* m_peakGravity;
+    QSpinBox* m_updateFps;
+    QComboBox* m_fftSize;
+    QComboBox* m_windowFunction;
+    QComboBox* m_drawStyle;
+    QCheckBox* m_showTopLabels;
+    QCheckBox* m_showBottomLabels;
+    QCheckBox* m_showLeftLabels;
+    QCheckBox* m_showRightLabels;
+    QCheckBox* m_showHorizontalGrid;
+    QCheckBox* m_showVerticalGrid;
+    QCheckBox* m_showWhiteKeys;
+    QCheckBox* m_showBlackKeys;
+    QCheckBox* m_showTooltip;
+    QCheckBox* m_fillSpectrum;
+    QCheckBox* m_interpolate;
+    FontButton* m_axisFont;
+    QGroupBox* m_colourGroup;
+    ColourButton* m_textColour;
+    ColourButton* m_backgroundColour;
+    GradientEditor* m_barGradient;
+    ColourButton* m_peaksColour;
+    ColourButton* m_horizontalGridColour;
+    ColourButton* m_verticalGridColour;
+    ColourButton* m_octaveGridColour;
+    ColourButton* m_whiteKeyColour;
+    ColourButton* m_blackKeyColour;
+};
+} // namespace Spectrum
+} // namespace Fooyin

--- a/src/plugins/spectrum/spectrumconfigwidget.h
+++ b/src/plugins/spectrum/spectrumconfigwidget.h
@@ -64,7 +64,7 @@ private:
     QGroupBox* m_peaksGroup;
     QSpinBox* m_peakHoldTime;
     QSpinBox* m_peakGravity;
-    QSpinBox* m_updateFps;
+    QComboBox* m_updateFps;
     QComboBox* m_fftSize;
     QComboBox* m_windowFunction;
     QComboBox* m_drawStyle;

--- a/src/plugins/spectrum/spectrumplugin.cpp
+++ b/src/plugins/spectrum/spectrumplugin.cpp
@@ -1,0 +1,52 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "spectrumplugin.h"
+
+#include "spectrumcolours.h"
+#include "spectrumwidget.h"
+
+#include <core/engine/enginecontroller.h>
+#include <core/player/playercontroller.h>
+#include <gui/widgetprovider.h>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Spectrum {
+void SpectrumPlugin::initialise(const CorePluginContext& context)
+{
+    m_playerController = context.playerController;
+    m_engine           = context.engine;
+    m_settings         = context.settingsManager;
+}
+
+void SpectrumPlugin::initialise(const GuiPluginContext& context)
+{
+    m_widgetProvider = context.widgetProvider;
+
+    qRegisterMetaType<Fooyin::Spectrum::Colours>("Fooyin::Spectrum::Colours");
+
+    m_widgetProvider->registerWidget(
+        u"Spectrum"_s, [this]() { return new SpectrumWidget(m_engine, m_playerController, m_settings); },
+        tr("Spectrum"));
+    m_widgetProvider->setSubMenus(u"Spectrum"_s, {tr("Visualisations")});
+}
+} // namespace Fooyin::Spectrum
+
+#include "moc_spectrumplugin.cpp"

--- a/src/plugins/spectrum/spectrumplugin.h
+++ b/src/plugins/spectrum/spectrumplugin.h
@@ -1,0 +1,46 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/plugins/coreplugin.h>
+#include <core/plugins/plugin.h>
+#include <gui/plugins/guiplugin.h>
+
+namespace Fooyin::Spectrum {
+class SpectrumPlugin : public QObject,
+                       public Plugin,
+                       public CorePlugin,
+                       public GuiPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.fooyin.fooyin.plugin/1.0" FILE "spectrum.json")
+    Q_INTERFACES(Fooyin::Plugin Fooyin::CorePlugin Fooyin::GuiPlugin)
+
+public:
+    void initialise(const CorePluginContext& context) override;
+    void initialise(const GuiPluginContext& context) override;
+
+private:
+    PlayerController* m_playerController{nullptr};
+    EngineController* m_engine{nullptr};
+    SettingsManager* m_settings{nullptr};
+    WidgetProvider* m_widgetProvider{nullptr};
+};
+} // namespace Fooyin::Spectrum

--- a/src/plugins/spectrum/spectrumsettings.h
+++ b/src/plugins/spectrum/spectrumsettings.h
@@ -1,0 +1,109 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Fooyin::Spectrum {
+enum class WindowFunction : uint8_t
+{
+    BlackmanHarris = 0,
+    Hann,
+    None
+};
+
+enum class GradientOrientation : uint8_t
+{
+    Vertical = 0,
+    Horizontal
+};
+
+enum class LabelMode : uint8_t
+{
+    Frequency = 0,
+    Notes
+};
+
+enum class DrawStyle : uint8_t
+{
+    Bars = 0,
+    Curve
+};
+
+constexpr auto MinBandCount     = 1;
+constexpr auto MaxBandCount     = 2048;
+constexpr auto DefaultBandCount = 80;
+
+constexpr auto MinBarSpacing     = 0;
+constexpr auto MaxBarSpacing     = 20;
+constexpr auto DefaultBarSpacing = 1;
+
+constexpr auto MinBarSections     = 1;
+constexpr auto MaxBarSections     = 200;
+constexpr auto DefaultBarSections = 1;
+
+constexpr auto MinSectionSpacing     = 1;
+constexpr auto MaxSectionSpacing     = 20;
+constexpr auto DefaultSectionSpacing = 1;
+
+constexpr auto MinFrequencyHz        = 20;
+constexpr auto MaxFrequencyHz        = 25000;
+constexpr auto DefaultMinFrequencyHz = 50;
+constexpr auto DefaultMaxFrequencyHz = 25000;
+constexpr auto MinPitchHz            = 220;
+constexpr auto MaxPitchHz            = 880;
+constexpr auto DefaultPitchHz        = 440;
+constexpr auto MinTranspose          = -24;
+constexpr auto MaxTranspose          = 24;
+constexpr auto DefaultTranspose      = 0;
+constexpr auto MinNote               = 0;
+constexpr auto MaxNote               = 125;
+constexpr auto DefaultMinNote        = 0;
+constexpr auto DefaultMaxNote        = 125;
+
+constexpr auto MinAmplitudeDb        = -120;
+constexpr auto MaxAmplitudeDb        = 12;
+constexpr auto DefaultAmplitudeMinDb = -60;
+constexpr auto DefaultAmplitudeMaxDb = 0;
+
+constexpr auto DefaultAmplitudesEnabled   = false;
+constexpr auto MinAmplitudeHoldTimeMs     = 0;
+constexpr auto MaxAmplitudeHoldTimeMs     = 5000;
+constexpr auto DefaultAmplitudeHoldTimeMs = 0;
+constexpr auto MinAmplitudeGravity        = 0;
+constexpr auto MaxAmplitudeGravity        = 500;
+constexpr auto DefaultAmplitudeGravity    = 100;
+
+constexpr auto DefaultPeaksEnabled   = true;
+constexpr auto MinPeakHoldTimeMs     = 0;
+constexpr auto MaxPeakHoldTimeMs     = 5000;
+constexpr auto DefaultPeakHoldTimeMs = 500;
+constexpr auto MinPeakGravity        = 0;
+constexpr auto MaxPeakGravity        = 500;
+constexpr auto DefaultPeakGravity    = 50;
+
+constexpr auto MinUpdateFps     = 20;
+constexpr auto MaxUpdateFps     = 240;
+constexpr auto DefaultUpdateFps = 40;
+
+constexpr auto MinFftSize     = 256;
+constexpr auto MaxFftSize     = 16384;
+constexpr auto DefaultFftSize = 8192;
+} // namespace Fooyin::Spectrum

--- a/src/plugins/spectrum/spectrumview.cpp
+++ b/src/plugins/spectrum/spectrumview.cpp
@@ -179,7 +179,8 @@ SpectrumView::SpectrumView(EngineController* engine, PlayerController* playerCon
 
     QObject::connect(playerController, &PlayerController::playStateChanged, this,
                      [this](const Player::PlayState state) { playStateChanged(state); });
-    QObject::connect(playerController, &PlayerController::currentTrackChanged, this, [this]() { clearLevels(); });
+    QObject::connect(playerController, &PlayerController::currentTrackChanged, this,
+                     &SpectrumView::currentTrackChanged);
 }
 
 void SpectrumView::setConfig(const SpectrumWidget::ConfigData& config)
@@ -295,6 +296,13 @@ void SpectrumView::playStateChanged(Player::PlayState state)
     }
     else {
         m_updateTimer.stop();
+    }
+}
+
+void SpectrumView::currentTrackChanged()
+{
+    if(m_paused || m_stopped) {
+        clearLevels();
     }
 }
 

--- a/src/plugins/spectrum/spectrumview.cpp
+++ b/src/plugins/spectrum/spectrumview.cpp
@@ -1,0 +1,1040 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "spectrumview.h"
+
+#include <core/engine/enginecontroller.h>
+#include <core/player/playercontroller.h>
+#include <gui/widgets/gradienteditor.h>
+
+#include <QContextMenuEvent>
+#include <QFont>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+#include <QRectF>
+#include <QRegion>
+
+#include <cmath>
+#include <span>
+#include <utility>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto A4NoteIndex = 57;
+
+namespace Fooyin::Spectrum {
+namespace {
+VisualisationSession::SpectrumWindowFunction toBackendWindowFunction(WindowFunction windowFunction)
+{
+    using BackendWindow = VisualisationSession::SpectrumWindowFunction;
+
+    switch(windowFunction) {
+        case WindowFunction::BlackmanHarris:
+            return BackendWindow::BlackmanHarris;
+        case WindowFunction::Hann:
+            return BackendWindow::Hann;
+        case WindowFunction::None:
+            return BackendWindow::None;
+    }
+
+    return BackendWindow::BlackmanHarris;
+}
+
+float magnitudeToScale(float magnitude, int amplitudeMinDb, int amplitudeMaxDb)
+{
+    const float db    = 20.0F * std::log10(std::max(magnitude, 1.0e-9F));
+    const float minDb = static_cast<float>(std::min(amplitudeMinDb, amplitudeMaxDb - 1));
+    const float maxDb = static_cast<float>(std::max(amplitudeMaxDb, amplitudeMinDb + 1));
+    return std::clamp((db - minDb) / (maxDb - minDb), 0.0F, 1.0F);
+}
+
+float sampleMagnitudeAtBin(std::span<const float> bins, double binPosition)
+{
+    if(bins.empty()) {
+        return 0.0F;
+    }
+
+    const double clamped  = std::clamp(binPosition, 1.0, static_cast<double>(bins.size() - 1));
+    const auto leftBin    = static_cast<size_t>(std::floor(clamped));
+    const size_t rightBin = std::min(leftBin + 1, bins.size() - 1);
+    const auto t          = static_cast<float>(clamped - static_cast<double>(leftBin));
+    return bins[leftBin] + ((bins[rightBin] - bins[leftBin]) * t);
+}
+
+// Hermite-style interpolation
+float interpolate(std::span<const float> values, size_t index, float t)
+{
+    if(values.empty()) {
+        return 0.0F;
+    }
+    if(values.size() == 1) {
+        return values.front();
+    }
+
+    const auto valueAt = [values](std::ptrdiff_t valueIndex) {
+        if(valueIndex < 0) {
+            return values.front() - (values[1] - values.front());
+        }
+        if(std::cmp_greater_equal(valueIndex, values.size())) {
+            return values.back() + (values.back() - values[values.size() - 2]);
+        }
+        return values[valueIndex];
+    };
+
+    const auto start = static_cast<int>(index);
+    const float y0   = valueAt(start - 1);
+    const float y1   = valueAt(start);
+    const float y2   = valueAt(start + 1);
+    const float y3   = valueAt(start + 2);
+
+    static constexpr float Tension = 0.35F;
+    static constexpr float Bias    = 0.0F;
+
+    const float t2 = t * t;
+    const float t3 = t2 * t;
+    float m0       = (y1 - y0) * (1.0F + Bias) * (1.0F - Tension) * 0.5F;
+    m0 += (y2 - y1) * (1.0F - Bias) * (1.0F - Tension) * 0.5F;
+    float m1 = (y2 - y1) * (1.0F + Bias) * (1.0F - Tension) * 0.5F;
+    m1 += (y3 - y2) * (1.0F - Bias) * (1.0F - Tension) * 0.5F;
+
+    const float a0 = (2.0F * t3) - (3.0F * t2) + 1.0F;
+    const float a1 = t3 - (2.0F * t2) + t;
+    const float a2 = t3 - t2;
+    const float a3 = (-2.0F * t3) + (3.0F * t2);
+    return (a0 * y1) + (a1 * m0) + (a2 * m1) + (a3 * y2);
+}
+
+int updateIntervalFromFps(int fps)
+{
+    const int clampedFps = std::clamp(fps, MinUpdateFps, MaxUpdateFps);
+    return std::max(1, 1000 / clampedFps);
+}
+
+QFont fontFromString(const QString& fontString)
+{
+    QFont font;
+    if(!fontString.isEmpty()) {
+        font.fromString(fontString);
+    }
+    return font;
+}
+
+void drawBarOutline(QPainter& painter, const QRectF& barRect, int barHeight, const QPen& pen)
+{
+    barHeight = std::clamp(barHeight, 0, static_cast<int>(std::round(barRect.height())));
+    if(barHeight <= 0) {
+        return;
+    }
+
+    const QRectF rect{barRect.left(), barRect.bottom() - static_cast<double>(barHeight), barRect.width(),
+                      static_cast<double>(barHeight)};
+    painter.save();
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(pen);
+    painter.drawRect(rect.adjusted(0.5, 0.5, -0.5, -0.5));
+    painter.restore();
+}
+} // namespace
+
+SpectrumView::SpectrumView(EngineController* engine, PlayerController* playerController, QWidget* parent)
+    : QWidget(parent)
+    , m_session{engine->visualisationService()->createSession()}
+    , m_paused{false}
+    , m_stopped{true}
+    , m_toolTipBand{-1}
+    , m_bandMapFftSize{0}
+    , m_bandMapSampleRate{0}
+    , m_bandMapBandCount{0}
+    , m_bandMapMinFrequencyHz{0}
+    , m_bandMapMaxFrequencyHz{0}
+    , m_lowResEnd{-1}
+{
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setMouseTracking(true);
+
+    m_axisRenderer.setConfig(m_config);
+
+    m_session->requestBacklog(1000);
+
+    m_elapsedTimer.start();
+    playStateChanged(playerController ? playerController->playState() : Player::PlayState::Stopped);
+
+    QObject::connect(playerController, &PlayerController::playStateChanged, this,
+                     [this](const Player::PlayState state) { playStateChanged(state); });
+    QObject::connect(playerController, &PlayerController::currentTrackChanged, this, [this]() { clearLevels(); });
+}
+
+void SpectrumView::setConfig(const SpectrumWidget::ConfigData& config)
+{
+    m_config = config;
+    m_axisRenderer.setConfig(m_config);
+
+    const size_t bandCount = effectiveBandCount();
+    m_levels.assign(bandCount, 0.0F);
+    m_peakLevels.assign(bandCount, 0.0F);
+    m_barHeights.assign(bandCount, 0);
+    m_peakHeights.assign(bandCount, 0);
+    m_barHoldRemainingMs.assign(bandCount, 0);
+    m_peakHoldRemainingMs.assign(bandCount, 0);
+
+    updateBarGeometry();
+    invalidateBandMap();
+    invalidateStaticLayer();
+
+    m_session->requestBacklog(1000);
+
+    if(m_updateTimer.isActive() && !m_paused) {
+        startUpdateTimer();
+    }
+    if(!m_config.showTooltip) {
+        hideToolTip();
+    }
+
+    update();
+}
+
+const SpectrumWidget::ConfigData& SpectrumView::currentConfig() const
+{
+    return m_config;
+}
+
+void SpectrumView::refreshStyleColours()
+{
+    invalidateStaticLayer();
+    update();
+}
+
+void SpectrumView::paintEvent(QPaintEvent* /*event*/)
+{
+    QPainter painter{this};
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    paint(painter, rect(), palette());
+}
+
+void SpectrumView::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    updateBarGeometry();
+    invalidateStaticLayer();
+    update();
+}
+
+void SpectrumView::timerEvent(QTimerEvent* event)
+{
+    if(event->timerId() == m_updateTimer.timerId()) {
+        tick();
+        return;
+    }
+
+    QWidget::timerEvent(event);
+}
+
+void SpectrumView::mouseMoveEvent(QMouseEvent* event)
+{
+    QWidget::mouseMoveEvent(event);
+    showToolTip(event->pos());
+}
+
+void SpectrumView::leaveEvent(QEvent* event)
+{
+    QWidget::leaveEvent(event);
+    hideToolTip();
+}
+
+void SpectrumView::changeEvent(QEvent* event)
+{
+    QWidget::changeEvent(event);
+
+    switch(event->type()) {
+        case QEvent::ApplicationPaletteChange:
+        case QEvent::PaletteChange:
+        case QEvent::StyleChange:
+            refreshStyleColours();
+            break;
+        default:
+            break;
+    }
+}
+
+void SpectrumView::contextMenuEvent(QContextMenuEvent* event)
+{
+    Q_EMIT contextMenuRequested(event->globalPos());
+}
+
+void SpectrumView::playStateChanged(Player::PlayState state)
+{
+    m_paused  = state != Player::PlayState::Playing;
+    m_stopped = state == Player::PlayState::Stopped;
+
+    if(state == Player::PlayState::Stopped) {
+        hideToolTip();
+        clearLevels();
+        return;
+    }
+
+    if(state == Player::PlayState::Playing) {
+        startUpdateTimer();
+    }
+    else {
+        m_updateTimer.stop();
+    }
+}
+
+void SpectrumView::startUpdateTimer()
+{
+    m_elapsedTimer.restart();
+    m_updateTimer.start(updateIntervalFromFps(m_config.updateFps), Qt::PreciseTimer, this);
+}
+
+void SpectrumView::clearLevels()
+{
+    std::ranges::fill(m_levels, 0.0F);
+    std::ranges::fill(m_peakLevels, 0.0F);
+    std::ranges::fill(m_barHeights, 0);
+    std::ranges::fill(m_peakHeights, 0);
+    std::ranges::fill(m_barHoldRemainingMs, 0);
+    std::ranges::fill(m_peakHoldRemainingMs, 0);
+
+    if(m_paused) {
+        m_updateTimer.stop();
+    }
+    else {
+        startUpdateTimer();
+    }
+
+    update();
+}
+
+Colours SpectrumView::colours() const
+{
+    return m_config.colours.isValid() && m_config.colours.canConvert<Colours>() ? m_config.colours.value<Colours>()
+                                                                                : Colours{};
+}
+
+QFont SpectrumView::axisFont() const
+{
+    return m_config.axisFont.isEmpty() ? SpectrumAxisRenderer::defaultAxisFont(font())
+                                       : fontFromString(m_config.axisFont);
+}
+
+size_t SpectrumView::effectiveBandCount() const
+{
+    if(m_config.labelMode == LabelMode::Notes) {
+        return static_cast<size_t>(std::max(1, m_config.maxNote - m_config.minNote + 1));
+    }
+    return static_cast<size_t>(std::max(1, m_config.bandCount));
+}
+
+void SpectrumView::tick()
+{
+    if(m_paused) {
+        m_updateTimer.stop();
+        return;
+    }
+
+    const int elapsedMs          = std::max(1, static_cast<int>(m_elapsedTimer.restart()));
+    const float dbRange          = static_cast<float>(std::max(1, m_config.amplitudeMaxDb - m_config.amplitudeMinDb));
+    const float barFalloffPerMs  = static_cast<float>(std::max(0, m_config.amplitudeGravity)) / dbRange / 1000.0F;
+    const float peakFalloffPerMs = static_cast<float>(std::max(0, m_config.peakGravity)) / dbRange / 1000.0F;
+
+    QRegion dirtyRegion;
+    bool changed{false};
+
+    for(size_t index{0}; index < m_levels.size(); ++index) {
+        float& current = m_levels[index];
+        int& barHoldMs = m_barHoldRemainingMs[index];
+        float next{current};
+
+        if(m_config.amplitudesEnabled && barHoldMs > 0) {
+            barHoldMs = std::max(0, barHoldMs - elapsedMs);
+        }
+        else if(m_config.amplitudesEnabled) {
+            next = std::max(0.0F, current - (barFalloffPerMs * static_cast<float>(elapsedMs)));
+        }
+        if(next != current) {
+            current = next;
+            changed = true;
+        }
+
+        if(m_config.peaksEnabled && index < m_peakLevels.size()) {
+            float& peak = m_peakLevels[index];
+            int& holdMs = m_peakHoldRemainingMs[index];
+
+            if(holdMs > 0) {
+                holdMs = std::max(0, holdMs - elapsedMs);
+            }
+            else {
+                const float nextPeak = std::max(current, peak - (peakFalloffPerMs * static_cast<float>(elapsedMs)));
+                if(nextPeak != peak) {
+                    peak    = nextPeak;
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    changed |= renderLatestSpectrum();
+
+    if(changed) {
+        updateDirtyRegion(dirtyRegion);
+        repaintDirtyRegion(dirtyRegion);
+        refreshToolTip();
+    }
+}
+
+bool SpectrumView::renderLatestSpectrum()
+{
+    VisualisationSession::SpectrumWindow spectrum;
+    const auto windowFunction = toBackendWindowFunction(m_config.windowFunction);
+    const uint64_t endTimeMs  = m_session->currentTimeMs();
+    const bool gotSpectrum
+        = endTimeMs > 0 && m_session->getSpectrumWindowEndingAt(spectrum, endTimeMs, m_config.fftSize, windowFunction);
+
+    if(!gotSpectrum) {
+        return false;
+    }
+
+    return updateLevelsFromSpectrum(spectrum);
+}
+
+bool SpectrumView::updateLevelsFromSpectrum(const VisualisationSession::SpectrumWindow& spectrum)
+{
+    if(!spectrum.isValid() || spectrum.sampleRate <= 0 || spectrum.fftSize <= 0 || m_levels.empty()) {
+        return false;
+    }
+
+    const auto bins = spectrum.bins();
+    if(bins.empty()) {
+        return false;
+    }
+
+    ensureBandMap(spectrum);
+    std::vector<float> nextLevels(m_levels.size(), 0.0F);
+    bool changed{false};
+
+    for(size_t band{0}; band < m_levels.size() && band < m_bandBinRanges.size(); ++band) {
+        const BandBinRange& range = m_bandBinRanges[band];
+        float maxMagnitude{0.0F};
+        for(size_t bin{range.startBin}; bin < range.endBin; ++bin) {
+            maxMagnitude = std::max(maxMagnitude, bins[bin]);
+        }
+
+        nextLevels[band] = magnitudeToScale(maxMagnitude, m_config.amplitudeMinDb, m_config.amplitudeMaxDb);
+    }
+
+    if(m_lowResEnd >= 0 && m_config.interpolate && m_lowResIndices.size() >= 2) {
+        std::vector<float> anchorLevels;
+        anchorLevels.reserve(m_lowResIndices.size());
+
+        for(const int anchor : m_lowResIndices) {
+            const size_t band     = static_cast<size_t>(std::clamp(anchor, 0, static_cast<int>(m_levels.size()) - 1));
+            const size_t key      = band < m_bandKeys.size() ? m_bandKeys[band] : 1;
+            const float magnitude = key < bins.size() ? bins[key] : sampleMagnitudeAtBin(bins, m_bandCenterBins[band]);
+            anchorLevels.push_back(magnitudeToScale(magnitude, m_config.amplitudeMinDb, m_config.amplitudeMaxDb));
+        }
+
+        const int limit = std::min(m_lowResEnd, static_cast<int>(nextLevels.size()) - 1);
+        for(size_t anchorIndex{0}; anchorIndex + 1 < m_lowResIndices.size(); ++anchorIndex) {
+            const int startBand = std::clamp(m_lowResIndices[anchorIndex], 0, limit + 1);
+            const int endBand   = std::clamp(m_lowResIndices[anchorIndex + 1], startBand + 1, limit + 1);
+            const int distance  = std::max(1, endBand - startBand);
+
+            for(int band = startBand; band < endBand && band <= limit; ++band) {
+                const float t    = static_cast<float>(band - startBand) / static_cast<float>(distance);
+                nextLevels[band] = std::clamp(interpolate(anchorLevels, anchorIndex, t), 0.0F, 1.0F);
+            }
+
+            if(endBand > limit) {
+                break;
+            }
+        }
+    }
+    else if(m_lowResEnd >= 0) {
+        const int limit = std::min(m_lowResEnd, static_cast<int>(nextLevels.size()) - 1);
+        for(int band{0}; band <= limit; ++band) {
+            const double centerBin       = m_bandCenterBins[band];
+            const float sampledMagnitude = sampleMagnitudeAtBin(bins, centerBin);
+            nextLevels[band] = magnitudeToScale(sampledMagnitude, m_config.amplitudeMinDb, m_config.amplitudeMaxDb);
+        }
+    }
+
+    const auto raisePeak = [this, &changed](size_t peakBand, float level) {
+        if(!m_config.peaksEnabled || peakBand >= m_peakLevels.size() || level <= m_peakLevels[peakBand]) {
+            return;
+        }
+
+        m_peakLevels[peakBand]          = level;
+        m_peakHoldRemainingMs[peakBand] = m_config.peakHoldTimeMs;
+        changed                         = true;
+    };
+
+    for(size_t band{0}; band < m_levels.size() && band < m_bandBinRanges.size(); ++band) {
+        const float next = nextLevels[band];
+        float& current   = m_levels[band];
+
+        if(!m_config.amplitudesEnabled) {
+            if(next != current) {
+                current = next;
+                changed = true;
+            }
+
+            if(band < m_barHoldRemainingMs.size()) {
+                m_barHoldRemainingMs[band] = 0;
+            }
+
+            raisePeak(band, next);
+            continue;
+        }
+
+        if(next <= current) {
+            raisePeak(band, next);
+            continue;
+        }
+
+        current = next;
+
+        if(band < m_barHoldRemainingMs.size()) {
+            m_barHoldRemainingMs[band] = m_config.amplitudeHoldTimeMs;
+        }
+
+        raisePeak(band, next);
+        changed = true;
+    }
+
+    return changed;
+}
+
+void SpectrumView::paint(QPainter& painter, const QRect& rect, const QPalette& palette) const
+{
+    if(rect.width() <= 0 || rect.height() <= 0 || m_barRects.empty()) {
+        return;
+    }
+
+    ensureStaticLayer(palette);
+    if(!m_staticLayer.isNull()) {
+        painter.drawPixmap(rect.topLeft(), m_staticLayer, rect);
+    }
+
+    const Colours customColours{colours()};
+
+    painter.setPen(Qt::NoPen);
+
+    const QLinearGradient gradient = linearGradient(
+        m_plotRect, m_config.gradientOrientation == GradientOrientation::Vertical ? Qt::Vertical : Qt::Horizontal,
+        customColours.gradient(palette));
+
+    if(m_config.drawStyle == DrawStyle::Curve) {
+        drawCurveSpectrum(painter, QBrush{gradient});
+    }
+    else {
+        for(size_t index{0}; index < m_barRects.size() && index < m_barHeights.size(); ++index) {
+            const QRectF& barRect = m_barRects[index];
+            const int barHeight   = m_barHeights[index];
+
+            if(m_config.fillSpectrum) {
+                drawBar(painter, barRect, barHeight, QBrush{gradient});
+            }
+            else {
+                drawBarOutline(painter, barRect, barHeight, QPen{QBrush{gradient}, 1.0});
+            }
+        }
+    }
+
+    if(m_config.peaksEnabled) {
+        const QColor peaksColour = customColours.colour(Colours::Type::Peaks, palette);
+        for(size_t index{0}; index < m_barRects.size() && index < m_peakHeights.size(); ++index) {
+            const QRectF& barRect = m_barRects[index];
+            const int peakHeight  = m_peakHeights[index];
+            drawPeak(painter, barRect, peakHeight, peaksColour);
+        }
+    }
+}
+
+void SpectrumView::updateBarGeometry()
+{
+    const int bandCount = static_cast<int>(std::max<size_t>(1, m_levels.size()));
+    m_geometry          = m_axisRenderer.layout(rect(), axisFont(), bandCount);
+    m_barRects          = m_geometry.barRects;
+    m_barSourceBands    = m_geometry.sourceBands;
+    m_spectrumRect      = m_geometry.spectrumRect;
+    m_plotRect          = m_geometry.plotRect;
+
+    m_barHeights.assign(m_barRects.size(), 0);
+    m_peakHeights.assign(m_barRects.size(), 0);
+}
+
+int SpectrumView::barPixelHeight(float level) const
+{
+    return std::clamp(static_cast<int>(std::round(level * static_cast<float>(m_plotRect.height()))), 0,
+                      std::max(0, m_plotRect.height()));
+}
+
+float SpectrumView::effectiveMinFrequencyHz() const
+{
+    return m_axisRenderer.effectiveMinFrequencyHz();
+}
+
+float SpectrumView::effectiveMaxFrequencyHz() const
+{
+    return m_axisRenderer.effectiveMaxFrequencyHz();
+}
+
+std::vector<QRectF> SpectrumView::sectionRects(const QRectF& barRect) const
+{
+    if(barRect.isEmpty()) {
+        return {};
+    }
+
+    int sectionCount  = std::clamp(m_config.barSections, MinBarSections, MaxBarSections);
+    const int spacing = std::clamp(m_config.sectionSpacing, MinSectionSpacing, MaxSectionSpacing);
+
+    while(sectionCount > 1
+          && (barRect.height() - static_cast<double>(spacing * (sectionCount - 1)))
+                 < static_cast<double>(sectionCount)) {
+        --sectionCount;
+    }
+
+    std::vector<QRectF> rects;
+    rects.reserve(sectionCount);
+
+    if(sectionCount <= 1) {
+        rects.emplace_back(barRect);
+        return rects;
+    }
+
+    const auto totalSpacing    = static_cast<double>(spacing * (sectionCount - 1));
+    const double sectionHeight = std::max(1.0, (barRect.height() - totalSpacing) / sectionCount);
+
+    for(int section{0}; section < sectionCount; ++section) {
+        const double endOffset
+            = (static_cast<double>(section + 1) * sectionHeight) + static_cast<double>(section * spacing);
+        const double y = barRect.bottom() - endOffset;
+        rects.emplace_back(barRect.left(), y, barRect.width(), sectionHeight);
+    }
+
+    return rects;
+}
+
+void SpectrumView::drawBar(QPainter& painter, const QRectF& barRect, int barHeight, const QBrush& brush) const
+{
+    barHeight = std::clamp(barHeight, 0, static_cast<int>(std::round(barRect.height())));
+    if(barHeight <= 0) {
+        return;
+    }
+
+    const QRectF fillRect{barRect.left(), barRect.bottom() - static_cast<double>(barHeight), barRect.width(),
+                          static_cast<double>(barHeight)};
+    const auto sections = sectionRects(barRect);
+    for(const QRectF& section : sections) {
+        const QRectF visibleSection = section.intersected(fillRect);
+        if(!visibleSection.isEmpty()) {
+            painter.fillRect(visibleSection, brush);
+        }
+    }
+}
+
+void SpectrumView::drawPeak(QPainter& painter, const QRectF& barRect, int peakHeight, const QColor& colour) const
+{
+    peakHeight = std::clamp(peakHeight, 0, static_cast<int>(std::round(barRect.height())));
+    if(peakHeight <= 0) {
+        return;
+    }
+
+    const double peakY = std::clamp(barRect.bottom() - static_cast<double>(peakHeight),
+                                    static_cast<double>(m_plotRect.top()), static_cast<double>(m_plotRect.bottom()));
+    painter.fillRect(QRectF{barRect.left(), peakY, barRect.width(), 1.0}, colour);
+}
+
+void SpectrumView::drawCurveSpectrum(QPainter& painter, const QBrush& brush) const
+{
+    const auto count = static_cast<int>(std::min<>(m_barRects.size(), m_barHeights.size()));
+    if(count <= 0 || m_plotRect.isEmpty()) {
+        return;
+    }
+
+    QPainterPath path;
+    path.moveTo(m_barRects.front().left(), m_plotRect.bottom());
+
+    for(int index{0}; index < count; ++index) {
+        const QRectF& barRect = m_barRects[index];
+        const int height      = m_barHeights[index];
+        path.lineTo(barRect.center().x(), m_plotRect.bottom() - static_cast<double>(height));
+    }
+
+    if(m_config.fillSpectrum) {
+        path.lineTo(m_barRects[count - 1].right(), m_plotRect.bottom());
+        path.closeSubpath();
+        painter.fillPath(path, brush);
+    }
+    else {
+        painter.save();
+        painter.setBrush(Qt::NoBrush);
+        painter.setPen(QPen{brush, 1.0});
+        painter.drawPath(path);
+        painter.restore();
+    }
+}
+
+int SpectrumView::bandAtPosition(const QPoint& position) const
+{
+    if(m_stopped || !m_config.showTooltip || !m_spectrumRect.contains(position) || m_barRects.empty()) {
+        return -1;
+    }
+
+    for(size_t index{0}; index < m_barRects.size(); ++index) {
+        if(m_barRects[index].toAlignedRect().contains(position)) {
+            return sourceBandForBar(static_cast<int>(index));
+        }
+    }
+
+    if(position.x() < m_plotRect.left() || position.x() > m_plotRect.right() || m_plotRect.width() <= 0) {
+        return -1;
+    }
+
+    const int barCount = static_cast<int>(m_barRects.size());
+    const double t     = static_cast<double>(position.x() - m_plotRect.left())
+                       / static_cast<double>(std::max(1, m_plotRect.width() - 1));
+    const int bar = std::clamp(static_cast<int>(std::round(t * static_cast<double>(barCount - 1))), 0, barCount - 1);
+    return sourceBandForBar(bar);
+}
+
+int SpectrumView::sourceBandForBar(int bar) const
+{
+    if(bar < 0 || std::cmp_greater_equal(bar, m_barSourceBands.size()) || m_levels.empty()) {
+        return -1;
+    }
+    return std::clamp(m_barSourceBands[bar], 0, static_cast<int>(m_levels.size()) - 1);
+}
+
+float SpectrumView::frequencyForBand(int band) const
+{
+    return m_axisRenderer.frequencyForBand(band, static_cast<int>(m_levels.size()));
+}
+
+int SpectrumView::noteForBand(int band) const
+{
+    return m_axisRenderer.noteForBand(band, static_cast<int>(m_levels.size()));
+}
+
+QString SpectrumView::labelForBand(int band) const
+{
+    if(m_config.labelMode != LabelMode::Notes) {
+        return SpectrumAxisRenderer::formatTooltipFrequency(frequencyForBand(band));
+    }
+
+    return SpectrumAxisRenderer::formatNoteLabel(noteForBand(band));
+}
+
+std::pair<QString, QString> SpectrumView::toolTipContentForBand(int band) const
+{
+    if(band < 0 || std::cmp_greater_equal(band, m_levels.size())) {
+        return {};
+    }
+
+    const float level = std::clamp(m_levels[band], 0.0F, 1.0F);
+    const int dbValue = static_cast<int>(
+        std::round(static_cast<float>(m_config.amplitudeMinDb)
+                   + (static_cast<float>(m_config.amplitudeMaxDb - m_config.amplitudeMinDb) * level)));
+    const QString dbText = QString::number(dbValue) + u".00 dB"_s;
+
+    if(m_config.labelMode == LabelMode::Notes) {
+        return {SpectrumAxisRenderer::formatTooltipFrequency(frequencyForBand(band)) + u" ("_s + labelForBand(band)
+                    + u")"_s,
+                dbText};
+    }
+
+    return {labelForBand(band), dbText};
+}
+
+void SpectrumView::hideToolTip()
+{
+    if(m_toolTip) {
+        m_toolTip->hide();
+    }
+    m_toolTipBand = -1;
+}
+
+void SpectrumView::refreshToolTip()
+{
+    if(m_toolTipBand < 0 || !m_toolTip || !m_toolTip->isVisible()) {
+        return;
+    }
+    if(m_stopped) {
+        hideToolTip();
+        return;
+    }
+
+    const auto [text, subtext] = toolTipContentForBand(m_toolTipBand);
+    if(text.isEmpty()) {
+        hideToolTip();
+        return;
+    }
+
+    m_toolTip->setContent(text, subtext);
+}
+
+void SpectrumView::showToolTip(const QPoint& position)
+{
+    const int band = bandAtPosition(position);
+    if(band < 0) {
+        hideToolTip();
+        return;
+    }
+
+    const auto [text, subtext] = toolTipContentForBand(band);
+    if(text.isEmpty()) {
+        hideToolTip();
+        return;
+    }
+
+    if(!m_toolTip) {
+        m_toolTip = new ToolTip(window());
+    }
+
+    m_toolTipBand = band;
+    m_toolTip->setContent(text, subtext);
+    m_toolTip->show();
+    m_toolTip->raise();
+
+    static constexpr int Offset{8};
+
+    QPoint toolTipPos     = mapTo(window(), position + QPoint{Offset, 0});
+    const int windowWidth = window() ? window()->width() : width();
+
+    if(toolTipPos.x() + m_toolTip->width() > windowWidth) {
+        toolTipPos = mapTo(window(), position - QPoint{Offset, 0});
+        m_toolTip->setPosition(toolTipPos, Qt::AlignRight);
+    }
+    else {
+        m_toolTip->setPosition(toolTipPos, Qt::AlignLeft);
+    }
+}
+
+QRect SpectrumView::dirtyRectForBar(int index) const
+{
+    if(index < 0 || std::cmp_greater_equal(index, m_barRects.size())) {
+        return {};
+    }
+
+    QRect dirty = m_barRects[index].toAlignedRect().adjusted(-1, 0, 1, 0);
+    dirty.setTop(m_spectrumRect.top());
+    return dirty;
+}
+
+QRect SpectrumView::dirtyRectForSpectrum() const
+{
+    return m_spectrumRect.adjusted(-1, 0, 1, 0);
+}
+
+void SpectrumView::invalidateStaticLayer()
+{
+    m_staticLayer = QPixmap{};
+}
+
+void SpectrumView::updateDirtyRegion(QRegion& dirtyRegion)
+{
+    if(m_config.drawStyle == DrawStyle::Curve) {
+        dirtyRegion += dirtyRectForSpectrum();
+
+        for(size_t index{0}; index < m_barHeights.size() && index < m_barRects.size(); ++index) {
+            const int sourceBand = sourceBandForBar(static_cast<int>(index));
+            if(sourceBand < 0) {
+                continue;
+            }
+
+            m_barHeights[index]  = barPixelHeight(m_levels[sourceBand]);
+            m_peakHeights[index] = std::cmp_less(sourceBand, m_peakLevels.size()) && m_config.peaksEnabled
+                                     ? barPixelHeight(m_peakLevels[sourceBand])
+                                     : 0;
+        }
+        return;
+    }
+
+    for(size_t index{0}; index < m_barHeights.size() && index < m_barRects.size(); ++index) {
+        const int sourceBand = sourceBandForBar(static_cast<int>(index));
+        if(sourceBand < 0) {
+            continue;
+        }
+
+        const int newHeight     = barPixelHeight(m_levels[sourceBand]);
+        const int newPeakHeight = std::cmp_less(sourceBand, m_peakLevels.size()) && m_config.peaksEnabled
+                                    ? barPixelHeight(m_peakLevels[sourceBand])
+                                    : 0;
+
+        if(newHeight == m_barHeights[index] && newPeakHeight == m_peakHeights[index]) {
+            continue;
+        }
+
+        m_barHeights[index]  = newHeight;
+        m_peakHeights[index] = newPeakHeight;
+        dirtyRegion += dirtyRectForBar(static_cast<int>(index));
+    }
+}
+
+void SpectrumView::repaintDirtyRegion(const QRegion& dirtyRegion)
+{
+    if(!dirtyRegion.isEmpty()) {
+        repaint(dirtyRegion.boundingRect());
+    }
+}
+
+void SpectrumView::invalidateBandMap()
+{
+    m_bandBinRanges.clear();
+    m_bandKeys.clear();
+    m_bandCenterBins.clear();
+    m_lowResIndices.clear();
+
+    m_lowResEnd             = -1;
+    m_bandMapFftSize        = 0;
+    m_bandMapSampleRate     = 0;
+    m_bandMapBandCount      = 0;
+    m_bandMapMinFrequencyHz = 0;
+    m_bandMapMaxFrequencyHz = 0;
+}
+
+void SpectrumView::ensureBandMap(const VisualisationSession::SpectrumWindow& spectrum)
+{
+    const size_t bandCount = m_levels.size();
+    if(bandCount == 0 || !spectrum.isValid() || spectrum.sampleRate <= 0 || spectrum.fftSize <= 0) {
+        invalidateBandMap();
+        return;
+    }
+
+    if(m_bandMapFftSize == spectrum.fftSize && m_bandMapSampleRate == spectrum.sampleRate
+       && std::cmp_equal(m_bandMapBandCount, bandCount) && m_bandMapMinFrequencyHz == m_config.minFrequencyHz
+       && m_bandMapMaxFrequencyHz == m_config.maxFrequencyHz && m_bandBinRanges.size() == bandCount) {
+        return;
+    }
+
+    m_bandBinRanges.assign(bandCount, {});
+    m_bandKeys.assign(bandCount, 1);
+    m_bandCenterBins.assign(bandCount, 1.0);
+    m_lowResIndices.clear();
+    m_lowResEnd = -1;
+
+    const auto bins      = spectrum.bins();
+    const float nyquist  = static_cast<float>(spectrum.sampleRate) * 0.5F;
+    const float minFreq  = std::clamp(effectiveMinFrequencyHz(), 1.0F, nyquist);
+    const float maxFreq  = std::clamp(effectiveMaxFrequencyHz(), minFreq + 1.0F, nyquist);
+    const float binFreq  = static_cast<float>(spectrum.sampleRate) / static_cast<float>(spectrum.fftSize);
+    const size_t lastBin = bins.empty() ? 0 : (bins.size() - 1);
+
+    if(m_config.labelMode == LabelMode::Notes) {
+        const int noteCount   = std::max(1, m_config.maxNote - m_config.minNote + 1);
+        const double noteSize = static_cast<double>(bandCount) / static_cast<double>(noteCount);
+        const double a4Pos    = (static_cast<double>(A4NoteIndex + m_config.transpose - m_config.minNote)) * noteSize;
+        const double octave   = 12.0 * noteSize;
+
+        for(size_t band{0}; band < bandCount; ++band) {
+            const double noteFrequency
+                = static_cast<double>(m_config.pitchHz) * std::pow(2.0, (static_cast<double>(band) - a4Pos) / octave);
+            const double centerBin = noteFrequency / static_cast<double>(binFreq);
+            const size_t keyBin
+                = std::clamp(static_cast<size_t>(std::llround(centerBin)), static_cast<size_t>(1), lastBin);
+            m_bandCenterBins[band] = std::clamp(centerBin, 1.0, static_cast<double>(lastBin));
+            m_bandKeys[band]       = keyBin;
+        }
+    }
+    else {
+        const double ratio = static_cast<double>(maxFreq) / static_cast<double>(minFreq);
+        for(size_t band{0}; band < bandCount; ++band) {
+            const double t = bandCount > 1 ? static_cast<double>(band) / static_cast<double>(bandCount - 1) : 0.0;
+            const double centerFreq = static_cast<double>(minFreq) * std::pow(ratio, t);
+            const double centerBin  = centerFreq / static_cast<double>(binFreq);
+            const size_t keyBin
+                = std::clamp(static_cast<size_t>(std::llround(centerBin)), static_cast<size_t>(1), lastBin);
+            m_bandCenterBins[band] = std::clamp(centerBin, 1.0, static_cast<double>(lastBin));
+            m_bandKeys[band]       = keyBin;
+        }
+    }
+
+    for(size_t band{0}; band < bandCount; ++band) {
+        const size_t k0 = m_bandKeys[band > 0 ? band - 1 : 0];
+        const size_t k1 = m_bandKeys[band];
+        const size_t k2 = m_bandKeys[std::min(band + 1, bandCount - 1)];
+
+        auto startBin = static_cast<size_t>(std::ceil((static_cast<double>(k1 - k0) * 0.5) + static_cast<double>(k0)));
+        auto endBin   = static_cast<size_t>(std::ceil((static_cast<double>(k2 - k1) * 0.5) + static_cast<double>(k1)));
+
+        startBin = std::clamp(startBin, static_cast<size_t>(1), lastBin);
+        endBin   = std::clamp(endBin, static_cast<size_t>(1), lastBin);
+
+        if(startBin >= endBin) {
+            endBin = std::min(lastBin + 1, startBin + 1);
+        }
+        else {
+            endBin = std::min(lastBin + 1, endBin);
+        }
+
+        m_bandBinRanges[band] = {.startBin = startBin, .endBin = endBin};
+    }
+
+    for(size_t band{1}; band < bandCount; ++band) {
+        if(m_bandKeys[band] == m_bandKeys[band - 1]) {
+            m_lowResEnd = static_cast<int>(band);
+        }
+    }
+
+    if(m_lowResEnd > 0) {
+        size_t lastKey{0};
+        bool haveLastKey{false};
+
+        for(int band = 0; band <= m_lowResEnd; ++band) {
+            const size_t key = m_bandKeys[band];
+            if(!haveLastKey || key != lastKey) {
+                m_lowResIndices.push_back(band);
+                lastKey     = key;
+                haveLastKey = true;
+            }
+        }
+
+        for(int band = m_lowResEnd + 1; std::cmp_less(band, bandCount) && band < (m_lowResEnd + 4); ++band) {
+            m_lowResIndices.push_back(band);
+        }
+    }
+
+    m_bandMapFftSize        = spectrum.fftSize;
+    m_bandMapSampleRate     = spectrum.sampleRate;
+    m_bandMapBandCount      = static_cast<int>(bandCount);
+    m_bandMapMinFrequencyHz = m_config.minFrequencyHz;
+    m_bandMapMaxFrequencyHz = m_config.maxFrequencyHz;
+}
+
+void SpectrumView::ensureStaticLayer(const QPalette& palette) const
+{
+    const QSize size = this->size();
+    const qreal dpr  = devicePixelRatioF();
+
+    if(!m_staticLayer.isNull() && m_staticLayer.size() == (size * dpr)
+       && qFuzzyCompare(m_staticLayer.devicePixelRatio(), dpr)) {
+        return;
+    }
+
+    m_staticLayer = QPixmap{size * dpr};
+    m_staticLayer.setDevicePixelRatio(dpr);
+
+    QPainter painter{&m_staticLayer};
+    m_axisRenderer.paint(painter, m_geometry, size, palette, axisFont());
+}
+} // namespace Fooyin::Spectrum
+
+#include "moc_spectrumview.cpp"

--- a/src/plugins/spectrum/spectrumview.h
+++ b/src/plugins/spectrum/spectrumview.h
@@ -1,0 +1,154 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "spectrumaxisrenderer.h"
+#include "spectrumcolours.h"
+#include "spectrumwidget.h"
+
+#include <core/engine/visualisationservice.h>
+#include <core/player/playerdefs.h>
+#include <gui/widgets/tooltip.h>
+
+#include <QBasicTimer>
+#include <QElapsedTimer>
+#include <QPointer>
+#include <QWidget>
+
+#include <vector>
+
+namespace Fooyin {
+class EngineController;
+class PlayerController;
+
+namespace Spectrum {
+class SpectrumView : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SpectrumView(EngineController* engine, PlayerController* playerController, QWidget* parent = nullptr);
+
+    void setConfig(const SpectrumWidget::ConfigData& config);
+    void refreshStyleColours();
+    [[nodiscard]] const SpectrumWidget::ConfigData& currentConfig() const;
+
+Q_SIGNALS:
+    void contextMenuRequested(const QPoint& pos);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void timerEvent(QTimerEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    void changeEvent(QEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+private:
+    struct BandBinRange
+    {
+        size_t startBin{1};
+        size_t endBin{1};
+    };
+
+    void playStateChanged(Player::PlayState state);
+
+    void startUpdateTimer();
+
+    void clearLevels();
+
+    [[nodiscard]] Colours colours() const;
+    [[nodiscard]] QFont axisFont() const;
+    [[nodiscard]] size_t effectiveBandCount() const;
+
+    void tick();
+    bool renderLatestSpectrum();
+    bool updateLevelsFromSpectrum(const VisualisationSession::SpectrumWindow& spectrum);
+
+    void paint(QPainter& painter, const QRect& rect, const QPalette& palette) const;
+
+    void updateBarGeometry();
+
+    [[nodiscard]] int barPixelHeight(float level) const;
+    [[nodiscard]] float effectiveMinFrequencyHz() const;
+    [[nodiscard]] float effectiveMaxFrequencyHz() const;
+    [[nodiscard]] std::vector<QRectF> sectionRects(const QRectF& barRect) const;
+
+    void drawBar(QPainter& painter, const QRectF& barRect, int barHeight, const QBrush& brush) const;
+    void drawPeak(QPainter& painter, const QRectF& barRect, int peakHeight, const QColor& colour) const;
+    void drawCurveSpectrum(QPainter& painter, const QBrush& brush) const;
+
+    [[nodiscard]] int bandAtPosition(const QPoint& position) const;
+    [[nodiscard]] int sourceBandForBar(int bar) const;
+    [[nodiscard]] float frequencyForBand(int band) const;
+    [[nodiscard]] int noteForBand(int band) const;
+    [[nodiscard]] QString labelForBand(int band) const;
+    [[nodiscard]] std::pair<QString, QString> toolTipContentForBand(int band) const;
+
+    void hideToolTip();
+    void refreshToolTip();
+    void showToolTip(const QPoint& position);
+
+    [[nodiscard]] QRect dirtyRectForBar(int index) const;
+    [[nodiscard]] QRect dirtyRectForSpectrum() const;
+
+    void invalidateStaticLayer();
+    void updateDirtyRegion(QRegion& dirtyRegion);
+    void repaintDirtyRegion(const QRegion& dirtyRegion);
+
+    void invalidateBandMap();
+    void ensureBandMap(const VisualisationSession::SpectrumWindow& spectrum);
+    void ensureStaticLayer(const QPalette& palette) const;
+
+    VisualisationSessionPtr m_session;
+    SpectrumWidget::ConfigData m_config;
+    SpectrumAxisRenderer m_axisRenderer;
+    std::vector<float> m_levels;
+    std::vector<float> m_peakLevels;
+    std::vector<int> m_barHeights;
+    std::vector<int> m_peakHeights;
+    std::vector<int> m_barHoldRemainingMs;
+    std::vector<int> m_peakHoldRemainingMs;
+    SpectrumPlotGeometry m_geometry;
+    std::vector<QRectF> m_barRects;
+    std::vector<int> m_barSourceBands;
+    QRect m_spectrumRect;
+    QRect m_plotRect;
+    std::vector<BandBinRange> m_bandBinRanges;
+    std::vector<size_t> m_bandKeys;
+    std::vector<double> m_bandCenterBins;
+    std::vector<int> m_lowResIndices;
+    bool m_paused;
+    bool m_stopped;
+    QBasicTimer m_updateTimer;
+    QElapsedTimer m_elapsedTimer;
+    QPointer<ToolTip> m_toolTip;
+    int m_toolTipBand;
+    mutable QPixmap m_staticLayer;
+    int m_bandMapFftSize;
+    int m_bandMapSampleRate;
+    int m_bandMapBandCount;
+    int m_bandMapMinFrequencyHz;
+    int m_bandMapMaxFrequencyHz;
+    int m_lowResEnd;
+};
+} // namespace Spectrum
+} // namespace Fooyin

--- a/src/plugins/spectrum/spectrumview.h
+++ b/src/plugins/spectrum/spectrumview.h
@@ -70,6 +70,7 @@ private:
     };
 
     void playStateChanged(Player::PlayState state);
+    void currentTrackChanged();
 
     void startUpdateTimer();
 

--- a/src/plugins/spectrum/spectrumwidget.cpp
+++ b/src/plugins/spectrum/spectrumwidget.cpp
@@ -1,0 +1,636 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "spectrumwidget.h"
+
+#include "spectrumcolours.h"
+#include "spectrumconfigwidget.h"
+#include "spectrumview.h"
+
+#include <gui/guisettings.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QColor>
+#include <QContextMenuEvent>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QMenu>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto BandCountKey           = u"Spectrum/BandCount";
+constexpr auto BarSpacingKey          = u"Spectrum/BarSpacing";
+constexpr auto LegacyBarWidthKey      = u"Spectrum/BarWidth";
+constexpr auto LegacyBarAlignmentKey  = u"Spectrum/BarAlignment";
+constexpr auto BarSectionsKey         = u"Spectrum/BarSections";
+constexpr auto SectionSpacingKey      = u"Spectrum/SectionSpacing";
+constexpr auto MinFrequencyKey        = u"Spectrum/MinFrequencyHz";
+constexpr auto MaxFrequencyKey        = u"Spectrum/MaxFrequencyHz";
+constexpr auto MinNoteKey             = u"Spectrum/MinNote";
+constexpr auto MaxNoteKey             = u"Spectrum/MaxNote";
+constexpr auto PitchHzKey             = u"Spectrum/PitchHz";
+constexpr auto TransposeKey           = u"Spectrum/Transpose";
+constexpr auto AmplitudeMinDbKey      = u"Spectrum/AmplitudeMinDb";
+constexpr auto AmplitudeMaxDbKey      = u"Spectrum/AmplitudeMaxDb";
+constexpr auto ChannelModeKey         = u"Spectrum/ChannelMode";
+constexpr auto AmplitudesEnabledKey   = u"Spectrum/AmplitudesEnabled";
+constexpr auto AmplitudeHoldTimeKey   = u"Spectrum/AmplitudeHoldTimeMs";
+constexpr auto AmplitudeGravityKey    = u"Spectrum/AmplitudeGravity";
+constexpr auto PeaksEnabledKey        = u"Spectrum/PeaksEnabled";
+constexpr auto PeakHoldTimeKey        = u"Spectrum/PeakHoldTimeMs";
+constexpr auto PeakGravityKey         = u"Spectrum/PeakGravity";
+constexpr auto UpdateFpsKey           = u"Spectrum/UpdateFps";
+constexpr auto FftSizeKey             = u"Spectrum/FftSize";
+constexpr auto WindowFunctionKey      = u"Spectrum/WindowFunction";
+constexpr auto GradientOrientationKey = u"Spectrum/GradientOrientation";
+constexpr auto LabelModeKey           = u"Spectrum/LabelMode";
+constexpr auto DrawStyleKey           = u"Spectrum/DrawStyle";
+constexpr auto ShowTopLabelsKey       = u"Spectrum/ShowTopLabels";
+constexpr auto ShowBottomLabelsKey    = u"Spectrum/ShowBottomLabels";
+constexpr auto ShowLeftLabelsKey      = u"Spectrum/ShowLeftLabels";
+constexpr auto ShowRightLabelsKey     = u"Spectrum/ShowRightLabels";
+constexpr auto ShowHorizontalGridKey  = u"Spectrum/ShowHorizontalGrid";
+constexpr auto ShowVerticalGridKey    = u"Spectrum/ShowVerticalGrid";
+constexpr auto ShowWhiteKeysKey       = u"Spectrum/ShowWhiteKeys";
+constexpr auto ShowBlackKeysKey       = u"Spectrum/ShowBlackKeys";
+constexpr auto ShowTooltipKey         = u"Spectrum/ShowTooltip";
+constexpr auto FillSpectrumKey        = u"Spectrum/FillSpectrum";
+constexpr auto InterpolateKey         = u"Spectrum/Interpolate";
+constexpr auto AxisFontKey            = u"Spectrum/AxisFont";
+constexpr auto ColoursKey             = u"Spectrum/Colours";
+
+namespace Fooyin::Spectrum {
+namespace {
+int normaliseFftSize(int fftSize)
+{
+    const int normalized = std::clamp(fftSize, MinFftSize, MaxFftSize);
+    if((normalized & (normalized - 1)) == 0) {
+        return normalized;
+    }
+
+    int power = MinFftSize;
+    while(power < normalized && power < MaxFftSize) {
+        power <<= 1;
+    }
+    return std::clamp(power, MinFftSize, MaxFftSize);
+}
+} // namespace
+
+SpectrumWidget::SpectrumWidget(EngineController* engine, PlayerController* playerController, SettingsManager* settings,
+                               QWidget* parent)
+    : FyWidget{parent}
+    , m_settings{settings}
+    , m_view{new SpectrumView(engine, playerController, this)}
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins({});
+    layout->addWidget(m_view);
+
+    QObject::connect(m_view, &SpectrumView::contextMenuRequested, this, &SpectrumWidget::showContextMenu);
+
+    m_config = defaultConfig();
+    applyConfig(m_config);
+
+    const auto updateThemeColours = [this]() {
+        m_view->refreshStyleColours();
+    };
+    m_settings->subscribe<Settings::Gui::Theme>(this, updateThemeColours);
+    m_settings->subscribe<Settings::Gui::Style>(this, updateThemeColours);
+}
+
+SpectrumWidget::~SpectrumWidget() = default;
+
+QString SpectrumWidget::name() const
+{
+    return tr("Spectrum");
+}
+
+QString SpectrumWidget::layoutName() const
+{
+    return u"Spectrum"_s;
+}
+
+void SpectrumWidget::saveLayoutData(QJsonObject& layout)
+{
+    saveConfigToLayout(m_config, layout);
+}
+
+void SpectrumWidget::loadLayoutData(const QJsonObject& layout)
+{
+    applyConfig(configFromLayout(layout));
+}
+
+SpectrumWidget::ConfigData SpectrumWidget::factoryConfig() const
+{
+    return {};
+}
+
+SpectrumWidget::ConfigData SpectrumWidget::defaultConfig() const
+{
+    auto config{factoryConfig()};
+
+    config.bandCount           = m_settings->fileValue(BandCountKey, config.bandCount).toInt();
+    config.barSpacing          = m_settings->fileValue(BarSpacingKey, config.barSpacing).toInt();
+    config.barSections         = m_settings->fileValue(BarSectionsKey, config.barSections).toInt();
+    config.sectionSpacing      = m_settings->fileValue(SectionSpacingKey, config.sectionSpacing).toInt();
+    config.minFrequencyHz      = m_settings->fileValue(MinFrequencyKey, config.minFrequencyHz).toInt();
+    config.maxFrequencyHz      = m_settings->fileValue(MaxFrequencyKey, config.maxFrequencyHz).toInt();
+    config.minNote             = m_settings->fileValue(MinNoteKey, config.minNote).toInt();
+    config.maxNote             = m_settings->fileValue(MaxNoteKey, config.maxNote).toInt();
+    config.pitchHz             = m_settings->fileValue(PitchHzKey, config.pitchHz).toInt();
+    config.transpose           = m_settings->fileValue(TransposeKey, config.transpose).toInt();
+    config.amplitudeMinDb      = m_settings->fileValue(AmplitudeMinDbKey, config.amplitudeMinDb).toInt();
+    config.amplitudeMaxDb      = m_settings->fileValue(AmplitudeMaxDbKey, config.amplitudeMaxDb).toInt();
+    config.amplitudesEnabled   = m_settings->fileValue(AmplitudesEnabledKey, config.amplitudesEnabled).toBool();
+    config.amplitudeHoldTimeMs = m_settings->fileValue(AmplitudeHoldTimeKey, config.amplitudeHoldTimeMs).toInt();
+    config.amplitudeGravity    = m_settings->fileValue(AmplitudeGravityKey, config.amplitudeGravity).toInt();
+    config.peaksEnabled        = m_settings->fileValue(PeaksEnabledKey, config.peaksEnabled).toBool();
+    config.peakHoldTimeMs      = m_settings->fileValue(PeakHoldTimeKey, config.peakHoldTimeMs).toInt();
+    config.peakGravity         = m_settings->fileValue(PeakGravityKey, config.peakGravity).toInt();
+    config.updateFps           = m_settings->fileValue(UpdateFpsKey, config.updateFps).toInt();
+    config.fftSize             = m_settings->fileValue(FftSizeKey, config.fftSize).toInt();
+    config.windowFunction      = static_cast<WindowFunction>(
+        m_settings->fileValue(WindowFunctionKey, static_cast<int>(config.windowFunction)).toInt());
+    config.gradientOrientation = static_cast<GradientOrientation>(
+        m_settings->fileValue(GradientOrientationKey, static_cast<int>(config.gradientOrientation)).toInt());
+    config.labelMode
+        = static_cast<LabelMode>(m_settings->fileValue(LabelModeKey, static_cast<int>(config.labelMode)).toInt());
+    config.drawStyle
+        = static_cast<DrawStyle>(m_settings->fileValue(DrawStyleKey, static_cast<int>(config.drawStyle)).toInt());
+    config.showTopLabels      = m_settings->fileValue(ShowTopLabelsKey, config.showTopLabels).toBool();
+    config.showBottomLabels   = m_settings->fileValue(ShowBottomLabelsKey, config.showBottomLabels).toBool();
+    config.showLeftLabels     = m_settings->fileValue(ShowLeftLabelsKey, config.showLeftLabels).toBool();
+    config.showRightLabels    = m_settings->fileValue(ShowRightLabelsKey, config.showRightLabels).toBool();
+    config.showHorizontalGrid = m_settings->fileValue(ShowHorizontalGridKey, config.showHorizontalGrid).toBool();
+    config.showVerticalGrid   = m_settings->fileValue(ShowVerticalGridKey, config.showVerticalGrid).toBool();
+    config.showWhiteKeys      = m_settings->fileValue(ShowWhiteKeysKey, config.showWhiteKeys).toBool();
+    config.showBlackKeys      = m_settings->fileValue(ShowBlackKeysKey, config.showBlackKeys).toBool();
+    config.showTooltip        = m_settings->fileValue(ShowTooltipKey, config.showTooltip).toBool();
+    config.fillSpectrum       = m_settings->fileValue(FillSpectrumKey, config.fillSpectrum).toBool();
+    config.interpolate        = m_settings->fileValue(InterpolateKey, config.interpolate).toBool();
+    config.axisFont           = m_settings->fileValue(AxisFontKey, config.axisFont).toString();
+    config.colours            = m_settings->fileValue(ColoursKey, config.colours);
+
+    return config;
+}
+
+const SpectrumWidget::ConfigData& SpectrumWidget::currentConfig() const
+{
+    return m_config;
+}
+
+void SpectrumWidget::saveDefaults(const ConfigData& config) const
+{
+    auto validated{config};
+    validated.bandCount      = std::clamp(validated.bandCount, MinBandCount, MaxBandCount);
+    validated.barSpacing     = std::clamp(validated.barSpacing, MinBarSpacing, MaxBarSpacing);
+    validated.barSections    = std::clamp(validated.barSections, MinBarSections, MaxBarSections);
+    validated.sectionSpacing = std::clamp(validated.sectionSpacing, MinSectionSpacing, MaxSectionSpacing);
+    validated.minFrequencyHz = std::clamp(validated.minFrequencyHz, MinFrequencyHz, MaxFrequencyHz);
+    validated.maxFrequencyHz = std::clamp(validated.maxFrequencyHz, validated.minFrequencyHz + 1, MaxFrequencyHz);
+    validated.minNote        = std::clamp(validated.minNote, MinNote, MaxNote - 12);
+    validated.maxNote        = std::clamp(validated.maxNote, validated.minNote + 12, MaxNote);
+    validated.pitchHz        = std::clamp(validated.pitchHz, MinPitchHz, MaxPitchHz);
+    validated.transpose      = std::clamp(validated.transpose, MinTranspose, MaxTranspose);
+    validated.amplitudeMinDb = std::clamp(validated.amplitudeMinDb, MinAmplitudeDb, MaxAmplitudeDb);
+    validated.amplitudeMaxDb = std::clamp(validated.amplitudeMaxDb, validated.amplitudeMinDb + 1, MaxAmplitudeDb);
+    validated.amplitudeHoldTimeMs
+        = std::clamp(validated.amplitudeHoldTimeMs, MinAmplitudeHoldTimeMs, MaxAmplitudeHoldTimeMs);
+    validated.amplitudeGravity = std::clamp(validated.amplitudeGravity, MinAmplitudeGravity, MaxAmplitudeGravity);
+    validated.peakHoldTimeMs   = std::clamp(validated.peakHoldTimeMs, MinPeakHoldTimeMs, MaxPeakHoldTimeMs);
+    validated.peakGravity      = std::clamp(validated.peakGravity, MinPeakGravity, MaxPeakGravity);
+    validated.updateFps        = std::clamp(validated.updateFps, MinUpdateFps, MaxUpdateFps);
+    validated.fftSize          = normaliseFftSize(validated.fftSize);
+    validated.windowFunction
+        = std::clamp(validated.windowFunction, WindowFunction::BlackmanHarris, WindowFunction::None);
+    validated.gradientOrientation
+        = std::clamp(validated.gradientOrientation, GradientOrientation::Vertical, GradientOrientation::Horizontal);
+    validated.labelMode = std::clamp(validated.labelMode, LabelMode::Frequency, LabelMode::Notes);
+    validated.drawStyle = std::clamp(validated.drawStyle, DrawStyle::Bars, DrawStyle::Curve);
+
+    if(!validated.colours.canConvert<Colours>()
+       || (validated.colours.isValid() && validated.colours.value<Colours>().isEmpty())) {
+        validated.colours = QVariant{};
+    }
+
+    m_settings->fileSet(BandCountKey, validated.bandCount);
+    m_settings->fileSet(BarSpacingKey, validated.barSpacing);
+    m_settings->fileRemove(LegacyBarWidthKey);
+    m_settings->fileRemove(LegacyBarAlignmentKey);
+    m_settings->fileSet(BarSectionsKey, validated.barSections);
+    m_settings->fileSet(SectionSpacingKey, validated.sectionSpacing);
+    m_settings->fileSet(MinFrequencyKey, validated.minFrequencyHz);
+    m_settings->fileSet(MaxFrequencyKey, validated.maxFrequencyHz);
+    m_settings->fileSet(MinNoteKey, validated.minNote);
+    m_settings->fileSet(MaxNoteKey, validated.maxNote);
+    m_settings->fileSet(PitchHzKey, validated.pitchHz);
+    m_settings->fileSet(TransposeKey, validated.transpose);
+    m_settings->fileSet(AmplitudeMinDbKey, validated.amplitudeMinDb);
+    m_settings->fileSet(AmplitudeMaxDbKey, validated.amplitudeMaxDb);
+    m_settings->fileSet(AmplitudesEnabledKey, validated.amplitudesEnabled);
+    m_settings->fileSet(AmplitudeHoldTimeKey, validated.amplitudeHoldTimeMs);
+    m_settings->fileSet(AmplitudeGravityKey, validated.amplitudeGravity);
+    m_settings->fileSet(PeaksEnabledKey, validated.peaksEnabled);
+    m_settings->fileSet(PeakHoldTimeKey, validated.peakHoldTimeMs);
+    m_settings->fileSet(PeakGravityKey, validated.peakGravity);
+    m_settings->fileSet(UpdateFpsKey, validated.updateFps);
+    m_settings->fileSet(FftSizeKey, validated.fftSize);
+    m_settings->fileSet(WindowFunctionKey, static_cast<int>(validated.windowFunction));
+    m_settings->fileSet(GradientOrientationKey, static_cast<int>(validated.gradientOrientation));
+    m_settings->fileSet(LabelModeKey, static_cast<int>(validated.labelMode));
+    m_settings->fileSet(DrawStyleKey, static_cast<int>(validated.drawStyle));
+    m_settings->fileSet(ShowTopLabelsKey, validated.showTopLabels);
+    m_settings->fileSet(ShowBottomLabelsKey, validated.showBottomLabels);
+    m_settings->fileSet(ShowLeftLabelsKey, validated.showLeftLabels);
+    m_settings->fileSet(ShowRightLabelsKey, validated.showRightLabels);
+    m_settings->fileSet(ShowHorizontalGridKey, validated.showHorizontalGrid);
+    m_settings->fileSet(ShowVerticalGridKey, validated.showVerticalGrid);
+    m_settings->fileSet(ShowWhiteKeysKey, validated.showWhiteKeys);
+    m_settings->fileSet(ShowBlackKeysKey, validated.showBlackKeys);
+    m_settings->fileSet(ShowTooltipKey, validated.showTooltip);
+    m_settings->fileSet(FillSpectrumKey, validated.fillSpectrum);
+    m_settings->fileSet(InterpolateKey, validated.interpolate);
+    m_settings->fileSet(AxisFontKey, validated.axisFont);
+    m_settings->fileSet(ColoursKey, validated.colours);
+}
+
+void SpectrumWidget::clearSavedDefaults() const
+{
+    m_settings->fileRemove(BandCountKey);
+    m_settings->fileRemove(BarSpacingKey);
+    m_settings->fileRemove(LegacyBarWidthKey);
+    m_settings->fileRemove(LegacyBarAlignmentKey);
+    m_settings->fileRemove(BarSectionsKey);
+    m_settings->fileRemove(SectionSpacingKey);
+    m_settings->fileRemove(MinFrequencyKey);
+    m_settings->fileRemove(MaxFrequencyKey);
+    m_settings->fileRemove(MinNoteKey);
+    m_settings->fileRemove(MaxNoteKey);
+    m_settings->fileRemove(PitchHzKey);
+    m_settings->fileRemove(TransposeKey);
+    m_settings->fileRemove(AmplitudeMinDbKey);
+    m_settings->fileRemove(AmplitudeMaxDbKey);
+    m_settings->fileRemove(ChannelModeKey);
+    m_settings->fileRemove(AmplitudesEnabledKey);
+    m_settings->fileRemove(AmplitudeHoldTimeKey);
+    m_settings->fileRemove(AmplitudeGravityKey);
+    m_settings->fileRemove(PeaksEnabledKey);
+    m_settings->fileRemove(PeakHoldTimeKey);
+    m_settings->fileRemove(PeakGravityKey);
+    m_settings->fileRemove(UpdateFpsKey);
+    m_settings->fileRemove(FftSizeKey);
+    m_settings->fileRemove(WindowFunctionKey);
+    m_settings->fileRemove(GradientOrientationKey);
+    m_settings->fileRemove(LabelModeKey);
+    m_settings->fileRemove(DrawStyleKey);
+    m_settings->fileRemove(ShowTopLabelsKey);
+    m_settings->fileRemove(ShowBottomLabelsKey);
+    m_settings->fileRemove(ShowLeftLabelsKey);
+    m_settings->fileRemove(ShowRightLabelsKey);
+    m_settings->fileRemove(ShowHorizontalGridKey);
+    m_settings->fileRemove(ShowVerticalGridKey);
+    m_settings->fileRemove(ShowWhiteKeysKey);
+    m_settings->fileRemove(ShowBlackKeysKey);
+    m_settings->fileRemove(ShowTooltipKey);
+    m_settings->fileRemove(FillSpectrumKey);
+    m_settings->fileRemove(InterpolateKey);
+    m_settings->fileRemove(AxisFontKey);
+    m_settings->fileRemove(ColoursKey);
+}
+
+void SpectrumWidget::applyConfig(const ConfigData& config)
+{
+    auto validated{config};
+    validated.bandCount      = std::clamp(validated.bandCount, MinBandCount, MaxBandCount);
+    validated.barSpacing     = std::clamp(validated.barSpacing, MinBarSpacing, MaxBarSpacing);
+    validated.barSections    = std::clamp(validated.barSections, MinBarSections, MaxBarSections);
+    validated.sectionSpacing = std::clamp(validated.sectionSpacing, MinSectionSpacing, MaxSectionSpacing);
+    validated.minFrequencyHz = std::clamp(validated.minFrequencyHz, MinFrequencyHz, MaxFrequencyHz);
+    validated.maxFrequencyHz = std::clamp(validated.maxFrequencyHz, validated.minFrequencyHz + 1, MaxFrequencyHz);
+    validated.minNote        = std::clamp(validated.minNote, MinNote, MaxNote - 12);
+    validated.maxNote        = std::clamp(validated.maxNote, validated.minNote + 12, MaxNote);
+    validated.pitchHz        = std::clamp(validated.pitchHz, MinPitchHz, MaxPitchHz);
+    validated.transpose      = std::clamp(validated.transpose, MinTranspose, MaxTranspose);
+    validated.amplitudeMinDb = std::clamp(validated.amplitudeMinDb, MinAmplitudeDb, MaxAmplitudeDb);
+    validated.amplitudeMaxDb = std::clamp(validated.amplitudeMaxDb, validated.amplitudeMinDb + 1, MaxAmplitudeDb);
+    validated.amplitudeHoldTimeMs
+        = std::clamp(validated.amplitudeHoldTimeMs, MinAmplitudeHoldTimeMs, MaxAmplitudeHoldTimeMs);
+    validated.amplitudeGravity = std::clamp(validated.amplitudeGravity, MinAmplitudeGravity, MaxAmplitudeGravity);
+    validated.peakHoldTimeMs   = std::clamp(validated.peakHoldTimeMs, MinPeakHoldTimeMs, MaxPeakHoldTimeMs);
+    validated.peakGravity      = std::clamp(validated.peakGravity, MinPeakGravity, MaxPeakGravity);
+    validated.updateFps        = std::clamp(validated.updateFps, MinUpdateFps, MaxUpdateFps);
+    validated.fftSize          = normaliseFftSize(validated.fftSize);
+    validated.windowFunction
+        = std::clamp(validated.windowFunction, WindowFunction::BlackmanHarris, WindowFunction::None);
+    validated.gradientOrientation
+        = std::clamp(validated.gradientOrientation, GradientOrientation::Vertical, GradientOrientation::Horizontal);
+    validated.labelMode = std::clamp(validated.labelMode, LabelMode::Frequency, LabelMode::Notes);
+    validated.drawStyle = std::clamp(validated.drawStyle, DrawStyle::Bars, DrawStyle::Curve);
+
+    if(!validated.colours.canConvert<Colours>()
+       || (validated.colours.isValid() && validated.colours.value<Colours>().isEmpty())) {
+        validated.colours = QVariant{};
+    }
+
+    m_config = validated;
+    m_view->setConfig(m_config);
+}
+
+QSize SpectrumWidget::minimumSizeHint() const
+{
+    return {32, 24};
+}
+
+void SpectrumWidget::contextMenuEvent(QContextMenuEvent* event)
+{
+    showContextMenu(event->globalPos());
+}
+
+void SpectrumWidget::openConfigDialog()
+{
+    showConfigDialog(new SpectrumConfigDialog(this, this));
+}
+
+SpectrumWidget::ConfigData SpectrumWidget::configFromLayout(const QJsonObject& layout) const
+{
+    ConfigData config{defaultConfig()};
+
+    if(layout.contains("BandCount"_L1)) {
+        config.bandCount = layout.value("BandCount"_L1).toInt();
+    }
+    if(layout.contains("BarSpacing"_L1)) {
+        config.barSpacing = layout.value("BarSpacing"_L1).toInt();
+    }
+    if(layout.contains("BarSections"_L1)) {
+        config.barSections = layout.value("BarSections"_L1).toInt();
+    }
+    if(layout.contains("SectionSpacing"_L1)) {
+        config.sectionSpacing = layout.value("SectionSpacing"_L1).toInt();
+    }
+    if(layout.contains("MinFrequencyHz"_L1)) {
+        config.minFrequencyHz = layout.value("MinFrequencyHz"_L1).toInt();
+    }
+    if(layout.contains("MaxFrequencyHz"_L1)) {
+        config.maxFrequencyHz = layout.value("MaxFrequencyHz"_L1).toInt();
+    }
+    if(layout.contains("MinNote"_L1)) {
+        config.minNote = layout.value("MinNote"_L1).toInt();
+    }
+    if(layout.contains("MaxNote"_L1)) {
+        config.maxNote = layout.value("MaxNote"_L1).toInt();
+    }
+    if(layout.contains("PitchHz"_L1)) {
+        config.pitchHz = layout.value("PitchHz"_L1).toInt();
+    }
+    if(layout.contains("Transpose"_L1)) {
+        config.transpose = layout.value("Transpose"_L1).toInt();
+    }
+    if(layout.contains("AmplitudeMinDb"_L1)) {
+        config.amplitudeMinDb = layout.value("AmplitudeMinDb"_L1).toInt();
+    }
+    if(layout.contains("AmplitudeMaxDb"_L1)) {
+        config.amplitudeMaxDb = layout.value("AmplitudeMaxDb"_L1).toInt();
+    }
+    if(layout.contains("AmplitudesEnabled"_L1)) {
+        config.amplitudesEnabled = layout.value("AmplitudesEnabled"_L1).toBool();
+    }
+    if(layout.contains("AmplitudeHoldTimeMs"_L1)) {
+        config.amplitudeHoldTimeMs = layout.value("AmplitudeHoldTimeMs"_L1).toInt();
+    }
+    if(layout.contains("AmplitudeGravity"_L1)) {
+        config.amplitudeGravity = layout.value("AmplitudeGravity"_L1).toInt();
+    }
+    if(layout.contains("PeaksEnabled"_L1)) {
+        config.peaksEnabled = layout.value("PeaksEnabled"_L1).toBool();
+    }
+    if(layout.contains("PeakHoldTimeMs"_L1)) {
+        config.peakHoldTimeMs = layout.value("PeakHoldTimeMs"_L1).toInt();
+    }
+    if(layout.contains("PeakGravity"_L1)) {
+        config.peakGravity = layout.value("PeakGravity"_L1).toInt();
+    }
+    if(layout.contains("UpdateFps"_L1)) {
+        config.updateFps = layout.value("UpdateFps"_L1).toInt();
+    }
+    if(layout.contains("FftSize"_L1)) {
+        config.fftSize = layout.value("FftSize"_L1).toInt();
+    }
+    if(layout.contains("WindowFunction"_L1)) {
+        config.windowFunction = static_cast<WindowFunction>(layout.value("WindowFunction"_L1).toInt());
+    }
+    if(layout.contains("GradientOrientation"_L1)) {
+        config.gradientOrientation = static_cast<GradientOrientation>(layout.value("GradientOrientation"_L1).toInt());
+    }
+    if(layout.contains("LabelMode"_L1)) {
+        config.labelMode = static_cast<LabelMode>(layout.value("LabelMode"_L1).toInt());
+    }
+    if(layout.contains("DrawStyle"_L1)) {
+        config.drawStyle = static_cast<DrawStyle>(layout.value("DrawStyle"_L1).toInt());
+    }
+    if(layout.contains("ShowTopLabels"_L1)) {
+        config.showTopLabels = layout.value("ShowTopLabels"_L1).toBool();
+    }
+    if(layout.contains("ShowBottomLabels"_L1)) {
+        config.showBottomLabels = layout.value("ShowBottomLabels"_L1).toBool();
+    }
+    if(layout.contains("ShowLeftLabels"_L1)) {
+        config.showLeftLabels = layout.value("ShowLeftLabels"_L1).toBool();
+    }
+    if(layout.contains("ShowRightLabels"_L1)) {
+        config.showRightLabels = layout.value("ShowRightLabels"_L1).toBool();
+    }
+    if(layout.contains("ShowHorizontalGrid"_L1)) {
+        config.showHorizontalGrid = layout.value("ShowHorizontalGrid"_L1).toBool();
+    }
+    if(layout.contains("ShowVerticalGrid"_L1)) {
+        config.showVerticalGrid = layout.value("ShowVerticalGrid"_L1).toBool();
+    }
+    if(layout.contains("ShowWhiteKeys"_L1)) {
+        config.showWhiteKeys = layout.value("ShowWhiteKeys"_L1).toBool();
+    }
+    if(layout.contains("ShowBlackKeys"_L1)) {
+        config.showBlackKeys = layout.value("ShowBlackKeys"_L1).toBool();
+    }
+    if(layout.contains("ShowTooltip"_L1)) {
+        config.showTooltip = layout.value("ShowTooltip"_L1).toBool();
+    }
+    if(layout.contains("FillSpectrum"_L1)) {
+        config.fillSpectrum = layout.value("FillSpectrum"_L1).toBool();
+    }
+    if(layout.contains("Interpolate"_L1)) {
+        config.interpolate = layout.value("Interpolate"_L1).toBool();
+    }
+    if(layout.contains("AxisFont"_L1)) {
+        config.axisFont = layout.value("AxisFont"_L1).toString();
+    }
+
+    if(layout.contains("UseCustomColours"_L1)) {
+        if(layout.value("UseCustomColours"_L1).toBool()) {
+            Colours colours;
+
+            const auto setColour = [&layout, &colours](const QString& key, Colours::Type type) {
+                if(!layout.contains(key)) {
+                    return;
+                }
+
+                const QColor colour{layout.value(key).toString()};
+                if(colour.isValid()) {
+                    colours.setColour(type, colour);
+                }
+            };
+
+            setColour(u"BackgroundColour"_s, Colours::Type::Background);
+            setColour(u"PeaksColour"_s, Colours::Type::Peaks);
+            setColour(u"TextColour"_s, Colours::Type::Text);
+            setColour(u"HorizontalGridColour"_s, Colours::Type::HorizontalGrid);
+            setColour(u"VerticalGridColour"_s, Colours::Type::VerticalGrid);
+            setColour(u"OctaveGridColour"_s, Colours::Type::OctaveGrid);
+            setColour(u"WhiteKeyColour"_s, Colours::Type::WhiteKey);
+            setColour(u"BlackKeyColour"_s, Colours::Type::BlackKey);
+
+            if(const QJsonValue value = layout.value("BarGradientColours"_L1); value.isArray()) {
+                std::vector<QColor> gradient;
+                const QJsonArray array = value.toArray();
+                for(const auto& colourValue : array) {
+                    const QColor colour{colourValue.toString()};
+                    if(colour.isValid()) {
+                        gradient.push_back(colour);
+                    }
+                }
+                colours.setGradient(gradient);
+            }
+            else {
+                std::vector<QColor> gradient;
+                const QColor topColour{layout.value("BarTopColour"_L1).toString()};
+                const QColor bottomColour{layout.value("BarBottomColour"_L1).toString()};
+                if(topColour.isValid()) {
+                    gradient.push_back(topColour);
+                }
+                if(bottomColour.isValid()) {
+                    gradient.push_back(bottomColour);
+                }
+                colours.setGradient(gradient);
+            }
+
+            if(!colours.isEmpty()) {
+                config.colours = QVariant::fromValue(colours);
+            }
+        }
+        else {
+            config.colours = QVariant{};
+        }
+    }
+
+    return config;
+}
+
+void SpectrumWidget::saveConfigToLayout(const ConfigData& config, QJsonObject& layout) const
+{
+    layout["BandCount"_L1]           = config.bandCount;
+    layout["BarSpacing"_L1]          = config.barSpacing;
+    layout["BarSections"_L1]         = config.barSections;
+    layout["SectionSpacing"_L1]      = config.sectionSpacing;
+    layout["MinFrequencyHz"_L1]      = config.minFrequencyHz;
+    layout["MaxFrequencyHz"_L1]      = config.maxFrequencyHz;
+    layout["MinNote"_L1]             = config.minNote;
+    layout["MaxNote"_L1]             = config.maxNote;
+    layout["PitchHz"_L1]             = config.pitchHz;
+    layout["Transpose"_L1]           = config.transpose;
+    layout["AmplitudeMinDb"_L1]      = config.amplitudeMinDb;
+    layout["AmplitudeMaxDb"_L1]      = config.amplitudeMaxDb;
+    layout["AmplitudesEnabled"_L1]   = config.amplitudesEnabled;
+    layout["AmplitudeHoldTimeMs"_L1] = config.amplitudeHoldTimeMs;
+    layout["AmplitudeGravity"_L1]    = config.amplitudeGravity;
+    layout["PeaksEnabled"_L1]        = config.peaksEnabled;
+    layout["PeakHoldTimeMs"_L1]      = config.peakHoldTimeMs;
+    layout["PeakGravity"_L1]         = config.peakGravity;
+    layout["UpdateFps"_L1]           = config.updateFps;
+    layout["FftSize"_L1]             = config.fftSize;
+    layout["WindowFunction"_L1]      = static_cast<int>(config.windowFunction);
+    layout["GradientOrientation"_L1] = static_cast<int>(config.gradientOrientation);
+    layout["LabelMode"_L1]           = static_cast<int>(config.labelMode);
+    layout["DrawStyle"_L1]           = static_cast<int>(config.drawStyle);
+    layout["ShowTopLabels"_L1]       = config.showTopLabels;
+    layout["ShowBottomLabels"_L1]    = config.showBottomLabels;
+    layout["ShowLeftLabels"_L1]      = config.showLeftLabels;
+    layout["ShowRightLabels"_L1]     = config.showRightLabels;
+    layout["ShowHorizontalGrid"_L1]  = config.showHorizontalGrid;
+    layout["ShowVerticalGrid"_L1]    = config.showVerticalGrid;
+    layout["ShowWhiteKeys"_L1]       = config.showWhiteKeys;
+    layout["ShowBlackKeys"_L1]       = config.showBlackKeys;
+    layout["ShowTooltip"_L1]         = config.showTooltip;
+    layout["FillSpectrum"_L1]        = config.fillSpectrum;
+    layout["Interpolate"_L1]         = config.interpolate;
+    layout["AxisFont"_L1]            = config.axisFont;
+
+    const bool customColours      = config.colours.isValid() && config.colours.canConvert<Colours>()
+                                 && !config.colours.value<Colours>().isEmpty();
+    layout["UseCustomColours"_L1] = customColours;
+
+    if(!customColours) {
+        return;
+    }
+
+    const auto colours    = config.colours.value<Colours>();
+    const auto saveColour = [&layout, &colours](const QString& key, Colours::Type type) {
+        const QColor colour = colours.customColour(type);
+        if(colour.isValid()) {
+            layout[key] = colour.name(QColor::HexArgb);
+        }
+        else {
+            layout.remove(key);
+        }
+    };
+
+    saveColour(u"BackgroundColour"_s, Colours::Type::Background);
+    saveColour(u"PeaksColour"_s, Colours::Type::Peaks);
+    saveColour(u"TextColour"_s, Colours::Type::Text);
+    saveColour(u"HorizontalGridColour"_s, Colours::Type::HorizontalGrid);
+    saveColour(u"VerticalGridColour"_s, Colours::Type::VerticalGrid);
+    saveColour(u"OctaveGridColour"_s, Colours::Type::OctaveGrid);
+    saveColour(u"WhiteKeyColour"_s, Colours::Type::WhiteKey);
+    saveColour(u"BlackKeyColour"_s, Colours::Type::BlackKey);
+
+    const std::vector<QColor>& customGradient = colours.customGradient();
+    if(customGradient.empty()) {
+        layout.remove("BarGradientColours"_L1);
+    }
+    else {
+        QJsonArray gradientColours;
+        for(const QColor& colour : customGradient) {
+            gradientColours.append(colour.name(QColor::HexArgb));
+        }
+        layout["BarGradientColours"_L1] = gradientColours;
+    }
+
+    layout.remove("BarTopColour"_L1);
+    layout.remove("BarBottomColour"_L1);
+}
+
+void SpectrumWidget::showContextMenu(const QPoint& globalPos)
+{
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    addConfigureAction(menu, false);
+    menu->popup(globalPos);
+}
+} // namespace Fooyin::Spectrum
+
+#include "moc_spectrumwidget.cpp"

--- a/src/plugins/spectrum/spectrumwidget.cpp
+++ b/src/plugins/spectrum/spectrumwidget.cpp
@@ -26,6 +26,8 @@
 #include <gui/guisettings.h>
 #include <utils/settings/settingsmanager.h>
 
+#include <QAction>
+#include <QActionGroup>
 #include <QColor>
 #include <QContextMenuEvent>
 #include <QJsonArray>
@@ -628,7 +630,200 @@ void SpectrumWidget::showContextMenu(const QPoint& globalPos)
 {
     auto* menu = new QMenu(this);
     menu->setAttribute(Qt::WA_DeleteOnClose);
-    addConfigureAction(menu, false);
+
+    auto* styleMenu  = new QMenu(tr("Style"), menu);
+    auto* styleGroup = new QActionGroup(styleMenu);
+
+    auto* bars = new QAction(tr("Bars"), styleGroup);
+    bars->setCheckable(true);
+    bars->setChecked(m_config.drawStyle == DrawStyle::Bars);
+    auto* curve = new QAction(tr("Curve"), styleGroup);
+    curve->setCheckable(true);
+    curve->setChecked(m_config.drawStyle == DrawStyle::Curve);
+
+    QObject::connect(bars, &QAction::triggered, this, [this]() {
+        auto config{m_config};
+        config.drawStyle = DrawStyle::Bars;
+        applyConfig(config);
+    });
+    QObject::connect(curve, &QAction::triggered, this, [this]() {
+        auto config{m_config};
+        config.drawStyle = DrawStyle::Curve;
+        applyConfig(config);
+    });
+
+    styleMenu->addAction(bars);
+    styleMenu->addAction(curve);
+
+    auto* axisMenu  = new QMenu(tr("Axis"), menu);
+    auto* axisGroup = new QActionGroup(axisMenu);
+
+    auto* frequencies = new QAction(tr("Frequencies"), axisGroup);
+    frequencies->setCheckable(true);
+    frequencies->setChecked(m_config.labelMode == LabelMode::Frequency);
+    auto* notes = new QAction(tr("Notes"), axisGroup);
+    notes->setCheckable(true);
+    notes->setChecked(m_config.labelMode == LabelMode::Notes);
+
+    QObject::connect(frequencies, &QAction::triggered, this, [this]() {
+        auto config{m_config};
+        config.labelMode = LabelMode::Frequency;
+        applyConfig(config);
+    });
+    QObject::connect(notes, &QAction::triggered, this, [this]() {
+        auto config{m_config};
+        config.labelMode = LabelMode::Notes;
+        applyConfig(config);
+    });
+
+    axisMenu->addAction(frequencies);
+    axisMenu->addAction(notes);
+
+    auto* fftSizeMenu  = new QMenu(tr("FFT size"), menu);
+    auto* fftSizeGroup = new QActionGroup(fftSizeMenu);
+
+    for(int fftSize{MinFftSize}; fftSize <= MaxFftSize; fftSize <<= 1) {
+        auto* action = new QAction(QString::number(fftSize), fftSizeGroup);
+        action->setCheckable(true);
+        action->setChecked(m_config.fftSize == fftSize);
+
+        QObject::connect(action, &QAction::triggered, this, [this, fftSize]() {
+            auto config{m_config};
+            config.fftSize = fftSize;
+            applyConfig(config);
+        });
+
+        fftSizeMenu->addAction(action);
+    }
+
+    auto* showPeaks = new QAction(tr("Show peaks"), menu);
+    showPeaks->setCheckable(true);
+    showPeaks->setChecked(m_config.peaksEnabled);
+    QObject::connect(showPeaks, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.peaksEnabled = checked;
+        applyConfig(config);
+    });
+
+    auto* fillSpectrum = new QAction(tr("Fill spectrum"), menu);
+    fillSpectrum->setCheckable(true);
+    fillSpectrum->setChecked(m_config.fillSpectrum);
+    QObject::connect(fillSpectrum, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.fillSpectrum = checked;
+        applyConfig(config);
+    });
+
+    auto* showTooltip = new QAction(tr("Show tooltip"), menu);
+    showTooltip->setCheckable(true);
+    showTooltip->setChecked(m_config.showTooltip);
+    QObject::connect(showTooltip, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showTooltip = checked;
+        applyConfig(config);
+    });
+
+    auto* labelsMenu = new QMenu(tr("Labels"), menu);
+
+    auto* topLabels = new QAction(tr("Top"), labelsMenu);
+    topLabels->setCheckable(true);
+    topLabels->setChecked(m_config.showTopLabels);
+    QObject::connect(topLabels, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showTopLabels = checked;
+        applyConfig(config);
+    });
+
+    auto* bottomLabels = new QAction(tr("Bottom"), labelsMenu);
+    bottomLabels->setCheckable(true);
+    bottomLabels->setChecked(m_config.showBottomLabels);
+    QObject::connect(bottomLabels, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showBottomLabels = checked;
+        applyConfig(config);
+    });
+
+    auto* leftLabels = new QAction(tr("Left"), labelsMenu);
+    leftLabels->setCheckable(true);
+    leftLabels->setChecked(m_config.showLeftLabels);
+    QObject::connect(leftLabels, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showLeftLabels = checked;
+        applyConfig(config);
+    });
+
+    auto* rightLabels = new QAction(tr("Right"), labelsMenu);
+    rightLabels->setCheckable(true);
+    rightLabels->setChecked(m_config.showRightLabels);
+    QObject::connect(rightLabels, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showRightLabels = checked;
+        applyConfig(config);
+    });
+
+    labelsMenu->addAction(topLabels);
+    labelsMenu->addAction(bottomLabels);
+    labelsMenu->addAction(leftLabels);
+    labelsMenu->addAction(rightLabels);
+
+    auto* gridMenu = new QMenu(tr("Gridlines"), menu);
+
+    auto* horizontalGrid = new QAction(tr("Horizontal"), gridMenu);
+    horizontalGrid->setCheckable(true);
+    horizontalGrid->setChecked(m_config.showHorizontalGrid);
+    QObject::connect(horizontalGrid, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showHorizontalGrid = checked;
+        applyConfig(config);
+    });
+
+    auto* verticalGrid = new QAction(tr("Vertical"), gridMenu);
+    verticalGrid->setCheckable(true);
+    verticalGrid->setChecked(m_config.showVerticalGrid);
+    QObject::connect(verticalGrid, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showVerticalGrid = checked;
+        applyConfig(config);
+    });
+
+    auto* whiteKeys = new QAction(tr("White keys"), gridMenu);
+    whiteKeys->setCheckable(true);
+    whiteKeys->setChecked(m_config.showWhiteKeys);
+    whiteKeys->setEnabled(m_config.labelMode == LabelMode::Notes);
+    QObject::connect(whiteKeys, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showWhiteKeys = checked;
+        applyConfig(config);
+    });
+
+    auto* blackKeys = new QAction(tr("Black keys"), gridMenu);
+    blackKeys->setCheckable(true);
+    blackKeys->setChecked(m_config.showBlackKeys);
+    blackKeys->setEnabled(m_config.labelMode == LabelMode::Notes);
+    QObject::connect(blackKeys, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showBlackKeys = checked;
+        applyConfig(config);
+    });
+
+    gridMenu->addAction(horizontalGrid);
+    gridMenu->addAction(verticalGrid);
+    gridMenu->addSeparator();
+    gridMenu->addAction(whiteKeys);
+    gridMenu->addAction(blackKeys);
+
+    menu->addAction(showPeaks);
+    menu->addAction(fillSpectrum);
+    menu->addAction(showTooltip);
+    menu->addSeparator();
+    menu->addMenu(labelsMenu);
+    menu->addMenu(gridMenu);
+    menu->addSeparator();
+    menu->addMenu(styleMenu);
+    menu->addMenu(axisMenu);
+    menu->addMenu(fftSizeMenu);
+
+    addConfigureAction(menu);
     menu->popup(globalPos);
 }
 } // namespace Fooyin::Spectrum

--- a/src/plugins/spectrum/spectrumwidget.h
+++ b/src/plugins/spectrum/spectrumwidget.h
@@ -1,0 +1,116 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "spectrumsettings.h"
+
+#include <gui/fywidget.h>
+
+#include <QString>
+#include <QVariant>
+
+class QJsonObject;
+
+namespace Fooyin {
+class EngineController;
+class PlayerController;
+class SettingsManager;
+
+namespace Spectrum {
+class SpectrumView;
+class SpectrumWidget : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    struct ConfigData
+    {
+        int bandCount{DefaultBandCount};
+        int barSpacing{DefaultBarSpacing};
+        int barSections{DefaultBarSections};
+        int sectionSpacing{DefaultSectionSpacing};
+        int minFrequencyHz{DefaultMinFrequencyHz};
+        int maxFrequencyHz{DefaultMaxFrequencyHz};
+        int minNote{DefaultMinNote};
+        int maxNote{DefaultMaxNote};
+        int pitchHz{DefaultPitchHz};
+        int transpose{DefaultTranspose};
+        int amplitudeMinDb{DefaultAmplitudeMinDb};
+        int amplitudeMaxDb{DefaultAmplitudeMaxDb};
+        bool amplitudesEnabled{DefaultAmplitudesEnabled};
+        int amplitudeHoldTimeMs{DefaultAmplitudeHoldTimeMs};
+        int amplitudeGravity{DefaultAmplitudeGravity};
+        bool peaksEnabled{DefaultPeaksEnabled};
+        int peakHoldTimeMs{DefaultPeakHoldTimeMs};
+        int peakGravity{DefaultPeakGravity};
+        int updateFps{DefaultUpdateFps};
+        int fftSize{DefaultFftSize};
+        WindowFunction windowFunction{WindowFunction::BlackmanHarris};
+        GradientOrientation gradientOrientation{GradientOrientation::Vertical};
+        LabelMode labelMode{LabelMode::Frequency};
+        DrawStyle drawStyle{DrawStyle::Bars};
+        bool showTopLabels{false};
+        bool showBottomLabels{true};
+        bool showLeftLabels{false};
+        bool showRightLabels{true};
+        bool showHorizontalGrid{true};
+        bool showVerticalGrid{false};
+        bool showWhiteKeys{false};
+        bool showBlackKeys{false};
+        bool showTooltip{true};
+        bool fillSpectrum{true};
+        bool interpolate{true};
+        QString axisFont;
+        QVariant colours;
+    };
+
+    explicit SpectrumWidget(EngineController* engine, PlayerController* playerController, SettingsManager* settings,
+                            QWidget* parent = nullptr);
+    ~SpectrumWidget() override;
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
+
+    [[nodiscard]] ConfigData factoryConfig() const;
+    [[nodiscard]] ConfigData defaultConfig() const;
+    [[nodiscard]] const ConfigData& currentConfig() const;
+    void saveDefaults(const ConfigData& config) const;
+    void clearSavedDefaults() const;
+    void applyConfig(const ConfigData& config);
+
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+    void openConfigDialog() override;
+
+private:
+    [[nodiscard]] ConfigData configFromLayout(const QJsonObject& layout) const;
+    void saveConfigToLayout(const ConfigData& config, QJsonObject& layout) const;
+    void showContextMenu(const QPoint& globalPos);
+
+    SettingsManager* m_settings;
+    SpectrumView* m_view;
+    ConfigData m_config;
+};
+} // namespace Spectrum
+} // namespace Fooyin

--- a/src/plugins/spectrum/spectrumwidget.h
+++ b/src/plugins/spectrum/spectrumwidget.h
@@ -74,7 +74,7 @@ public:
         bool showVerticalGrid{false};
         bool showWhiteKeys{false};
         bool showBlackKeys{false};
-        bool showTooltip{true};
+        bool showTooltip{false};
         bool fillSpectrum{true};
         bool interpolate{true};
         QString axisFont;

--- a/tests/core/engine/audioenginetest.cpp
+++ b/tests/core/engine/audioenginetest.cpp
@@ -1636,7 +1636,7 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, AudioEngineDispatchesPcmFrame
     EXPECT_FLOAT_EQ(frame.interleavedSamples().back(), 0.1F);
 }
 
-FOOYIN_AUDIOENGINE_REGULAR_TEST(AudioEngineTest, VisualisationBackendUsesPresentedPosition)
+FOOYIN_AUDIOENGINE_REGULAR_TEST(AudioEngineTest, PublishPositionDoesNotDriveVisualisationClock)
 {
     ensureCoreApplication();
 
@@ -1652,7 +1652,7 @@ FOOYIN_AUDIOENGINE_REGULAR_TEST(AudioEngineTest, VisualisationBackendUsesPresent
 
     AudioEngineTestAccessor::publishPosition(engine, 1000, 120, 1.0, AudioClock::UpdateMode::Discontinuity, false);
 
-    EXPECT_EQ(AudioEngineTestAccessor::visualisationCurrentTimeMs(engine), 880);
+    EXPECT_EQ(AudioEngineTestAccessor::visualisationCurrentTimeMs(engine), 0);
 }
 
 FOOYIN_AUDIOENGINE_REGULAR_TEST(AudioEngineTest, UpdateLiveDspSettingsHandlesUnknownInstanceGracefully)

--- a/tests/core/engine/visualisationbackendtest.cpp
+++ b/tests/core/engine/visualisationbackendtest.cpp
@@ -154,6 +154,69 @@ TEST(VisualisationBackendTest, ResetsBacklogWhenGapExceedsTolerance)
     EXPECT_GE(window.startTimeMs, discontinuityStartMs);
 }
 
+TEST(VisualisationBackendTest, MapsClockAcrossBridgedTimelineUntilReset)
+{
+    static constexpr auto frameCount = 100;
+    static constexpr auto sampleRate = 1000;
+    static constexpr auto fftSize    = 256;
+
+    Fooyin::VisualisationBackend backend;
+    const auto token = backend.registerSession();
+    backend.requestBacklog(token, 2000);
+
+    for(uint64_t streamTimeMs{10000}; streamTimeMs < 10600; streamTimeMs += 100) {
+        backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, streamTimeMs));
+    }
+
+    backend.setCurrentTimeMs(10550);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 100));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 200));
+
+    Fooyin::VisualisationSession::SpectrumWindow spectrum;
+    ASSERT_TRUE(backend.getSpectrumWindowEndingAt(spectrum, 200, fftSize, {},
+                                                  Fooyin::VisualisationSession::SpectrumWindowFunction::Hann));
+    EXPECT_GT(spectrum.startTimeMs, 10000);
+
+    backend.setCurrentTimeMs(500);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 500));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 600));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 700));
+    backend.setCurrentTimeMs(800);
+
+    ASSERT_TRUE(backend.getSpectrumWindowEndingAt(spectrum, 800, fftSize, {},
+                                                  Fooyin::VisualisationSession::SpectrumWindowFunction::Hann));
+    EXPECT_GE(spectrum.startTimeMs, 500);
+    EXPECT_LT(spectrum.startTimeMs, 600);
+}
+
+TEST(VisualisationBackendTest, AcceptsZeroTimeAfterBacklogResetLeavesOldTimeline)
+{
+    static constexpr auto frameCount = 100;
+    static constexpr auto sampleRate = 1000;
+
+    Fooyin::VisualisationBackend backend;
+    const auto token = backend.registerSession();
+    backend.requestBacklog(token, 2000);
+
+    backend.setCurrentTimeMs(10000);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 10000));
+
+    Fooyin::PcmFrame monoFrame;
+    monoFrame.format       = Fooyin::AudioFormat{Fooyin::SampleFormat::F32, sampleRate, 1};
+    monoFrame.frameCount   = frameCount;
+    monoFrame.streamTimeMs = 0;
+    std::fill_n(monoFrame.samples.data(), frameCount, 0.2F);
+    backend.appendFrame(monoFrame);
+
+    backend.setCurrentTimeMs(0);
+    EXPECT_EQ(backend.currentTimeMs(), 0);
+
+    backend.appendFrame(monoFrame);
+    EXPECT_GT(backend.currentTimeMs(), 0);
+    EXPECT_LT(backend.currentTimeMs(), 500);
+}
+
 TEST(VisualisationBackendTest, ChannelSelectionsSupportSingleChannelMidAndSide)
 {
     static constexpr auto fftSize    = 1024;

--- a/tests/core/engine/visualisationbackendtest.cpp
+++ b/tests/core/engine/visualisationbackendtest.cpp
@@ -84,14 +84,52 @@ TEST(VisualisationBackendTest, ComputesSpectrumForMonoPcmBacklog)
     const auto dominant = std::ranges::max_element(spectrum.magnitudes);
     ASSERT_NE(dominant, spectrum.magnitudes.end());
     EXPECT_EQ(std::distance(spectrum.magnitudes.begin(), dominant), targetBin);
-    EXPECT_GT(*dominant, 0.2F);
+    EXPECT_GT(*dominant, 0.9F);
+}
+
+TEST(VisualisationBackendTest, CompensatesWindowGainForSpectrumMagnitude)
+{
+    static constexpr int fftSize    = 1024;
+    static constexpr int sampleRate = 1024;
+    static constexpr int targetBin  = 7;
+    static constexpr float twoPi    = std::numbers::pi_v<float> * 2.0F;
+
+    Fooyin::PcmFrame frame;
+    frame.format       = Fooyin::AudioFormat{Fooyin::SampleFormat::F32, sampleRate, 1};
+    frame.frameCount   = fftSize;
+    frame.streamTimeMs = 0;
+
+    for(int index{0}; index < fftSize; ++index) {
+        const float phase
+            = twoPi * static_cast<float>(targetBin) * static_cast<float>(index) / static_cast<float>(fftSize);
+        frame.samples[static_cast<size_t>(index)] = std::sin(phase);
+    }
+
+    for(const auto windowFunction : {Fooyin::VisualisationSession::SpectrumWindowFunction::Hann,
+                                     Fooyin::VisualisationSession::SpectrumWindowFunction::BlackmanHarris,
+                                     Fooyin::VisualisationSession::SpectrumWindowFunction::None}) {
+        Fooyin::VisualisationBackend backend;
+        const auto token = backend.registerSession();
+        backend.requestBacklog(token, 1000);
+        backend.appendFrame(frame);
+
+        Fooyin::VisualisationSession::SpectrumWindow spectrum;
+        ASSERT_TRUE(backend.getSpectrumWindow(spectrum, 500, fftSize, {}, windowFunction));
+        ASSERT_TRUE(spectrum.isValid());
+
+        const auto dominant = std::ranges::max_element(spectrum.magnitudes);
+        ASSERT_NE(dominant, spectrum.magnitudes.end());
+        EXPECT_EQ(std::distance(spectrum.magnitudes.begin(), dominant), targetBin);
+        EXPECT_GT(*dominant, 0.9F);
+        EXPECT_LT(*dominant, 1.1F);
+    }
 }
 
 TEST(VisualisationBackendTest, ResetsBacklogWhenGapExceedsTolerance)
 {
     static constexpr auto frameCount               = 128;
     static constexpr auto sampleRate               = 1000;
-    static constexpr uint64_t discontinuityStartMs = 300;
+    static constexpr uint64_t discontinuityStartMs = 400;
 
     Fooyin::VisualisationBackend backend;
     const auto token = backend.registerSession();

--- a/tests/core/engine/visualisationbackendtest.cpp
+++ b/tests/core/engine/visualisationbackendtest.cpp
@@ -27,7 +27,8 @@
 #include <ranges>
 
 namespace {
-Fooyin::PcmFrame makeStereoSineFrame(int frameCount, int sampleRate, int leftBin, int rightBin, uint64_t streamTimeMs)
+Fooyin::PcmFrame makeStereoSineFrame(int frameCount, int sampleRate, int leftBin, int rightBin, uint64_t streamTimeMs,
+                                     uint32_t streamId = 0)
 {
     static constexpr float twoPi = std::numbers::pi_v<float> * 2.0F;
 
@@ -35,6 +36,7 @@ Fooyin::PcmFrame makeStereoSineFrame(int frameCount, int sampleRate, int leftBin
     frame.format       = Fooyin::AudioFormat{Fooyin::SampleFormat::F32, sampleRate, 2};
     frame.frameCount   = frameCount;
     frame.streamTimeMs = streamTimeMs;
+    frame.streamId     = streamId;
 
     for(size_t index{0}; std::cmp_less(index, frameCount); ++index) {
         const float leftPhase
@@ -125,72 +127,66 @@ TEST(VisualisationBackendTest, CompensatesWindowGainForSpectrumMagnitude)
     }
 }
 
-TEST(VisualisationBackendTest, ResetsBacklogWhenGapExceedsTolerance)
+TEST(VisualisationBackendTest, DropsOldBacklogWhenScopedStreamGapExceedsTolerance)
 {
     static constexpr auto frameCount               = 128;
     static constexpr auto sampleRate               = 1000;
     static constexpr uint64_t discontinuityStartMs = 400;
+    static constexpr uint32_t streamId             = 1;
 
     Fooyin::VisualisationBackend backend;
     const auto token = backend.registerSession();
     backend.requestBacklog(token, 1000);
 
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0));
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 128));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0, streamId));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 128, streamId));
 
     Fooyin::VisualisationSession::PcmWindow window;
     ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 128, 20, {}));
     EXPECT_EQ(window.startTimeMs, 108);
 
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, discontinuityStartMs));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, discontinuityStartMs, streamId));
 
     ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 128, 20, {}));
-    EXPECT_GE(window.startTimeMs, discontinuityStartMs);
+    EXPECT_EQ(window.startTimeMs, 108);
+    EXPECT_EQ(window.frameCount, 20);
 
-    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 256, 20, {}));
-    EXPECT_GE(window.startTimeMs, discontinuityStartMs);
+    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 128, 200, {}));
+    EXPECT_EQ(window.startTimeMs, 0);
+    EXPECT_EQ(window.frameCount, frameCount);
 
-    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, discontinuityStartMs, 20, {}));
-    EXPECT_GE(window.startTimeMs, discontinuityStartMs);
+    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, discontinuityStartMs, 200, {}));
+    EXPECT_EQ(window.startTimeMs, 0);
+    EXPECT_EQ(window.frameCount, frameCount);
 }
 
-TEST(VisualisationBackendTest, MapsClockAcrossBridgedTimelineUntilReset)
+TEST(VisualisationBackendTest, PreservesTimelineWhenPcmStreamChanges)
 {
     static constexpr auto frameCount = 100;
     static constexpr auto sampleRate = 1000;
-    static constexpr auto fftSize    = 256;
 
     Fooyin::VisualisationBackend backend;
     const auto token = backend.registerSession();
     backend.requestBacklog(token, 2000);
 
-    for(uint64_t streamTimeMs{10000}; streamTimeMs < 10600; streamTimeMs += 100) {
-        backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, streamTimeMs));
+    for(uint64_t streamTimeMs{10000}; streamTimeMs < 10400; streamTimeMs += 100) {
+        backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, streamTimeMs, 1));
     }
 
-    backend.setCurrentTimeMs(10550);
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0));
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 100));
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 200));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0, 2));
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 100, 2));
 
-    Fooyin::VisualisationSession::SpectrumWindow spectrum;
-    ASSERT_TRUE(backend.getSpectrumWindowEndingAt(spectrum, 200, fftSize, {},
-                                                  Fooyin::VisualisationSession::SpectrumWindowFunction::Hann));
-    EXPECT_GT(spectrum.startTimeMs, 10000);
+    Fooyin::VisualisationSession::PcmWindow window;
+    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 600, 20, {}));
 
-    backend.setCurrentTimeMs(500);
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 500));
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 600));
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 700));
-    backend.setCurrentTimeMs(800);
+    EXPECT_EQ(window.startTimeMs, 580);
+    EXPECT_EQ(window.frameCount, 20);
 
-    ASSERT_TRUE(backend.getSpectrumWindowEndingAt(spectrum, 800, fftSize, {},
-                                                  Fooyin::VisualisationSession::SpectrumWindowFunction::Hann));
-    EXPECT_GE(spectrum.startTimeMs, 500);
-    EXPECT_LT(spectrum.startTimeMs, 600);
+    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 420, 40, {}));
+    EXPECT_LT(window.startTimeMs, 400);
 }
 
-TEST(VisualisationBackendTest, AcceptsZeroTimeAfterBacklogResetLeavesOldTimeline)
+TEST(VisualisationBackendTest, StreamScopedTimeUpdateSwitchesTimelineExplicitly)
 {
     static constexpr auto frameCount = 100;
     static constexpr auto sampleRate = 1000;
@@ -199,22 +195,34 @@ TEST(VisualisationBackendTest, AcceptsZeroTimeAfterBacklogResetLeavesOldTimeline
     const auto token = backend.registerSession();
     backend.requestBacklog(token, 2000);
 
-    backend.setCurrentTimeMs(10000);
-    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 10000));
+    backend.setCurrentTimeMs(1, 180000);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 180000, 1));
+    backend.setCurrentTimeMs(2, 0);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0, 2));
+    ASSERT_GT(backend.currentTimeMs(), 0);
+    ASSERT_LT(backend.currentTimeMs(), 500);
+}
 
-    Fooyin::PcmFrame monoFrame;
-    monoFrame.format       = Fooyin::AudioFormat{Fooyin::SampleFormat::F32, sampleRate, 1};
-    monoFrame.frameCount   = frameCount;
-    monoFrame.streamTimeMs = 0;
-    std::fill_n(monoFrame.samples.data(), frameCount, 0.2F);
-    backend.appendFrame(monoFrame);
+TEST(VisualisationBackendTest, ResolvesStartupSpectrumAfterFirstAnalysisFrame)
+{
+    static constexpr auto frameCount = Fooyin::PcmFrame::MaxFrames;
+    static constexpr auto sampleRate = 44100;
+    static constexpr auto fftSize    = 8192;
 
-    backend.setCurrentTimeMs(0);
-    EXPECT_EQ(backend.currentTimeMs(), 0);
+    Fooyin::VisualisationBackend backend;
+    const auto token = backend.registerSession();
+    backend.requestBacklog(token, 2000);
 
-    backend.appendFrame(monoFrame);
-    EXPECT_GT(backend.currentTimeMs(), 0);
-    EXPECT_LT(backend.currentTimeMs(), 500);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0, 1));
+
+    Fooyin::VisualisationSession::SpectrumWindow spectrum;
+    ASSERT_TRUE(backend.getSpectrumWindowEndingAt(spectrum, 23, fftSize, {},
+                                                  Fooyin::VisualisationSession::SpectrumWindowFunction::Hann));
+    ASSERT_TRUE(spectrum.isValid());
+    EXPECT_LT(spectrum.fftSize, fftSize);
+    EXPECT_GE(spectrum.fftSize, frameCount / 2);
+    EXPECT_EQ(spectrum.sampleRate, sampleRate);
+    EXPECT_LE(spectrum.startTimeMs, 12);
 }
 
 TEST(VisualisationBackendTest, ChannelSelectionsSupportSingleChannelMidAndSide)
@@ -286,7 +294,9 @@ TEST(VisualisationBackendTest, FormatChangeDropsOldHistory)
 
     Fooyin::VisualisationSession::PcmWindow window;
     ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 23, 20, {}));
-    EXPECT_GE(window.startTimeMs, 1000);
+    EXPECT_LT(window.startTimeMs, 23);
+    EXPECT_EQ(window.format.sampleRate(), 48000);
+    EXPECT_EQ(window.format.channelCount(), 1);
 
     ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 1021, 20, {}));
     EXPECT_EQ(window.format.sampleRate(), 48000);


### PR DESCRIPTION
Adds a `Spectrum` widget plugin with a configurable FFT-based audio visualisation.

Default settings:
<img width="1536" height="179" alt="image" src="https://github.com/user-attachments/assets/b9a0f82e-2388-4ed3-b301-22a47e27b0c6" />

<img width="1536" height="184" alt="image" src="https://github.com/user-attachments/assets/8943b1e0-4abb-4b96-b04b-52f62c7dd3b0" />

LED style (using `Sections` display setting):
<img width="1536" height="179" alt="image" src="https://github.com/user-attachments/assets/3c6dec8a-02d3-46ee-8763-c0ae73195e9b" />

Outlines only:
<img width="1543" height="179" alt="image" src="https://github.com/user-attachments/assets/9186a93c-e439-4449-afcb-228a5b083b1c" />


Sections with spacing:
<img width="1536" height="184" alt="image" src="https://github.com/user-attachments/assets/824307bc-a890-4b48-9cda-815c83ee0ef6" />

Curve style:
<img width="1536" height="179" alt="image" src="https://github.com/user-attachments/assets/1704dbac-bb21-46e8-8813-99818b6b82ff" />

Musical notes:
<img width="1536" height="179" alt="image" src="https://github.com/user-attachments/assets/8e7942dc-693c-490e-8a40-8d5162778ad0" />


Also adds a reusable gradient editor widget and updates the visualisation backend to support the new analyser.

Closes #52
Closes #1025
