### PR TITLE
[gui] Rework layout management, editing, and add support for changing widget margins

### DIFF
--- a/include/gui/fywidget.h
+++ b/include/gui/fywidget.h
@@ -23,9 +23,9 @@
 
 #include <utils/id.h>
 
-#include <QPointer>
 #include <QWidget>
 
+#include <memory>
 #include <unordered_map>
 
 class QAction;
@@ -33,6 +33,8 @@ class QDialog;
 class QMenu;
 
 namespace Fooyin {
+class FyWidgetPrivate;
+
 class FYGUI_EXPORT LayoutCopyContext
 {
 public:
@@ -110,6 +112,7 @@ public:
     Q_DECLARE_FLAGS(Features, Feature)
 
     explicit FyWidget(QWidget* parent);
+    ~FyWidget() override;
 
     [[nodiscard]] Id id() const;
     /*!
@@ -230,9 +233,7 @@ Q_SIGNALS:
     void changeSearch(const QString& search);
 
 private:
-    Id m_id;
-    Features m_features;
-    QPointer<QDialog> m_configDialog;
+    std::unique_ptr<FyWidgetPrivate> p;
 };
 using WidgetList = std::vector<FyWidget*>;
 } // namespace Fooyin

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -230,6 +230,7 @@ constexpr auto DspManager                         = "Fooyin.Page.Playback.DspMan
 constexpr auto NowPlaying                         = "Fooyin.Page.Playback.NowPlaying";
 constexpr auto InterfaceGeneral                   = "Fooyin.Page.Interface.General";
 constexpr auto InterfaceDisplay                   = "Fooyin.Page.Interface.Display";
+constexpr auto InterfaceLayout                    = "Fooyin.Page.Interface.Layout";
 constexpr auto InterfaceTrackDisplay              = "Fooyin.Page.Interface.TrackDisplay";
 constexpr auto InterfaceContextMenuTrack          = "Fooyin.Page.Interface.ContextMenu.Track";
 constexpr auto InterfaceContextMenuPlaylistWidget = "Fooyin.Page.Interface.ContextMenu.PlaylistWidget";

--- a/include/gui/layoutprovider.h
+++ b/include/gui/layoutprovider.h
@@ -40,14 +40,21 @@ public:
     [[nodiscard]] FyLayout currentLayout() const;
     [[nodiscard]] LayoutList layouts() const;
     [[nodiscard]] FyLayout layoutByName(const QString& name) const;
+    [[nodiscard]] QString uniqueLayoutName(const QString& name) const;
+    [[nodiscard]] bool canDeleteLayout(const QString& name) const;
+    [[nodiscard]] bool canResetLayout(const QString& name) const;
 
-    void findLayouts();
-    void loadCurrentLayout();
+    void findLayouts() const;
     void saveCurrentLayout();
 
     void registerLayout(const FyLayout& layout);
     void registerLayout(const QByteArray& json);
     void changeLayout(const FyLayout& layout);
+    bool createLayout(const QString& name, const FyLayout& baseLayout);
+    bool deleteLayout(const QString& name);
+    bool renameLayout(const QString& oldName, const QString& newName);
+    bool duplicateLayout(const QString& sourceName, const QString& newName);
+    bool resetLayout(const QString& name);
 
     FyLayout importLayout(const QString& path);
     void importLayout(QWidget* parent);
@@ -56,6 +63,8 @@ public:
 Q_SIGNALS:
     void layoutAdded(const Fooyin::FyLayout& layout);
     void layoutChanged(const Fooyin::FyLayout& layout);
+    void layoutRemoved(const QString& name);
+    void currentLayoutChanged(const Fooyin::FyLayout& layout);
     void requestChangeLayout(const Fooyin::FyLayout& layout);
 
 private:

--- a/include/gui/widgetprovider.h
+++ b/include/gui/widgetprovider.h
@@ -72,6 +72,8 @@ public:
 
     /** Returns @c true if the widget at @p key exists. */
     [[nodiscard]] bool widgetExists(const QString& key) const;
+    /** Returns the display name registered for the widget at @p key, or @p key if no widget is registered. */
+    [[nodiscard]] QString displayName(const QString& key) const;
     /** Returns @c true if an instance can be created of the widget at @p key. */
     [[nodiscard]] bool canCreateWidget(const QString& key) const;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -155,6 +155,7 @@ set(SOURCES
     dsp/skipsilencesettingswidget.cpp
     dsp/skipsilencesettingswidget.h
     editablelayout.cpp
+    editablelayout_p.h
     fylayout.cpp
     fywidget.cpp
     guiapplication.cpp
@@ -374,8 +375,12 @@ set(SOURCES
     settings/guitrackdisplaypage.h
     settings/guigeneralpage.cpp
     settings/guigeneralpage.h
+    settings/guilayoutpage.cpp
+    settings/guilayoutpage.h
     settings/guithemespage.cpp
     settings/guithemespage.h
+    settings/layouttreemodel.cpp
+    settings/layouttreemodel.h
     settings/library/librarygeneralpage.cpp
     settings/library/librarygeneralpage.h
     settings/library/librarymetadatapage.cpp

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -17,6 +17,7 @@
  *
  */
 
+#include "editablelayout_p.h"
 #include <gui/editablelayout.h>
 
 #include "contextmenuids.h"
@@ -110,204 +111,108 @@ void preserveWidgetIds(QJsonObject& widgetObject, FyWidget* widget)
 }
 } // namespace
 
-class RootContainer : public WidgetContainer
+RootContainer::RootContainer(WidgetProvider* provider, SettingsManager* settings, QWidget* parent)
+    : WidgetContainer{provider, settings, parent}
+    , m_settings{settings}
+    , m_layout{new QVBoxLayout(this)}
+    , m_widget{new Dummy(m_settings, this)}
 {
-    Q_OBJECT
+    m_layout->setContentsMargins(0, 0, 0, 0);
+    m_layout->addWidget(m_widget);
+}
 
-public:
-    explicit RootContainer(WidgetProvider* provider, SettingsManager* settings, QWidget* parent = nullptr)
-        : WidgetContainer{provider, settings, parent}
-        , m_settings{settings}
-        , m_layout{new QVBoxLayout(this)}
-        , m_widget{new Dummy(m_settings, this)}
-    {
-        m_layout->setContentsMargins(0, 0, 0, 0);
-        m_layout->addWidget(m_widget);
-    }
-
-    void reset()
-    {
-        delete m_widget;
-        m_widget = new Dummy(m_settings, this);
-        m_layout->addWidget(m_widget);
-    }
-
-    [[nodiscard]] FyWidget* widget() const
-    {
-        return m_widget;
-    }
-
-    [[nodiscard]] QString name() const override
-    {
-        return u"Root"_s;
-    }
-
-    [[nodiscard]] QString layoutName() const override
-    {
-        return name();
-    }
-
-    [[nodiscard]] bool canAddWidget() const override
-    {
-        return !m_widget || qobject_cast<Dummy*>(m_widget);
-    }
-
-    [[nodiscard]] bool canMoveWidget(int /*index*/, int /*newIndex*/) const override
-    {
-        return false;
-    }
-
-    [[nodiscard]] int widgetIndex(const Id& id) const override
-    {
-        return m_widget && m_widget->id() == id ? 0 : -1;
-    }
-
-    [[nodiscard]] FyWidget* widgetAtId(const Id& id) const override
-    {
-        return m_widget && m_widget->id() == id ? m_widget : nullptr;
-    }
-
-    [[nodiscard]] FyWidget* widgetAtIndex(int index) const override
-    {
-        return index == 0 ? m_widget : nullptr;
-    }
-
-    [[nodiscard]] int widgetCount() const override
-    {
-        return m_widget && !qobject_cast<Dummy*>(m_widget) ? 1 : 0;
-    }
-
-    [[nodiscard]] WidgetList widgets() const override
-    {
-        if(m_widget) {
-            return {m_widget};
-        }
-
-        return {};
-    }
-
-    int addWidget(FyWidget* widget) override
-    {
-        insertWidget(0, widget);
-        return 0;
-    }
-
-    void insertWidget(int index, FyWidget* widget) override
-    {
-        if(index != 0) {
-            return;
-        }
-
-        widget->setParent(this);
-        delete m_widget;
-        m_widget = widget;
-        m_layout->insertWidget(0, m_widget);
-    }
-
-    void removeWidget(int index) override
-    {
-        if(index == 0) {
-            reset();
-        }
-    }
-
-    void replaceWidget(int index, FyWidget* newWidget) override
-    {
-        insertWidget(index, newWidget);
-    }
-
-    void moveWidget(int /*index*/, int /*newIndex*/) override { }
-
-private:
-    SettingsManager* m_settings;
-    QVBoxLayout* m_layout;
-    QPointer<FyWidget> m_widget;
-};
-
-class EditableLayoutPrivate
+void RootContainer::reset()
 {
-public:
-    EditableLayoutPrivate(EditableLayout* self, ActionManager* actionManager, WidgetProvider* widgetProvider,
-                          LayoutProvider* layoutProvider, SettingsManager* settings);
+    delete m_widget;
+    m_widget = new Dummy(m_settings, this);
+    m_layout->addWidget(m_widget);
+}
 
-    void setupDefault() const;
-    void updateMargins() const;
-    void changeEditingState(bool editing);
+FyWidget* RootContainer::widget() const
+{
+    return m_widget;
+}
 
-    void showOverlay(FyWidget* widget) const;
-    void hideOverlay() const;
+QString RootContainer::name() const
+{
+    return u"Root"_s;
+}
 
-    void setupAddWidgetMenu(QMenu* menu, WidgetContainer* parent, FyWidget* prev, FyWidget* current) const;
-    bool setupMoveWidgetMenu(QMenu* menu, WidgetContainer* parent, FyWidget* current) const;
-    void setupUnsplitAction(QMenu* menu, WidgetContainer* parent, FyWidget* current) const;
-    void setupPasteMenu(QMenu* menu, WidgetContainer* parent, FyWidget* prev, FyWidget* current, bool isDummy);
-    void setupContextMenu(FyWidget* widget, QMenu* menu);
+QString RootContainer::layoutName() const
+{
+    return name();
+}
 
-    [[nodiscard]] WidgetList findAllWidgets() const;
+bool RootContainer::canAddWidget() const
+{
+    return !m_widget || qobject_cast<Dummy*>(m_widget);
+}
 
-    template <typename T, typename Predicate>
-    [[nodiscard]] T findWidgets(const Predicate& predicate) const
-    {
-        if(!m_root) {
-            if constexpr(std::is_same_v<T, FyWidget*>) {
-                return nullptr;
-            }
-            return {};
-        }
+bool RootContainer::canMoveWidget(int /*index*/, int /*newIndex*/) const
+{
+    return false;
+}
 
-        T widgets;
+int RootContainer::widgetIndex(const Id& id) const
+{
+    return m_widget && m_widget->id() == id ? 0 : -1;
+}
 
-        std::stack<FyWidget*> widgetsToCheck;
-        widgetsToCheck.push(m_root);
+FyWidget* RootContainer::widgetAtId(const Id& id) const
+{
+    return m_widget && m_widget->id() == id ? m_widget : nullptr;
+}
 
-        while(!widgetsToCheck.empty()) {
-            auto* current = widgetsToCheck.top();
-            widgetsToCheck.pop();
+FyWidget* RootContainer::widgetAtIndex(int index) const
+{
+    return index == 0 ? m_widget : nullptr;
+}
 
-            if(!current) {
-                continue;
-            }
+int RootContainer::widgetCount() const
+{
+    return m_widget && !qobject_cast<Dummy*>(m_widget) ? 1 : 0;
+}
 
-            if(predicate(current)) {
-                if constexpr(std::is_same_v<T, WidgetList>) {
-                    widgets.push_back(current);
-                }
-                else {
-                    return current;
-                }
-            }
-
-            if(const auto* container = qobject_cast<WidgetContainer*>(current)) {
-                const auto containerWidgets = container->widgets();
-                for(FyWidget* containerWidget : containerWidgets) {
-                    widgetsToCheck.push(containerWidget);
-                }
-            }
-        }
-
-        if constexpr(std::is_same_v<T, FyWidget*>) {
-            return nullptr;
-        }
-        return widgets;
+WidgetList RootContainer::widgets() const
+{
+    if(m_widget) {
+        return {m_widget};
     }
 
-    EditableLayout* m_self;
+    return {};
+}
 
-    ActionManager* m_actionManager;
-    SettingsManager* m_settings;
-    WidgetProvider* m_widgetProvider;
-    LayoutProvider* m_layoutProvider;
+int RootContainer::addWidget(FyWidget* widget)
+{
+    insertWidget(0, widget);
+    return 0;
+}
 
-    QPointer<QMenu> m_editingMenu;
-    QHBoxLayout* m_box;
-    QPointer<OverlayWidget> m_overlay;
-    RootContainer* m_root;
-    bool m_layoutEditing{false};
+void RootContainer::insertWidget(int index, FyWidget* widget)
+{
+    if(index != 0) {
+        return;
+    }
 
-    WidgetContext* m_editingContext;
-    QJsonObject m_widgetClipboard;
-    QUndoStack* m_layoutHistory;
-};
+    widget->setParent(this);
+    delete m_widget;
+    m_widget = widget;
+    m_layout->insertWidget(0, m_widget);
+}
+
+void RootContainer::removeWidget(int index)
+{
+    if(index == 0) {
+        reset();
+    }
+}
+
+void RootContainer::replaceWidget(int index, FyWidget* newWidget)
+{
+    insertWidget(index, newWidget);
+}
+
+void RootContainer::moveWidget(int /*index*/, int /*newIndex*/) { }
 
 EditableLayoutPrivate::EditableLayoutPrivate(EditableLayout* self, ActionManager* actionManager,
                                              WidgetProvider* widgetProvider, LayoutProvider* layoutProvider,
@@ -319,6 +224,7 @@ EditableLayoutPrivate::EditableLayoutPrivate(EditableLayout* self, ActionManager
     , m_layoutProvider{layoutProvider}
     , m_box{new QHBoxLayout(m_self)}
     , m_root{new RootContainer(m_widgetProvider, m_settings, m_self)}
+    , m_layoutEditing{false}
     , m_editingContext{new WidgetContext(m_self, Context{"Fooyin.LayoutEditing"}, m_self)}
     , m_layoutHistory{new QUndoStack(m_self)}
 {
@@ -371,6 +277,27 @@ void EditableLayoutPrivate::changeEditingState(bool editing)
 
         m_self->saveLayout();
     }
+}
+
+void EditableLayoutPrivate::changeLayout(const FyLayout& layout) const
+{
+    m_root->reset();
+
+    if(m_self->loadLayout(layout)) {
+        m_layoutProvider->changeLayout(layout);
+    }
+    else {
+        setupDefault();
+    }
+
+    if(m_root->widgetCount() == 0) {
+        m_settings->set<Settings::Gui::LayoutEditing>(true);
+    }
+    else {
+        m_settings->set<Settings::Gui::LayoutEditing>(false);
+    }
+
+    Q_EMIT m_self->layoutChanged();
 }
 
 void EditableLayoutPrivate::showOverlay(FyWidget* widget) const
@@ -752,7 +679,7 @@ void EditableLayout::initialise()
                      [redo](bool canRedo) { redo->setEnabled(canRedo); });
     redo->setEnabled(p->m_layoutHistory->canRedo());
 
-    changeLayout(p->m_layoutProvider->currentLayout());
+    p->changeLayout(p->m_layoutProvider->currentLayout());
 }
 
 FyLayout EditableLayout::saveCurrentToLayout(const QString& name)
@@ -845,25 +772,14 @@ bool EditableLayout::eventFilter(QObject* watched, QEvent* event)
 
 void EditableLayout::changeLayout(const FyLayout& layout)
 {
-    p->m_root->reset();
-
-    if(!loadLayout(layout)) {
-        p->setupDefault();
-    }
-
-    if(p->m_root->widgetCount() == 0) {
-        p->m_settings->set<Settings::Gui::LayoutEditing>(true);
-    }
-    else {
-        p->m_settings->set<Settings::Gui::LayoutEditing>(false);
-    }
-
-    Q_EMIT layoutChanged();
+    p->m_layoutHistory->push(new SwitchLayoutCommand(p.get(), layout));
 }
 
 void EditableLayout::saveLayout()
 {
-    const auto layout = saveCurrentToLayout(u"Default"_s);
+    const auto currentLayout = p->m_layoutProvider->currentLayout();
+    const QString layoutName = currentLayout.name().isEmpty() ? u"Default"_s : currentLayout.name();
+    const auto layout        = saveCurrentToLayout(layoutName);
     if(layout.isValid()) {
         p->m_layoutProvider->changeLayout(layout);
         p->m_layoutProvider->saveCurrentLayout();
@@ -878,7 +794,6 @@ bool EditableLayout::loadLayout(const FyLayout& layout)
 
     const auto json = layout.json();
 
-    p->m_layoutHistory->clear();
     layout.loadWindowSize();
 
     if(!json.contains("Widgets"_L1)) {
@@ -981,5 +896,4 @@ void EditableLayout::showQuickSetup()
 }
 } // namespace Fooyin
 
-#include "editablelayout.moc"
 #include "gui/moc_editablelayout.cpp"

--- a/src/gui/editablelayout_p.h
+++ b/src/gui/editablelayout_p.h
@@ -1,0 +1,165 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "widgets/dummy.h"
+
+#include <gui/fywidget.h>
+#include <gui/widgetcontainer.h>
+#include <gui/widgets/overlaywidget.h>
+
+#include <QJsonObject>
+#include <QMenu>
+#include <QPointer>
+#include <QVBoxLayout>
+
+#include <stack>
+
+class QUndoStack;
+
+namespace Fooyin {
+class ActionManager;
+class EditableLayout;
+class FyLayout;
+class LayoutProvider;
+class SettingsManager;
+class WidgetContext;
+class WidgetProvider;
+
+class RootContainer : public WidgetContainer
+{
+    Q_OBJECT
+
+public:
+    explicit RootContainer(WidgetProvider* provider, SettingsManager* settings, QWidget* parent = nullptr);
+
+    void reset();
+
+    [[nodiscard]] FyWidget* widget() const;
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+
+    [[nodiscard]] bool canAddWidget() const override;
+    [[nodiscard]] bool canMoveWidget(int index, int newIndex) const override;
+    [[nodiscard]] int widgetIndex(const Id& id) const override;
+    [[nodiscard]] FyWidget* widgetAtId(const Id& id) const override;
+    [[nodiscard]] FyWidget* widgetAtIndex(int index) const override;
+    [[nodiscard]] int widgetCount() const override;
+    [[nodiscard]] WidgetList widgets() const override;
+
+    int addWidget(FyWidget* widget) override;
+    void insertWidget(int index, FyWidget* widget) override;
+    void removeWidget(int index) override;
+    void replaceWidget(int index, FyWidget* newWidget) override;
+    void moveWidget(int index, int newIndex) override;
+
+private:
+    SettingsManager* m_settings;
+    QVBoxLayout* m_layout;
+    QPointer<FyWidget> m_widget;
+};
+
+class EditableLayoutPrivate
+{
+public:
+    EditableLayoutPrivate(EditableLayout* self, ActionManager* actionManager, WidgetProvider* widgetProvider,
+                          LayoutProvider* layoutProvider, SettingsManager* settings);
+
+    void setupDefault() const;
+    void updateMargins() const;
+    void changeEditingState(bool editing);
+
+    void changeLayout(const FyLayout& layout) const;
+
+    void showOverlay(FyWidget* widget) const;
+    void hideOverlay() const;
+
+    void setupAddWidgetMenu(QMenu* menu, WidgetContainer* parent, FyWidget* prev, FyWidget* current) const;
+    bool setupMoveWidgetMenu(QMenu* menu, WidgetContainer* parent, FyWidget* current) const;
+    void setupUnsplitAction(QMenu* menu, WidgetContainer* parent, FyWidget* current) const;
+    void setupPasteMenu(QMenu* menu, WidgetContainer* parent, FyWidget* prev, FyWidget* current, bool isDummy);
+    void setupContextMenu(FyWidget* widget, QMenu* menu);
+
+    [[nodiscard]] WidgetList findAllWidgets() const;
+
+    template <typename T, typename Predicate>
+    [[nodiscard]] T findWidgets(const Predicate& predicate) const
+    {
+        if(!m_root) {
+            if constexpr(std::is_same_v<T, FyWidget*>) {
+                return nullptr;
+            }
+            return {};
+        }
+
+        T widgets;
+
+        std::stack<FyWidget*> widgetsToCheck;
+        widgetsToCheck.push(m_root);
+
+        while(!widgetsToCheck.empty()) {
+            auto* current = widgetsToCheck.top();
+            widgetsToCheck.pop();
+
+            if(!current) {
+                continue;
+            }
+
+            if(predicate(current)) {
+                if constexpr(std::is_same_v<T, WidgetList>) {
+                    widgets.push_back(current);
+                }
+                else {
+                    return current;
+                }
+            }
+
+            if(const auto* container = qobject_cast<WidgetContainer*>(current)) {
+                const auto containerWidgets = container->widgets();
+                for(FyWidget* containerWidget : containerWidgets) {
+                    widgetsToCheck.push(containerWidget);
+                }
+            }
+        }
+
+        if constexpr(std::is_same_v<T, FyWidget*>) {
+            return nullptr;
+        }
+        return widgets;
+    }
+
+    EditableLayout* m_self;
+
+    ActionManager* m_actionManager;
+    SettingsManager* m_settings;
+    WidgetProvider* m_widgetProvider;
+    LayoutProvider* m_layoutProvider;
+
+    QPointer<QMenu> m_editingMenu;
+    QHBoxLayout* m_box;
+    QPointer<OverlayWidget> m_overlay;
+    RootContainer* m_root;
+    bool m_layoutEditing;
+
+    WidgetContext* m_editingContext;
+    QJsonObject m_widgetClipboard;
+    QUndoStack* m_layoutHistory;
+};
+} // namespace Fooyin

--- a/src/gui/fywidget.cpp
+++ b/src/gui/fywidget.cpp
@@ -25,11 +25,45 @@
 #include <QDialog>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QLayout>
 #include <QMenu>
+#include <QPointer>
 
 using namespace Qt::StringLiterals;
 
 namespace Fooyin {
+class FyWidgetPrivate
+{
+public:
+    explicit FyWidgetPrivate(FyWidget* self)
+        : m_self{self}
+    { }
+
+    void saveCommonLayoutData(QJsonObject& layout, bool includeId) const
+    {
+        if(includeId
+           && (m_features & FyWidget::PersistId || m_features & (FyWidget::Search | FyWidget::ExclusiveSearch))) {
+            layout["ID"_L1] = m_id.name();
+        }
+
+        if(m_hasCustomMargins && m_self->layout()) {
+            const QMargins margins = m_self->layout()->contentsMargins();
+            QJsonObject marginData;
+            marginData["Left"_L1]   = margins.left();
+            marginData["Top"_L1]    = margins.top();
+            marginData["Right"_L1]  = margins.right();
+            marginData["Bottom"_L1] = margins.bottom();
+            layout["Margins"_L1]    = marginData;
+        }
+    }
+
+    FyWidget* m_self;
+    Id m_id{Utils::generateUniqueHash()};
+    FyWidget::Features m_features;
+    bool m_hasCustomMargins{false};
+    QPointer<QDialog> m_configDialog;
+};
+
 QString LayoutCopyContext::mappedString(const QString& scope, const QString& value)
 {
     const QString key = scope + u':' + value;
@@ -41,31 +75,33 @@ QString LayoutCopyContext::mappedString(const QString& scope, const QString& val
 
 FyWidget::FyWidget(QWidget* parent)
     : QWidget{parent}
-    , m_id{Utils::generateUniqueHash()}
+    , p{std::make_unique<FyWidgetPrivate>(this)}
 { }
+
+FyWidget::~FyWidget() = default;
 
 Id FyWidget::id() const
 {
-    return m_id;
+    return p->m_id;
 }
 
 FyWidget::Features FyWidget::features() const
 {
-    return m_features;
+    return p->m_features;
 }
 
 bool FyWidget::hasFeature(Feature feature) const
 {
-    return m_features & feature;
+    return p->m_features & feature;
 }
 
 void FyWidget::setFeature(Feature feature, bool on)
 {
     if(on) {
-        m_features |= feature;
+        p->m_features |= feature;
     }
     else {
-        m_features &= ~feature;
+        p->m_features &= ~feature;
     }
 }
 
@@ -97,10 +133,7 @@ void FyWidget::saveLayout(QJsonArray& layout)
 {
     QJsonObject widgetData;
 
-    if(m_features & PersistId || m_features & (Search | ExclusiveSearch)) {
-        widgetData["ID"_L1] = m_id.name();
-    }
-
+    p->saveCommonLayoutData(widgetData, true);
     saveLayoutData(widgetData);
 
     QJsonObject widgetObject;
@@ -113,6 +146,7 @@ void FyWidget::saveBaseLayout(QJsonArray& layout)
 {
     QJsonObject widgetData;
 
+    p->saveCommonLayoutData(widgetData, false);
     saveLayoutData(widgetData);
 
     QJsonObject widgetObject;
@@ -125,6 +159,7 @@ void FyWidget::saveCopyLayout(QJsonArray& layout, LayoutCopyContext& context, bo
 {
     QJsonObject widgetData;
 
+    p->saveCommonLayoutData(widgetData, false);
     saveCopyLayoutData(widgetData, context, isRoot);
 
     QJsonObject widgetObject;
@@ -136,7 +171,16 @@ void FyWidget::saveCopyLayout(QJsonArray& layout, LayoutCopyContext& context, bo
 void FyWidget::loadLayout(const QJsonObject& layout)
 {
     if(layout.contains("ID"_L1)) {
-        m_id = Id{layout["ID"_L1].toString()};
+        p->m_id = Id{layout["ID"_L1].toString()};
+    }
+
+    p->m_hasCustomMargins = false;
+
+    if(this->layout() && layout.value("Margins"_L1).isObject()) {
+        const QJsonObject marginData = layout.value("Margins"_L1).toObject();
+        this->layout()->setContentsMargins(marginData.value("Left"_L1).toInt(), marginData.value("Top"_L1).toInt(),
+                                           marginData.value("Right"_L1).toInt(), marginData.value("Bottom"_L1).toInt());
+        p->m_hasCustomMargins = true;
     }
 
     loadLayoutData(layout);
@@ -183,15 +227,15 @@ void FyWidget::showConfigDialog(QDialog* dialog)
         return;
     }
 
-    if(m_configDialog) {
+    if(p->m_configDialog) {
         dialog->deleteLater();
-        m_configDialog->raise();
-        m_configDialog->activateWindow();
+        p->m_configDialog->raise();
+        p->m_configDialog->activateWindow();
         return;
     }
 
-    m_configDialog = dialog;
-    QObject::connect(dialog, &QDialog::destroyed, this, [this]() { m_configDialog = nullptr; });
+    p->m_configDialog = dialog;
+    QObject::connect(dialog, &QDialog::destroyed, this, [this]() { p->m_configDialog = nullptr; });
     dialog->open();
 }
 } // namespace Fooyin

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -102,6 +102,7 @@
 #include <QFileInfo>
 #include <QImageReader>
 #include <QInputDialog>
+#include <QJsonObject>
 #include <QLoggingCategory>
 #include <QMessageBox>
 #include <QMimeDatabase>
@@ -477,6 +478,12 @@ void GuiApplicationPrivate::setupConnections()
         }
     });
     QObject::connect(m_layoutMenu, &LayoutMenu::changeLayout, m_editableLayout.get(), &EditableLayout::changeLayout);
+    QObject::connect(m_layoutMenu, &LayoutMenu::clearLayout, m_self, [this] {
+        const QString name = m_layoutProvider.currentLayout().name();
+        QJsonObject layout;
+        layout["Name"_L1] = name.isEmpty() ? u"Default"_s : name;
+        m_editableLayout->changeLayout(FyLayout{layout.value("Name"_L1).toString(), layout});
+    });
     QObject::connect(m_layoutMenu, &LayoutMenu::importLayout, m_self,
                      [this]() { m_layoutProvider.importLayout(m_mainWindow.get()); });
     QObject::connect(m_layoutMenu, &LayoutMenu::exportLayout, m_self,
@@ -1009,8 +1016,6 @@ void GuiApplicationPrivate::refreshAutoDetectedIconTheme() const
 
 void GuiApplicationPrivate::registerLayouts()
 {
-    m_layoutProvider.registerLayout(R"({"Name":"Empty"})");
-
     m_layoutProvider.registerLayout(
         R"({"Name":"Simple","Widgets":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAHAAAAn0AAAAXAP////8BAAAAAgA=",
             "Widgets":[{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAAEAAAAggAABqEAAAA+AAAAHAD/////AQAAAAEA","Widgets":[

--- a/src/gui/layoutcommands.cpp
+++ b/src/gui/layoutcommands.cpp
@@ -19,21 +19,32 @@
 
 #include "layoutcommands.h"
 
+#include "editablelayout_p.h"
 #include "widgets/dummy.h"
 
 #include <gui/editablelayout.h>
+#include <gui/layoutprovider.h>
 #include <gui/widgetcontainer.h>
 #include <gui/widgetprovider.h>
 
 #include <QJsonArray>
 
+#include <utility>
+
 namespace Fooyin {
+LayoutChangeCommand::LayoutChangeCommand(EditableLayout* layout)
+    : LayoutChangeCommand{layout, nullptr, nullptr}
+{ }
+
 LayoutChangeCommand::LayoutChangeCommand(EditableLayout* layout, WidgetProvider* provider, WidgetContainer* container)
     : m_layout{layout}
     , m_provider{provider}
     , m_container{container}
-    , m_containerId{container->id()}
-{ }
+{
+    if(container) {
+        m_containerId = container->id();
+    }
+}
 
 bool LayoutChangeCommand::checkContainer()
 {
@@ -44,6 +55,23 @@ bool LayoutChangeCommand::checkContainer()
     }
 
     return m_container != nullptr;
+}
+
+SwitchLayoutCommand::SwitchLayoutCommand(EditableLayoutPrivate* editableLayout, FyLayout layout)
+    : LayoutChangeCommand{editableLayout->m_self}
+    , m_editableLayout{editableLayout}
+    , m_oldLayout{m_layout->saveCurrentToLayout(editableLayout->m_layoutProvider->currentLayout().name())}
+    , m_newLayout{std::move(layout)}
+{ }
+
+void SwitchLayoutCommand::undo()
+{
+    m_editableLayout->changeLayout(m_oldLayout);
+}
+
+void SwitchLayoutCommand::redo()
+{
+    m_editableLayout->changeLayout(m_newLayout);
 }
 
 AddWidgetCommand::AddWidgetCommand(EditableLayout* layout, WidgetProvider* provider, WidgetContainer* container,

--- a/src/gui/layoutcommands.h
+++ b/src/gui/layoutcommands.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <gui/fylayout.h>
 #include <utils/id.h>
 
 #include <QJsonObject>
@@ -27,12 +28,14 @@
 
 namespace Fooyin {
 class EditableLayout;
+class EditableLayoutPrivate;
 class WidgetContainer;
 class WidgetProvider;
 
 class LayoutChangeCommand : public QUndoCommand
 {
 public:
+    explicit LayoutChangeCommand(EditableLayout* layout);
     LayoutChangeCommand(EditableLayout* layout, WidgetProvider* provider, WidgetContainer* container);
 
 protected:
@@ -43,6 +46,20 @@ protected:
     QPointer<WidgetContainer> m_container;
     Id m_containerId;
     QByteArray m_containerState;
+};
+
+class SwitchLayoutCommand : public LayoutChangeCommand
+{
+public:
+    SwitchLayoutCommand(EditableLayoutPrivate* editableLayout, FyLayout layout);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    EditableLayoutPrivate* m_editableLayout;
+    FyLayout m_oldLayout;
+    FyLayout m_newLayout;
 };
 
 class AddWidgetCommand : public LayoutChangeCommand

--- a/src/gui/layoutprovider.cpp
+++ b/src/gui/layoutprovider.cpp
@@ -19,80 +19,249 @@
 
 #include <gui/layoutprovider.h>
 
+#include <core/coresettings.h>
 #include <gui/guipaths.h>
 #include <utils/fileutils.h>
+#include <utils/helpers.h>
 #include <utils/utils.h>
 
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QJsonObject>
 #include <QLoggingCategory>
 #include <QMessageBox>
+#include <QRegularExpression>
 #include <QString>
 
 Q_LOGGING_CATEGORY(LAYOUT_PROV, "fy.layoutprovider")
 
 using namespace Qt::StringLiterals;
 
+constexpr auto ActiveLayoutState = "Interface/ActiveLayout"_L1;
+
+namespace Fooyin {
 namespace {
+QString layoutFilePath(const QString& name)
+{
+    QString filename = name.simplified();
+    filename.replace(QRegularExpression{uR"([\\/:*?"<>|])"_s}, u"_"_s);
+    if(filename.isEmpty()) {
+        filename = u"Layout"_s;
+    }
+    if(!filename.endsWith(u".fyl"_s, Qt::CaseInsensitive)) {
+        filename += u".fyl"_s;
+    }
+    return Gui::layoutsPath() + filename;
+}
+
 bool checkFile(const QFileInfo& file)
 {
     return file.exists() && file.isFile() && file.isReadable()
         && file.suffix().compare(u"fyl"_s, Qt::CaseInsensitive) == 0;
 }
+
+FyLayout renamedLayout(const FyLayout& layout, const QString& name)
+{
+    if(!layout.isValid() || name.isEmpty()) {
+        return {};
+    }
+
+    QJsonObject json = layout.json();
+    json["Name"_L1]  = name;
+    return FyLayout{name, json};
+}
+
+bool writeLayout(const FyLayout& layout, const QString& path)
+{
+    if(!layout.isValid() || path.isEmpty()) {
+        return false;
+    }
+
+    QDir{}.mkpath(QFileInfo{path}.absolutePath());
+    QFile file{path};
+    if(!file.open(QIODevice::WriteOnly)) {
+        qCWarning(LAYOUT_PROV) << "Couldn't open layout file";
+        return false;
+    }
+
+    const QByteArray json = QJsonDocument(layout.json()).toJson();
+    const auto written    = file.write(json);
+    file.close();
+
+    return written >= 0;
+}
+
+QString activeLayoutName()
+{
+    const FyStateSettings settings;
+    return settings.value(QLatin1String{ActiveLayoutState}).toString();
+}
 } // namespace
 
-namespace Fooyin {
 class LayoutProviderPrivate
 {
 public:
-    [[nodiscard]] bool layoutExists(const QString& name) const;
     [[nodiscard]] LayoutList::iterator layout(const QString& name);
-    FyLayout addLayout(const FyLayout& layout, bool import = false);
+
+    FyLayout addLayout(const FyLayout& layout, bool import = false, const QString& path = {});
+    void updateLayout(const FyLayout& layout);
+
+    void resolveActiveLayout();
+    void loadLegacyCurrentLayout();
+    [[nodiscard]] QString pathForLayout(const FyLayout& layout) const;
+    [[nodiscard]] bool isBuiltIn(const QString& name) const;
+
+    void setLayoutPath(const FyLayout& layout, const QString& path);
+    void saveActiveLayoutName() const;
 
     LayoutList m_layouts;
+    std::map<QString, FyLayout> m_builtInLayouts;
     FyLayout m_currentLayout;
-    QFile m_layoutFile{Gui::activeLayoutPath()};
+    std::map<QString, QString> m_layoutPaths;
+    QFile m_legacyLayoutFile{Gui::activeLayoutPath()};
 };
-
-bool LayoutProviderPrivate::layoutExists(const QString& name) const
-{
-    return std::ranges::any_of(m_layouts, [name](const FyLayout& layout) { return layout.name() == name; });
-}
 
 LayoutList::iterator LayoutProviderPrivate::layout(const QString& name)
 {
     return std::ranges::find_if(m_layouts, [name](const FyLayout& layout) { return layout.name() == name; });
 }
 
-FyLayout LayoutProviderPrivate::addLayout(const FyLayout& layout, bool import)
+FyLayout LayoutProviderPrivate::addLayout(const FyLayout& layout, bool import, const QString& path)
 {
     if(!layout.isValid()) {
         qCWarning(LAYOUT_PROV) << "Attempted to load an invalid layout";
         return {};
     }
 
-    const auto existingLayout = std::ranges::find_if(
-        std::as_const(m_layouts), [layout](const FyLayout& existing) { return existing.name() == layout.name(); });
+    const auto existingLayout = this->layout(layout.name());
 
     if(existingLayout != m_layouts.cend()) {
         if(import) {
             return *existingLayout;
+        }
+        if(!path.isEmpty()) {
+            *existingLayout = layout;
+            setLayoutPath(layout, path);
+            return layout;
         }
         qCWarning(LAYOUT_PROV) << "A layout with the same name (" << layout.name() << ") already exists";
         return {};
     }
 
     m_layouts.push_back(layout);
+    setLayoutPath(layout, path);
+    if(path.isEmpty()) {
+        m_builtInLayouts[layout.name()] = layout;
+    }
     return layout;
+}
+
+void LayoutProviderPrivate::updateLayout(const FyLayout& layout)
+{
+    if(!layout.isValid()) {
+        return;
+    }
+
+    if(const auto existing = this->layout(layout.name()); existing != m_layouts.end()) {
+        *existing = layout;
+    }
+    else {
+        m_layouts.push_back(layout);
+    }
+}
+
+void LayoutProviderPrivate::resolveActiveLayout()
+{
+    if(const QString activeName = activeLayoutName(); !activeName.isEmpty()) {
+        if(m_currentLayout.name() == activeName) {
+            updateLayout(m_currentLayout);
+        }
+        else if(const auto activeLayout = layout(activeName); activeLayout != m_layouts.end()) {
+            m_currentLayout = *activeLayout;
+        }
+    }
+    else if(m_currentLayout.isValid()) {
+        updateLayout(m_currentLayout);
+    }
+
+    if(!m_currentLayout.isValid() && !m_layouts.empty()) {
+        m_currentLayout = m_layouts.front();
+    }
+
+    updateLayout(m_currentLayout);
+    saveActiveLayoutName();
+
+    if(m_currentLayout.isValid() && pathForLayout(m_currentLayout).isEmpty()) {
+        const QString path = layoutFilePath(m_currentLayout.name());
+        setLayoutPath(m_currentLayout, path);
+        writeLayout(m_currentLayout, path);
+    }
+}
+
+void LayoutProviderPrivate::loadLegacyCurrentLayout()
+{
+    if(!m_legacyLayoutFile.exists()) {
+        return;
+    }
+
+    if(!m_legacyLayoutFile.open(QIODevice::ReadOnly)) {
+        qCWarning(LAYOUT_PROV) << "Couldn't open legacy layout file.";
+        return;
+    }
+
+    const QByteArray json = m_legacyLayoutFile.readAll();
+    m_legacyLayoutFile.close();
+
+    const FyLayout layout{json};
+    if(!layout.isValid()) {
+        qCWarning(LAYOUT_PROV) << "Attempted to load an invalid legacy layout";
+        return;
+    }
+
+    m_currentLayout = layout;
+}
+
+QString LayoutProviderPrivate::pathForLayout(const FyLayout& layout) const
+{
+    if(!layout.isValid()) {
+        return {};
+    }
+
+    if(const auto it = m_layoutPaths.find(layout.name()); it != m_layoutPaths.cend()) {
+        return it->second;
+    }
+    return {};
+}
+
+bool LayoutProviderPrivate::isBuiltIn(const QString& name) const
+{
+    return m_builtInLayouts.contains(name);
+}
+
+void LayoutProviderPrivate::setLayoutPath(const FyLayout& layout, const QString& path)
+{
+    if(layout.isValid() && !path.isEmpty()) {
+        m_layoutPaths[layout.name()] = path;
+    }
+}
+
+void LayoutProviderPrivate::saveActiveLayoutName() const
+{
+    if(!m_currentLayout.isValid()) {
+        return;
+    }
+
+    FyStateSettings settings;
+    settings.setValue(ActiveLayoutState, m_currentLayout.name());
 }
 
 LayoutProvider::LayoutProvider(QObject* parent)
     : QObject{parent}
     , p{std::make_unique<LayoutProviderPrivate>()}
 {
-    loadCurrentLayout();
+    p->loadLegacyCurrentLayout();
 }
 
 LayoutProvider::~LayoutProvider() = default;
@@ -116,7 +285,23 @@ FyLayout LayoutProvider::layoutByName(const QString& name) const
     return {};
 }
 
-void LayoutProvider::findLayouts()
+QString LayoutProvider::uniqueLayoutName(const QString& name) const
+{
+    return Utils::findUniqueString(name, p->m_layouts, [](const FyLayout& layout) { return layout.name(); });
+}
+
+bool LayoutProvider::canDeleteLayout(const QString& name) const
+{
+    const FyLayout layout = layoutByName(name);
+    return layout.isValid() && !p->pathForLayout(layout).isEmpty();
+}
+
+bool LayoutProvider::canResetLayout(const QString& name) const
+{
+    return p->isBuiltIn(name) && !p->pathForLayout(layoutByName(name)).isEmpty();
+}
+
+void LayoutProvider::findLayouts() const
 {
     QStringList files;
     QList<QDir> stack{Gui::layoutsPath()};
@@ -151,50 +336,30 @@ void LayoutProvider::findLayouts()
         newLayout.close();
 
         if(!json.isEmpty()) {
-            p->addLayout(FyLayout{json});
+            p->addLayout(FyLayout{json}, false, file);
         }
     }
-}
 
-void LayoutProvider::loadCurrentLayout()
-{
-    if(!p->m_layoutFile.exists()) {
-        return;
-    }
-
-    if(!p->m_layoutFile.open(QIODevice::ReadOnly)) {
-        qCWarning(LAYOUT_PROV) << "Couldn't open layout file.";
-        return;
-    }
-
-    const QByteArray json = p->m_layoutFile.readAll();
-    p->m_layoutFile.close();
-
-    const FyLayout layout{json};
-    if(!layout.isValid()) {
-        qCWarning(LAYOUT_PROV) << "Attempted to load an invalid layout";
-        return;
-    }
-
-    if(p->layoutExists(layout.name())) {
-        qCWarning(LAYOUT_PROV) << "A layout with the same name (" << layout.name() << ") already exists";
-        return;
-    }
-
-    p->m_currentLayout = layout;
+    p->resolveActiveLayout();
 }
 
 void LayoutProvider::saveCurrentLayout()
 {
-    if(!p->m_layoutFile.open(QIODevice::WriteOnly)) {
-        qCWarning(LAYOUT_PROV) << "Couldn't open layout file";
+    if(!p->m_currentLayout.isValid()) {
         return;
     }
 
-    const QByteArray json = QJsonDocument(p->m_currentLayout.json()).toJson();
+    QString filepath = p->pathForLayout(p->m_currentLayout);
+    if(filepath.isEmpty()) {
+        filepath = layoutFilePath(p->m_currentLayout.name());
+        p->setLayoutPath(p->m_currentLayout, filepath);
+    }
 
-    p->m_layoutFile.write(json);
-    p->m_layoutFile.close();
+    if(writeLayout(p->m_currentLayout, filepath)) {
+        p->saveActiveLayoutName();
+        Q_EMIT layoutChanged(p->m_currentLayout);
+        Q_EMIT currentLayoutChanged(p->m_currentLayout);
+    }
 }
 
 void LayoutProvider::registerLayout(const FyLayout& layout)
@@ -209,10 +374,141 @@ void LayoutProvider::registerLayout(const QByteArray& json)
 
 void LayoutProvider::changeLayout(const FyLayout& layout)
 {
-    std::ranges::replace_if(
-        p->m_layouts, [layout](const FyLayout& existing) { return existing.name() == layout.name(); }, layout);
-
+    p->updateLayout(layout);
     p->m_currentLayout = layout;
+    p->saveActiveLayoutName();
+    Q_EMIT currentLayoutChanged(layout);
+}
+
+bool LayoutProvider::createLayout(const QString& name, const FyLayout& baseLayout)
+{
+    if(name.isEmpty() || p->layout(name) != p->m_layouts.end()) {
+        return false;
+    }
+
+    const FyLayout layout = renamedLayout(baseLayout, name);
+    const QString path    = layoutFilePath(name);
+    if(!writeLayout(layout, path)) {
+        return false;
+    }
+
+    p->m_layouts.push_back(layout);
+    p->setLayoutPath(layout, path);
+    Q_EMIT layoutAdded(layout);
+    return true;
+}
+
+bool LayoutProvider::deleteLayout(const QString& name)
+{
+    auto layout = p->layout(name);
+    if(layout == p->m_layouts.end()) {
+        return false;
+    }
+
+    const QString path = p->pathForLayout(*layout);
+    if(path.isEmpty()) {
+        return false;
+    }
+
+    QFile file{path};
+    if(file.exists() && !file.moveToTrash()) {
+        qCWarning(LAYOUT_PROV) << "Couldn't delete layout file";
+        return false;
+    }
+
+    const bool wasCurrent = p->m_currentLayout.name() == name;
+    p->m_layoutPaths.erase(name);
+    p->m_layouts.erase(layout);
+
+    if(wasCurrent) {
+        if(const auto defaultLayout = p->layout(u"Default"_s); defaultLayout != p->m_layouts.end()) {
+            p->m_currentLayout = *defaultLayout;
+        }
+        else if(!p->m_layouts.empty()) {
+            p->m_currentLayout = p->m_layouts.front();
+        }
+        else {
+            p->m_currentLayout = {};
+        }
+        p->saveActiveLayoutName();
+        Q_EMIT currentLayoutChanged(p->m_currentLayout);
+    }
+
+    Q_EMIT layoutRemoved(name);
+    return true;
+}
+
+bool LayoutProvider::renameLayout(const QString& oldName, const QString& newName)
+{
+    if(oldName.isEmpty() || newName.isEmpty() || oldName == newName || p->layout(newName) != p->m_layouts.end()) {
+        return false;
+    }
+
+    const auto layout = p->layout(oldName);
+    if(layout == p->m_layouts.end()) {
+        return false;
+    }
+
+    const FyLayout renamed = renamedLayout(*layout, newName);
+    const QString oldPath  = p->pathForLayout(*layout);
+    const QString newPath  = layoutFilePath(newName);
+    if(!writeLayout(renamed, newPath)) {
+        return false;
+    }
+
+    if(!oldPath.isEmpty() && oldPath != newPath) {
+        QFile::moveToTrash(oldPath);
+    }
+
+    *layout = renamed;
+    p->m_layoutPaths.erase(oldName);
+    p->setLayoutPath(renamed, newPath);
+
+    if(p->m_currentLayout.name() == oldName) {
+        p->m_currentLayout = renamed;
+        p->saveActiveLayoutName();
+        Q_EMIT currentLayoutChanged(p->m_currentLayout);
+    }
+
+    Q_EMIT layoutRemoved(oldName);
+    Q_EMIT layoutAdded(renamed);
+    return true;
+}
+
+bool LayoutProvider::duplicateLayout(const QString& sourceName, const QString& newName)
+{
+    const FyLayout source = layoutByName(sourceName);
+    return createLayout(newName, source);
+}
+
+bool LayoutProvider::resetLayout(const QString& name)
+{
+    if(!canResetLayout(name)) {
+        return false;
+    }
+
+    const FyLayout current = layoutByName(name);
+    const QString path     = p->pathForLayout(current);
+    if(!path.isEmpty()) {
+        QFile::moveToTrash(path);
+    }
+
+    const auto builtIn = p->m_builtInLayouts.find(name);
+    if(builtIn == p->m_builtInLayouts.end()) {
+        return false;
+    }
+
+    p->updateLayout(builtIn->second);
+    p->m_layoutPaths.erase(name);
+
+    if(p->m_currentLayout.name() == name) {
+        p->m_currentLayout = builtIn->second;
+        p->saveActiveLayoutName();
+        Q_EMIT currentLayoutChanged(p->m_currentLayout);
+    }
+
+    Q_EMIT layoutChanged(builtIn->second);
+    return true;
 }
 
 FyLayout LayoutProvider::importLayout(const QString& path)
@@ -232,12 +528,21 @@ FyLayout LayoutProvider::importLayout(const QString& path)
         return {};
     }
 
+    FyLayout layout{json};
+    const bool existing = p->layout(layout.name()) != p->m_layouts.end();
+
+    QString layoutPath = fileInfo.absoluteFilePath();
     if(!Utils::File::isSamePath(fileInfo.absolutePath(), Gui::layoutsPath())) {
-        const QString newFile = Gui::layoutsPath() + fileInfo.fileName();
-        file.copy(newFile);
+        layoutPath = Gui::layoutsPath() + fileInfo.fileName();
+        file.copy(layoutPath);
     }
 
-    return p->addLayout(FyLayout{json}, true);
+    layout = p->addLayout(layout, true, layoutPath);
+    if(layout.isValid() && !existing) {
+        Q_EMIT layoutAdded(layout);
+    }
+
+    return layout;
 }
 
 void LayoutProvider::importLayout(QWidget* parent)
@@ -296,10 +601,12 @@ bool LayoutProvider::exportLayout(const FyLayout& layout, const QString& path)
         auto currLayout = p->layout(layout.name());
         if(currLayout != p->m_layouts.end()) {
             *currLayout = layout;
+            p->setLayoutPath(layout, filepath);
             Q_EMIT layoutChanged(layout);
         }
         else {
             p->m_layouts.push_back(layout);
+            p->setLayoutPath(layout, filepath);
             Q_EMIT layoutAdded(layout);
         }
     }

--- a/src/gui/menubar/layoutmenu.cpp
+++ b/src/gui/menubar/layoutmenu.cpp
@@ -29,6 +29,7 @@
 #include <utils/utils.h>
 
 #include <QAction>
+#include <QActionGroup>
 #include <QMenu>
 
 using namespace Qt::StringLiterals;
@@ -45,8 +46,13 @@ LayoutMenu::LayoutMenu(ActionManager* actionManager, LayoutProvider* layoutProvi
     , m_layoutEditingCmd{nullptr}
     , m_lockSplitters{nullptr}
     , m_lockSplittersCmd{nullptr}
+    , m_clearLayout{nullptr}
+    , m_layoutActionGroup{nullptr}
 {
-    QObject::connect(m_layoutProvider, &LayoutProvider::layoutAdded, this, &LayoutMenu::addLayout);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutAdded, this, &LayoutMenu::refreshLayouts);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutRemoved, this, &LayoutMenu::refreshLayouts);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutChanged, this, &LayoutMenu::refreshLayouts);
+    QObject::connect(m_layoutProvider, &LayoutProvider::currentLayoutChanged, this, &LayoutMenu::updateCurrentLayout);
 }
 
 void LayoutMenu::setup()
@@ -87,38 +93,84 @@ void LayoutMenu::setup()
     exportLayout->setStatusTip(tr("Save the current layout to the specified file"));
     QObject::connect(exportLayout, &QAction::triggered, this, &LayoutMenu::exportLayout);
 
+    if(!m_clearLayout) {
+        m_clearLayout = new QAction(tr("&Clear layout"), this);
+        m_clearLayout->setStatusTip(tr("Clear the current layout"));
+        QObject::connect(m_clearLayout, &QAction::triggered, this, &LayoutMenu::clearLayout);
+    }
+
     m_layoutMenu->addAction(m_layoutEditingCmd, Actions::Groups::One);
     m_layoutMenu->addAction(m_lockSplittersCmd);
+    m_layoutMenu->addAction(m_clearLayout);
     m_layoutMenu->addAction(importLayout);
     m_layoutMenu->addAction(exportLayout);
     m_layoutMenu->addSeparator();
 
-    const auto layouts = m_layoutProvider->layouts();
-    for(const auto& layout : layouts) {
-        addLayout(layout);
+    if(!m_layoutActionGroup) {
+        m_layoutActionGroup = new QActionGroup(this);
+        m_layoutActionGroup->setExclusive(true);
     }
+
+    refreshLayouts();
 }
 
-void LayoutMenu::addLayout(const FyLayout& layout)
+void LayoutMenu::refreshLayouts()
 {
     if(!m_layoutMenu) {
         return;
     }
 
-    const QString name = layout.name();
-
-    auto* layoutAction = new QAction(name, m_layoutMenu->menu());
-    layoutAction->setStatusTip(tr("Replace the current layout"));
-    auto* layoutCmd = m_actionManager->registerAction(layoutAction, Id{u"Layout.Switch.%1"_s.arg(name)});
-    layoutCmd->setCategories({tr("Layout"), tr("Switch")});
-
-    QObject::connect(layoutAction, &QAction::triggered, this, [this, name]() {
-        const auto fyLayout = m_layoutProvider->layoutByName(name);
-        if(fyLayout.isValid()) {
-            Q_EMIT changeLayout(fyLayout);
+    for(auto* action : m_layoutActions) {
+        m_layoutMenu->menu()->removeAction(action);
+        if(m_layoutActionGroup) {
+            m_layoutActionGroup->removeAction(action);
         }
-    });
-    m_layoutMenu->addAction(layoutCmd->action());
+        action->deleteLater();
+    }
+    m_layoutActions.clear();
+
+    const auto layouts   = m_layoutProvider->layouts();
+    const auto addLayout = [this](const FyLayout& layout) {
+        const QString name = layout.name();
+
+        auto* layoutAction = new QAction(name, m_layoutMenu->menu());
+        layoutAction->setStatusTip(tr("Replace the current layout"));
+        layoutAction->setCheckable(true);
+        m_layoutActionGroup->addAction(layoutAction);
+
+        QObject::connect(layoutAction, &QAction::triggered, this, [this, name]() {
+            const auto fyLayout = m_layoutProvider->layoutByName(name);
+            if(fyLayout.isValid()) {
+                Q_EMIT changeLayout(fyLayout);
+            }
+        });
+        m_layoutMenu->menu()->addAction(layoutAction);
+        m_layoutActions.emplace_back(layoutAction);
+    };
+
+    const auto defaultLayout
+        = std::ranges::find_if(layouts, [](const FyLayout& layout) { return layout.name() == u"Default"_s; });
+    if(defaultLayout != layouts.cend()) {
+        addLayout(*defaultLayout);
+    }
+
+    for(const auto& layout : layouts) {
+        if(layout.name() != u"Default"_s) {
+            addLayout(layout);
+        }
+    }
+
+    updateCurrentLayout();
+}
+
+void LayoutMenu::updateCurrentLayout()
+{
+    const QString current = m_layoutProvider->currentLayout().name();
+    for(auto* action : m_layoutActions) {
+        if(action) {
+            action->setChecked(action->text() == current);
+        }
+    }
 }
 } // namespace Fooyin
 

--- a/src/gui/menubar/layoutmenu.h
+++ b/src/gui/menubar/layoutmenu.h
@@ -21,7 +21,10 @@
 
 #include <QObject>
 
+#include <vector>
+
 class QAction;
+class QActionGroup;
 
 namespace Fooyin {
 class ActionContainer;
@@ -43,11 +46,13 @@ public:
 
 Q_SIGNALS:
     void changeLayout(const Fooyin::FyLayout& layout);
+    void clearLayout();
     void importLayout();
     void exportLayout();
 
 private:
-    void addLayout(const FyLayout& layout);
+    void refreshLayouts();
+    void updateCurrentLayout();
 
     ActionManager* m_actionManager;
     LayoutProvider* m_layoutProvider;
@@ -58,5 +63,8 @@ private:
     Command* m_layoutEditingCmd;
     QAction* m_lockSplitters;
     Command* m_lockSplittersCmd;
+    QAction* m_clearLayout;
+    QActionGroup* m_layoutActionGroup;
+    std::vector<QAction*> m_layoutActions;
 };
 } // namespace Fooyin

--- a/src/gui/settings/guilayoutpage.cpp
+++ b/src/gui/settings/guilayoutpage.cpp
@@ -1,0 +1,567 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "guilayoutpage.h"
+
+#include "layouttreemodel.h"
+
+#include <gui/editablelayout.h>
+#include <gui/guiconstants.h>
+#include <gui/guisettings.h>
+#include <gui/layoutprovider.h>
+#include <gui/widgetprovider.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QInputDialog>
+#include <QLabel>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSize>
+#include <QSpinBox>
+#include <QTreeView>
+
+#include <algorithm>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+std::vector<int> indexPath(const QModelIndex& index)
+{
+    std::vector<int> path;
+    for(QModelIndex current = index; current.isValid(); current = current.parent()) {
+        path.emplace_back(current.row());
+    }
+    std::ranges::reverse(path);
+    return path;
+}
+
+QModelIndex indexFromPath(const QAbstractItemModel* model, const std::vector<int>& path)
+{
+    QModelIndex parent;
+    for(const int row : path) {
+        parent = model->index(row, 0, parent);
+        if(!parent.isValid()) {
+            return {};
+        }
+    }
+    return parent;
+}
+
+class TreeSelectionGuard
+{
+public:
+    TreeSelectionGuard(QTreeView* tree, const QAbstractItemModel* model)
+        : m_tree{tree}
+        , m_model{model}
+        , m_path{indexPath(tree->currentIndex())}
+    { }
+
+    ~TreeSelectionGuard()
+    {
+        const QModelIndex restoredIndex = indexFromPath(m_model, m_path);
+        if(restoredIndex.isValid()) {
+            m_tree->setCurrentIndex(restoredIndex);
+        }
+    }
+
+    void moveLastRow(int offset)
+    {
+        if(!m_path.empty()) {
+            m_path.back() += offset;
+        }
+    }
+
+private:
+    QTreeView* m_tree;
+    const QAbstractItemModel* m_model;
+    std::vector<int> m_path;
+};
+
+void setEqualButtonWidth(std::initializer_list<QPushButton*> buttons)
+{
+    int width{0};
+    for(const auto* button : buttons) {
+        width = std::max(width, button->sizeHint().width());
+    }
+    for(auto* button : buttons) {
+        button->setFixedWidth(width);
+    }
+}
+} // namespace
+
+class GuiLayoutPageWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    explicit GuiLayoutPageWidget(LayoutProvider* layoutProvider, EditableLayout* editableLayout,
+                                 WidgetProvider* widgetProvider, SettingsManager* settings);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    void onContextMenuRequested(const QPoint& pos);
+    void onChangeLayout();
+    void onSelectionChanged();
+    void onCustomMarginsChanged(bool enabled);
+    void updateMarginControls();
+    void updateModelMargins();
+    void updateButtonStates();
+    void moveSelectionUp();
+    void moveSelectionDown();
+    void cutSelection();
+    void copySelection();
+    void pasteAfterSelection();
+    void onNewLayout();
+    void onDeleteLayout();
+    void onRenameLayout();
+    void onDuplicateLayout();
+
+    LayoutProvider* m_layoutProvider;
+    EditableLayout* m_editableLayout;
+    SettingsManager* m_settings;
+
+    QTreeView* m_layoutTree;
+    LayoutTreeModel* m_model;
+    QGroupBox* m_marginsGroup;
+    QCheckBox* m_customMargins;
+    QSpinBox* m_leftMargin;
+    QSpinBox* m_topMargin;
+    QSpinBox* m_rightMargin;
+    QSpinBox* m_bottomMargin;
+
+    QComboBox* m_layoutCombo;
+    QPushButton* m_deleteLayout;
+    QJsonObject m_clipboardItem;
+    bool m_loading{false};
+    bool m_updatingMargins{false};
+};
+
+GuiLayoutPageWidget::GuiLayoutPageWidget(LayoutProvider* layoutProvider, EditableLayout* editableLayout,
+                                         WidgetProvider* widgetProvider, SettingsManager* settings)
+    : m_layoutProvider{layoutProvider}
+    , m_editableLayout{editableLayout}
+    , m_settings{settings}
+    , m_layoutTree{new QTreeView(this)}
+    , m_model{new LayoutTreeModel(widgetProvider, this)}
+    , m_marginsGroup{new QGroupBox(tr("Margins"), this)}
+    , m_customMargins{new QCheckBox(tr("Use custom margins"), this)}
+    , m_leftMargin{new QSpinBox(this)}
+    , m_topMargin{new QSpinBox(this)}
+    , m_rightMargin{new QSpinBox(this)}
+    , m_bottomMargin{new QSpinBox(this)}
+    , m_layoutCombo{new QComboBox(this)}
+    , m_deleteLayout{new QPushButton(this)}
+{
+    m_layoutTree->setHeaderHidden(true);
+    m_layoutTree->setModel(m_model);
+
+    for(auto* spinBox : {m_leftMargin, m_topMargin, m_rightMargin, m_bottomMargin}) {
+        spinBox->setRange(-999, 999);
+        spinBox->setSuffix(u" px"_s);
+    }
+
+    auto* marginsLayout = new QGridLayout(m_marginsGroup);
+
+    int row{0};
+    marginsLayout->addWidget(m_customMargins, row++, 0, 1, 4);
+    marginsLayout->addWidget(new QLabel(tr("Left"), m_marginsGroup), row, 0);
+    marginsLayout->addWidget(m_leftMargin, row, 1);
+    marginsLayout->addWidget(new QLabel(tr("Top"), m_marginsGroup), row, 2);
+    marginsLayout->addWidget(m_topMargin, row++, 3);
+    marginsLayout->addWidget(new QLabel(tr("Right"), m_marginsGroup), row, 0);
+    marginsLayout->addWidget(m_rightMargin, row, 1);
+    marginsLayout->addWidget(new QLabel(tr("Bottom"), m_marginsGroup), row, 2);
+    marginsLayout->addWidget(m_bottomMargin, row++, 3);
+
+    auto* newLayout       = new QPushButton(tr("New"), this);
+    auto* renameLayout    = new QPushButton(tr("Rename"), this);
+    auto* duplicateLayout = new QPushButton(tr("Duplicate"), this);
+    setEqualButtonWidth({newLayout, m_deleteLayout, renameLayout, duplicateLayout});
+
+    auto* topBarLayout = new QHBoxLayout();
+    topBarLayout->addWidget(m_layoutCombo, 1);
+    topBarLayout->addWidget(newLayout);
+    topBarLayout->addWidget(m_deleteLayout);
+    topBarLayout->addWidget(renameLayout);
+    topBarLayout->addWidget(duplicateLayout);
+
+    auto* layout = new QGridLayout(this);
+    layout->addLayout(topBarLayout, 0, 0, 1, 2);
+    layout->addWidget(m_layoutTree, 1, 0);
+    layout->addWidget(m_marginsGroup, 1, 1, Qt::AlignTop);
+    layout->setColumnStretch(0, 1);
+    layout->setRowStretch(1, 1);
+
+    m_layoutTree->setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(m_layoutTree, &QWidget::customContextMenuRequested, this,
+                     &GuiLayoutPageWidget::onContextMenuRequested);
+
+    QObject::connect(m_layoutCombo, &QComboBox::currentIndexChanged, this, &GuiLayoutPageWidget::onChangeLayout);
+
+    QObject::connect(newLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onNewLayout);
+    QObject::connect(m_deleteLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onDeleteLayout);
+    QObject::connect(renameLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onRenameLayout);
+    QObject::connect(duplicateLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onDuplicateLayout);
+
+    QObject::connect(m_model, &QAbstractItemModel::modelReset, m_layoutTree, &QTreeView::expandAll);
+    QObject::connect(m_layoutTree->selectionModel(), &QItemSelectionModel::currentChanged, this,
+                     &GuiLayoutPageWidget::onSelectionChanged);
+
+    for(auto* spinBox : {m_leftMargin, m_topMargin, m_rightMargin, m_bottomMargin}) {
+        QObject::connect(spinBox, &QSpinBox::valueChanged, this, &GuiLayoutPageWidget::updateModelMargins);
+    }
+    QObject::connect(m_customMargins, &QCheckBox::toggled, this, &GuiLayoutPageWidget::onCustomMarginsChanged);
+
+    updateMarginControls();
+}
+
+void GuiLayoutPageWidget::load()
+{
+    m_loading = true;
+
+    m_layoutCombo->clear();
+
+    const auto addLayout = [this](const FyLayout& layout) {
+        m_layoutCombo->addItem(layout.name());
+    };
+
+    const auto layouts = m_layoutProvider->layouts();
+    const auto defaultLayout
+        = std::ranges::find_if(layouts, [](const FyLayout& layout) { return layout.name() == u"Default"_s; });
+    if(defaultLayout != layouts.cend()) {
+        addLayout(*defaultLayout);
+    }
+
+    for(const auto& layout : m_layoutProvider->layouts()) {
+        if(layout.name() != u"Default"_s) {
+            addLayout(layout);
+        }
+    }
+
+    const QString current = m_layoutProvider->currentLayout().name();
+    const int idx         = m_layoutCombo->findText(current);
+    if(idx >= 0) {
+        m_layoutCombo->setCurrentIndex(idx);
+    }
+
+    m_model->populate(m_layoutProvider->currentLayout());
+    m_layoutTree->setEnabled(idx >= 0);
+    updateMarginControls();
+    updateButtonStates();
+
+    m_loading = false;
+}
+
+void GuiLayoutPageWidget::apply()
+{
+    const FyLayout layout = m_model->layout();
+    if(layout.isValid()) {
+        const FyLayout currentLayout = m_layoutProvider->currentLayout();
+        if(currentLayout.isValid() && layout.name() == currentLayout.name() && layout.json() == currentLayout.json()) {
+            return;
+        }
+
+        const TreeSelectionGuard selectionGuard{m_layoutTree, m_model};
+        m_editableLayout->changeLayout(layout);
+        m_layoutProvider->saveCurrentLayout();
+        load();
+    }
+}
+
+void GuiLayoutPageWidget::reset() { }
+
+void GuiLayoutPageWidget::onContextMenuRequested(const QPoint& pos)
+{
+    const QModelIndex index = m_layoutTree->indexAt(pos);
+    if(!index.isValid()) {
+        return;
+    }
+    m_layoutTree->setCurrentIndex(index);
+
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* moveUp = new QAction(tr("Move up"), menu);
+    moveUp->setVisible(m_model->canMoveUp(index));
+    QObject::connect(moveUp, &QAction::triggered, this, &GuiLayoutPageWidget::moveSelectionUp);
+    menu->addAction(moveUp);
+
+    auto* moveDown = new QAction(tr("Move down"), menu);
+    moveDown->setVisible(m_model->canMoveDown(index));
+    QObject::connect(moveDown, &QAction::triggered, this, &GuiLayoutPageWidget::moveSelectionDown);
+    menu->addAction(moveDown);
+
+    auto* remove = new QAction(tr("Remove"), menu);
+    remove->setVisible(m_model->canRemove(index));
+    QObject::connect(remove, &QAction::triggered, m_model, [this, index]() { m_model->remove(index); });
+    menu->addAction(remove);
+
+    if(!m_model->isDummy(index)) {
+        menu->addSeparator();
+
+        auto* cut = new QAction(tr("Cut"), menu);
+        cut->setVisible(m_model->canCut(index));
+        QObject::connect(cut, &QAction::triggered, this, &GuiLayoutPageWidget::cutSelection);
+        menu->addAction(cut);
+
+        auto* copy = new QAction(tr("Copy"), menu);
+        copy->setVisible(m_model->canCopy(index));
+        QObject::connect(copy, &QAction::triggered, this, &GuiLayoutPageWidget::copySelection);
+        menu->addAction(copy);
+
+        if(!m_clipboardItem.empty() && m_model->canPasteAfter(index)) {
+            auto* paste = new QAction(tr("Paste"), menu);
+            QObject::connect(paste, &QAction::triggered, this, &GuiLayoutPageWidget::pasteAfterSelection);
+            menu->addAction(paste);
+        }
+    }
+
+    menu->popup(m_layoutTree->viewport()->mapToGlobal(pos));
+}
+
+void GuiLayoutPageWidget::onChangeLayout()
+{
+    if(m_loading) {
+        return;
+    }
+
+    const FyLayout layout = m_layoutProvider->layoutByName(m_layoutCombo->currentText());
+    m_model->populate(layout);
+    m_layoutTree->setEnabled(layout.isValid());
+    updateButtonStates();
+    updateMarginControls();
+}
+
+void GuiLayoutPageWidget::onSelectionChanged()
+{
+    updateMarginControls();
+}
+
+void GuiLayoutPageWidget::onCustomMarginsChanged(bool enabled)
+{
+    if(m_updatingMargins) {
+        return;
+    }
+
+    if(enabled) {
+        updateModelMargins();
+    }
+    else {
+        m_model->clearMargins(m_layoutTree->currentIndex());
+    }
+
+    updateMarginControls();
+}
+
+void GuiLayoutPageWidget::updateMarginControls()
+{
+    const QModelIndex index = m_layoutTree->currentIndex();
+    const bool enabled      = m_model->hasConfigurableMargins(index);
+    const bool custom       = m_model->hasCustomMargins(index);
+    const QMargins margins  = m_model->margins(index);
+
+    m_updatingMargins = true;
+    m_customMargins->setChecked(custom);
+    m_leftMargin->setValue(margins.left());
+    m_topMargin->setValue(margins.top());
+    m_rightMargin->setValue(margins.right());
+    m_bottomMargin->setValue(margins.bottom());
+    m_updatingMargins = false;
+
+    m_marginsGroup->setEnabled(enabled);
+    for(auto* spinBox : {m_leftMargin, m_topMargin, m_rightMargin, m_bottomMargin}) {
+        spinBox->setEnabled(enabled && custom);
+    }
+}
+
+void GuiLayoutPageWidget::updateModelMargins()
+{
+    if(m_updatingMargins || !m_customMargins->isChecked()) {
+        return;
+    }
+
+    m_model->setMargins(m_layoutTree->currentIndex(),
+                        {m_leftMargin->value(), m_topMargin->value(), m_rightMargin->value(), m_bottomMargin->value()});
+}
+
+void GuiLayoutPageWidget::updateButtonStates()
+{
+    const QString name  = m_layoutCombo->currentText();
+    const bool canReset = m_layoutProvider->canResetLayout(name);
+
+    m_deleteLayout->setText(canReset ? tr("Reset") : tr("Delete"));
+    m_deleteLayout->setEnabled(canReset || m_layoutProvider->canDeleteLayout(name));
+}
+
+void GuiLayoutPageWidget::moveSelectionUp()
+{
+    m_model->moveUp(m_layoutTree->currentIndex());
+}
+
+void GuiLayoutPageWidget::moveSelectionDown()
+{
+    m_model->moveDown(m_layoutTree->currentIndex());
+}
+
+void GuiLayoutPageWidget::cutSelection()
+{
+    const QModelIndex index = m_layoutTree->currentIndex();
+    if(!m_model->canCut(index)) {
+        return;
+    }
+
+    m_clipboardItem = m_model->copyItem(index);
+    m_model->remove(index);
+}
+
+void GuiLayoutPageWidget::copySelection()
+{
+    if(!m_model->canCopy(m_layoutTree->currentIndex())) {
+        return;
+    }
+
+    m_clipboardItem = m_model->copyItem(m_layoutTree->currentIndex());
+}
+
+void GuiLayoutPageWidget::pasteAfterSelection()
+{
+    if(m_clipboardItem.empty() || !m_model->canPasteAfter(m_layoutTree->currentIndex())) {
+        return;
+    }
+
+    TreeSelectionGuard selectionGuard{m_layoutTree, m_model};
+    selectionGuard.moveLastRow(1);
+    m_model->pasteAfter(m_layoutTree->currentIndex(), m_clipboardItem);
+}
+
+void GuiLayoutPageWidget::onNewLayout()
+{
+    const QString defaultName = m_layoutProvider->uniqueLayoutName(tr("New Layout"));
+    bool success{false};
+    const QString name = QInputDialog::getText(this, tr("New Layout"), tr("Layout Name") + u":"_s, QLineEdit::Normal,
+                                               defaultName, &success)
+                             .trimmed();
+
+    QJsonObject layout;
+    layout["Name"_L1] = name;
+
+    if(success && !name.isEmpty() && m_layoutProvider->createLayout(name, FyLayout{name, layout})) {
+        load();
+        m_layoutCombo->setCurrentText(name);
+    }
+}
+
+void GuiLayoutPageWidget::onDeleteLayout()
+{
+    const QString name = m_layoutCombo->currentText();
+    if(name.isEmpty()) {
+        return;
+    }
+
+    if(m_layoutProvider->canResetLayout(name)) {
+        const bool wasCurrent = m_layoutProvider->currentLayout().name() == name;
+        if(m_layoutProvider->resetLayout(name)) {
+            if(wasCurrent) {
+                m_editableLayout->changeLayout(m_layoutProvider->currentLayout());
+            }
+            load();
+            m_layoutCombo->setCurrentText(name);
+        }
+        return;
+    }
+
+    QMessageBox msg{QMessageBox::Question, tr("Delete Layout"), tr("Delete layout \"%1\"?").arg(name),
+                    QMessageBox::Yes | QMessageBox::No, this};
+    msg.setDefaultButton(QMessageBox::No);
+    if(msg.exec() != QMessageBox::Yes) {
+        return;
+    }
+
+    const bool wasCurrent = m_layoutProvider->currentLayout().name() == name;
+    if(m_layoutProvider->deleteLayout(name)) {
+        if(wasCurrent && m_layoutProvider->currentLayout().isValid()) {
+            m_editableLayout->changeLayout(m_layoutProvider->currentLayout());
+        }
+        load();
+    }
+}
+
+void GuiLayoutPageWidget::onRenameLayout()
+{
+    const QString oldName = m_layoutCombo->currentText();
+    if(oldName.isEmpty()) {
+        return;
+    }
+
+    bool success{false};
+    const QString newName = QInputDialog::getText(this, tr("Rename Layout"), tr("Layout Name") + u":"_s,
+                                                  QLineEdit::Normal, oldName, &success)
+                                .trimmed();
+
+    if(success && m_layoutProvider->renameLayout(oldName, newName)) {
+        load();
+        m_layoutCombo->setCurrentText(newName);
+    }
+}
+
+void GuiLayoutPageWidget::onDuplicateLayout()
+{
+    const QString sourceName = m_layoutCombo->currentText();
+    if(sourceName.isEmpty()) {
+        return;
+    }
+
+    const QString defaultName = m_layoutProvider->uniqueLayoutName(tr("%1 Copy").arg(sourceName));
+    bool success{false};
+    const QString newName = QInputDialog::getText(this, tr("Duplicate Layout"), tr("Layout Name") + u":"_s,
+                                                  QLineEdit::Normal, defaultName, &success)
+                                .trimmed();
+
+    if(success && m_layoutProvider->duplicateLayout(sourceName, newName)) {
+        load();
+        m_layoutCombo->setCurrentText(newName);
+    }
+}
+
+GuiLayoutPage::GuiLayoutPage(LayoutProvider* layoutProvider, EditableLayout* editableLayout,
+                             WidgetProvider* widgetProvider, SettingsManager* settings, QObject* parent)
+    : SettingsPage{settings->settingsDialog(), parent}
+{
+    setId(Constants::Page::InterfaceLayout);
+    setName(tr("Layout"));
+    setCategory({tr("Interface"), tr("Layout")});
+    setWidgetCreator([layoutProvider, editableLayout, settings, widgetProvider] {
+        return new GuiLayoutPageWidget(layoutProvider, editableLayout, widgetProvider, settings);
+    });
+}
+} // namespace Fooyin
+
+#include "guilayoutpage.moc"
+#include "moc_guilayoutpage.cpp"

--- a/src/gui/settings/guilayoutpage.h
+++ b/src/gui/settings/guilayoutpage.h
@@ -1,0 +1,38 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/settings/settingspage.h>
+
+namespace Fooyin {
+class SettingsManager;
+class EditableLayout;
+class LayoutProvider;
+class WidgetProvider;
+
+class GuiLayoutPage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    explicit GuiLayoutPage(LayoutProvider* layoutProvider, EditableLayout* editableLayout,
+                           WidgetProvider* widgetProvider, SettingsManager* settings, QObject* parent = nullptr);
+};
+} // namespace Fooyin

--- a/src/gui/settings/layouttreemodel.cpp
+++ b/src/gui/settings/layouttreemodel.cpp
@@ -1,0 +1,509 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "layouttreemodel.h"
+
+#include <gui/widgetprovider.h>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+QJsonArray saveChildren(const LayoutItem* parent)
+{
+    QJsonArray children;
+    for(const auto* child : parent->children()) {
+        if(!child || child->status() == LayoutItem::Removed) {
+            continue;
+        }
+
+        QJsonObject data = child->data();
+        if(child->childCount() > 0 || data.contains("Widgets"_L1)) {
+            data["Widgets"_L1] = saveChildren(child);
+        }
+
+        QJsonObject childObject;
+        childObject[child->key()] = data;
+        children.append(childObject);
+    }
+
+    return children;
+}
+
+QJsonObject saveItem(const LayoutItem* item)
+{
+    if(!item || item->status() == LayoutItem::Removed) {
+        return {};
+    }
+
+    QJsonObject data = item->data();
+    if(item->childCount() > 0 || data.contains("Widgets"_L1)) {
+        data["Widgets"_L1] = saveChildren(item);
+    }
+
+    QJsonObject itemObject;
+    itemObject[item->key()] = data;
+    return itemObject;
+}
+
+bool isValidItemObject(const QJsonObject& item)
+{
+    if(item.empty()) {
+        return false;
+    }
+
+    const auto it = item.constBegin();
+    return it->isObject();
+}
+
+bool isSplitter(const LayoutItem* item)
+{
+    if(!item) {
+        return false;
+    }
+    return item->key() == u"SplitterVertical"_s || item->key() == u"SplitterHorizontal"_s;
+}
+
+int minimumChildCount(const LayoutItem* item)
+{
+    return isSplitter(item) ? 2 : 1;
+}
+} // namespace
+
+LayoutItem::LayoutItem()
+    : LayoutItem{{}, {}, nullptr}
+{ }
+
+LayoutItem::LayoutItem(QString key, QJsonObject data, LayoutItem* parent)
+    : TreeStatusItem{parent}
+    , m_key{std::move(key)}
+    , m_data{std::move(data)}
+{ }
+
+QString LayoutItem::name() const
+{
+    return m_key;
+}
+
+QString LayoutItem::key() const
+{
+    return m_key;
+}
+
+QJsonObject LayoutItem::data() const
+{
+    return m_data;
+}
+
+void LayoutItem::setData(QJsonObject data)
+{
+    m_data = std::move(data);
+}
+
+bool LayoutItem::isContainer() const
+{
+    return m_data.value("Widgets"_L1).isArray();
+}
+
+LayoutTreeModel::LayoutTreeModel(WidgetProvider* widgetProvider, QObject* parent)
+    : TreeModel{parent}
+    , m_widgetProvider{widgetProvider}
+{ }
+
+void LayoutTreeModel::populate(const FyLayout& layout)
+{
+    beginResetModel();
+
+    resetRoot();
+    m_nodes.clear();
+    m_layoutName = layout.name();
+    m_layoutJson = layout.json();
+
+    if(layout.isValid()) {
+        populateChildren(rootItem(), m_layoutJson.value("Widgets"_L1).toArray());
+    }
+
+    endResetModel();
+}
+
+void LayoutTreeModel::remove(const QModelIndex& index)
+{
+    if(!canRemove(index)) {
+        return;
+    }
+
+    auto* item = itemForIndex(index);
+
+    const auto markRemovedRecursive = [](auto&& self, LayoutItem* current) -> void {
+        if(!current) {
+            return;
+        }
+
+        current->setStatus(LayoutItem::Removed);
+
+        if(current->isContainer()) {
+            for(auto* child : current->children()) {
+                self(self, child);
+            }
+        }
+    };
+
+    markRemovedRecursive(markRemovedRecursive, item);
+
+    invalidateData();
+}
+
+void LayoutTreeModel::moveUp(const QModelIndex& index)
+{
+    if(!canMoveUp(index)) {
+        return;
+    }
+
+    auto* item                    = itemForIndex(index);
+    auto* parent                  = item->parent();
+    const QModelIndex parentIndex = this->parent(index);
+    const int row                 = item->row();
+
+    if(!beginMoveRows(parentIndex, row, row, parentIndex, row - 1)) {
+        return;
+    }
+    parent->moveChild(row, row - 1);
+    item->setStatus(LayoutItem::Changed);
+    endMoveRows();
+
+    Q_EMIT dataChanged(indexOfItem(item), indexOfItem(item), {Qt::FontRole});
+}
+
+void LayoutTreeModel::moveDown(const QModelIndex& index)
+{
+    if(!canMoveDown(index)) {
+        return;
+    }
+
+    auto* item                    = itemForIndex(index);
+    auto* parent                  = item->parent();
+    const QModelIndex parentIndex = this->parent(index);
+    const int row                 = item->row();
+
+    if(!beginMoveRows(parentIndex, row, row, parentIndex, row + 2)) {
+        return;
+    }
+    parent->moveChild(row, row + 2);
+    item->setStatus(LayoutItem::Changed);
+    endMoveRows();
+
+    Q_EMIT dataChanged(indexOfItem(item), indexOfItem(item), {Qt::FontRole});
+}
+
+bool LayoutTreeModel::canMoveUp(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    const auto* item = itemForIndex(index);
+    return item && item->parent() && item->parent() != rootItem() && item->row() > 0;
+}
+
+bool LayoutTreeModel::canMoveDown(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    const auto* item = itemForIndex(index);
+    return item && item->parent() && item->parent() != rootItem() && item->row() < item->parent()->childCount() - 1;
+}
+
+bool LayoutTreeModel::canRemove(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    const auto* item = itemForIndex(index);
+    if(!item || !item->parent() || item->parent() == rootItem()) {
+        return false;
+    }
+
+    if(item->key() == u"Dummy"_s) {
+        return item->parent()->childCount() > minimumChildCount(item->parent());
+    }
+
+    return true;
+}
+
+bool LayoutTreeModel::canCut(const QModelIndex& index) const
+{
+    return canRemove(index) && !isDummy(index);
+}
+
+bool LayoutTreeModel::canCopy(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    return !isDummy(index);
+}
+
+bool LayoutTreeModel::canPasteAfter(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    const auto* item = itemForIndex(index);
+    return item && item->parent() && item->parent() != rootItem() && item->key() != u"Dummy"_s;
+}
+
+bool LayoutTreeModel::isDummy(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    const auto* item = itemForIndex(index);
+    return item && item->key() == u"Dummy"_s;
+}
+
+QJsonObject LayoutTreeModel::copyItem(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return {};
+    }
+
+    return saveItem(itemForIndex(index));
+}
+
+void LayoutTreeModel::pasteAfter(const QModelIndex& index, const QJsonObject& item)
+{
+    if(!canPasteAfter(index) || !isValidItemObject(item)) {
+        return;
+    }
+
+    auto* target = itemForIndex(index);
+    auto* parent = target->parent();
+
+    const auto it = item.constBegin();
+    auto* pasted  = insertItem(parent, target->row() + 1, it.key(), it->toObject());
+    populateChildren(pasted, pasted->data().value("Widgets"_L1).toArray(), LayoutItem::Added);
+    pasted->setStatus(LayoutItem::Added);
+
+    invalidateData();
+}
+
+FyLayout LayoutTreeModel::layout() const
+{
+    if(m_layoutName.isEmpty()) {
+        return {};
+    }
+
+    QJsonObject json   = m_layoutJson;
+    json["Name"_L1]    = m_layoutName;
+    json["Widgets"_L1] = saveChildren(rootItem());
+
+    return FyLayout{m_layoutName, json};
+}
+
+bool LayoutTreeModel::hasConfigurableMargins(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    auto* item = itemForIndex(index);
+    return item && m_widgetProvider && m_widgetProvider->widgetExists(item->key());
+}
+
+bool LayoutTreeModel::hasCustomMargins(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return false;
+    }
+
+    auto* item = itemForIndex(index);
+    return item && item->data().value("Margins"_L1).isObject();
+}
+
+QMargins LayoutTreeModel::margins(const QModelIndex& index) const
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return {};
+    }
+
+    auto* item = itemForIndex(index);
+    if(!item) {
+        return {};
+    }
+
+    const QJsonObject marginData = item->data().value("Margins"_L1).toObject();
+    return {marginData.value("Left"_L1).toInt(), marginData.value("Top"_L1).toInt(),
+            marginData.value("Right"_L1).toInt(), marginData.value("Bottom"_L1).toInt()};
+}
+
+void LayoutTreeModel::setMargins(const QModelIndex& index, const QMargins& margins)
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return;
+    }
+
+    auto* item = itemForIndex(index);
+    if(!item || !hasConfigurableMargins(index)) {
+        return;
+    }
+
+    QJsonObject marginData;
+    marginData["Left"_L1]   = margins.left();
+    marginData["Top"_L1]    = margins.top();
+    marginData["Right"_L1]  = margins.right();
+    marginData["Bottom"_L1] = margins.bottom();
+
+    QJsonObject data   = item->data();
+    data["Margins"_L1] = marginData;
+    item->setData(data);
+    item->setStatus(LayoutItem::Changed);
+    Q_EMIT dataChanged(index, index, {Qt::FontRole});
+}
+
+void LayoutTreeModel::clearMargins(const QModelIndex& index)
+{
+    if(!index.isValid() || !checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return;
+    }
+
+    auto* item = itemForIndex(index);
+    if(!item || !hasConfigurableMargins(index)) {
+        return;
+    }
+
+    QJsonObject data = item->data();
+    data.remove("Margins"_L1);
+    item->setData(data);
+    item->setStatus(LayoutItem::Changed);
+    Q_EMIT dataChanged(index, index, {Qt::FontRole});
+}
+
+QVariant LayoutTreeModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(role == Qt::TextAlignmentRole) {
+        return Qt::AlignHCenter;
+    }
+
+    if(role != Qt::DisplayRole || orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    switch(section) {
+        case 0:
+            return tr("Name");
+        default:
+            break;
+    }
+
+    return {};
+}
+
+QVariant LayoutTreeModel::data(const QModelIndex& index, int role) const
+{
+    if(role != Qt::DisplayRole && role != Qt::FontRole && role != LayoutItem::WidgetKey
+       && role != LayoutItem::IsContainer) {
+        return {};
+    }
+
+    if(!checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return {};
+    }
+
+    auto* item = itemForIndex(index);
+
+    if(role == Qt::FontRole) {
+        return item->font();
+    }
+
+    if(role == LayoutItem::WidgetKey) {
+        return item->key();
+    }
+
+    if(role == LayoutItem::IsContainer) {
+        return item->isContainer();
+    }
+
+    switch(index.column()) {
+        case 0:
+            return m_widgetProvider->displayName(item->key());
+        default:
+            break;
+    }
+
+    return {};
+}
+
+int LayoutTreeModel::columnCount(const QModelIndex& /*parent*/) const
+{
+    return 1;
+}
+
+LayoutItem* LayoutTreeModel::appendItem(LayoutItem* parent, const QString& key, const QJsonObject& data)
+{
+    auto node  = std::make_unique<LayoutItem>(key, data, parent);
+    auto* item = m_nodes.emplace_back(std::move(node)).get();
+    parent->appendChild(item);
+    return item;
+}
+
+LayoutItem* LayoutTreeModel::insertItem(LayoutItem* parent, int row, const QString& key, const QJsonObject& data)
+{
+    auto node  = std::make_unique<LayoutItem>(key, data, parent);
+    auto* item = m_nodes.emplace_back(std::move(node)).get();
+    parent->insertChild(row, item);
+    return item;
+}
+
+void LayoutTreeModel::populateChildren(LayoutItem* parent, const QJsonArray& children)
+{
+    populateChildren(parent, children, LayoutItem::None);
+}
+
+void LayoutTreeModel::populateChildren(LayoutItem* parent, const QJsonArray& children, LayoutItem::ItemStatus status)
+{
+    for(const auto& child : children) {
+        if(!child.isObject()) {
+            continue;
+        }
+
+        const QJsonObject childObject = child.toObject();
+        if(childObject.empty()) {
+            continue;
+        }
+
+        const auto it = childObject.constBegin();
+        if(!it->isObject()) {
+            continue;
+        }
+
+        const QString key      = it.key();
+        const QJsonObject data = it->toObject();
+        auto* item             = appendItem(parent, key, data);
+        item->setStatus(status);
+
+        populateChildren(item, data.value("Widgets"_L1).toArray(), status);
+    }
+}
+} // namespace Fooyin

--- a/src/gui/settings/layouttreemodel.h
+++ b/src/gui/settings/layouttreemodel.h
@@ -1,0 +1,104 @@
+/*
+ * Fooyin
+ * Copyright © 2025, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gui/fylayout.h>
+#include <utils/treemodel.h>
+#include <utils/treestatusitem.h>
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QMargins>
+
+#include <memory>
+#include <vector>
+
+namespace Fooyin {
+class WidgetProvider;
+
+class LayoutItem : public TreeStatusItem<LayoutItem>
+{
+public:
+    enum Role
+    {
+        IsContainer = Qt::UserRole,
+        WidgetKey
+    };
+
+    LayoutItem();
+    explicit LayoutItem(QString key, QJsonObject data, LayoutItem* parent);
+
+    [[nodiscard]] QString name() const;
+    [[nodiscard]] QString key() const;
+    [[nodiscard]] QJsonObject data() const;
+    void setData(QJsonObject data);
+
+    [[nodiscard]] bool isContainer() const;
+
+private:
+    QString m_key;
+    QJsonObject m_data;
+};
+
+class LayoutTreeModel : public TreeModel<LayoutItem>
+{
+    Q_OBJECT
+
+public:
+    explicit LayoutTreeModel(WidgetProvider* widgetProvider, QObject* parent = nullptr);
+
+    void populate(const FyLayout& layout);
+
+    void remove(const QModelIndex& index);
+    void moveUp(const QModelIndex& index);
+    void moveDown(const QModelIndex& index);
+    [[nodiscard]] bool canMoveUp(const QModelIndex& index) const;
+    [[nodiscard]] bool canMoveDown(const QModelIndex& index) const;
+    [[nodiscard]] bool canRemove(const QModelIndex& index) const;
+    [[nodiscard]] bool canCut(const QModelIndex& index) const;
+    [[nodiscard]] bool canCopy(const QModelIndex& index) const;
+    [[nodiscard]] bool canPasteAfter(const QModelIndex& index) const;
+    [[nodiscard]] bool isDummy(const QModelIndex& index) const;
+    [[nodiscard]] QJsonObject copyItem(const QModelIndex& index) const;
+    void pasteAfter(const QModelIndex& index, const QJsonObject& item);
+
+    [[nodiscard]] FyLayout layout() const;
+    [[nodiscard]] bool hasConfigurableMargins(const QModelIndex& index) const;
+    [[nodiscard]] bool hasCustomMargins(const QModelIndex& index) const;
+    [[nodiscard]] QMargins margins(const QModelIndex& index) const;
+    void setMargins(const QModelIndex& index, const QMargins& margins);
+    void clearMargins(const QModelIndex& index);
+
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+
+private:
+    LayoutItem* appendItem(LayoutItem* parent, const QString& key, const QJsonObject& data);
+    LayoutItem* insertItem(LayoutItem* parent, int row, const QString& key, const QJsonObject& data);
+    void populateChildren(LayoutItem* parent, const QJsonArray& children);
+    void populateChildren(LayoutItem* parent, const QJsonArray& children, LayoutItem::ItemStatus status);
+
+    QJsonObject m_layoutJson;
+    QString m_layoutName;
+    WidgetProvider* m_widgetProvider;
+    std::vector<std::unique_ptr<LayoutItem>> m_nodes;
+};
+} // namespace Fooyin

--- a/src/gui/widgetprovider.cpp
+++ b/src/gui/widgetprovider.cpp
@@ -200,6 +200,14 @@ bool WidgetProvider::widgetExists(const QString& key) const
     return p->m_widgets.contains(key);
 }
 
+QString WidgetProvider::displayName(const QString& key) const
+{
+    if(!p->m_widgets.contains(key)) {
+        return key;
+    }
+    return p->m_widgets.at(key).name;
+}
+
 bool WidgetProvider::canCreateWidget(const QString& key) const
 {
     return p->canCreateWidget(key);

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -66,6 +66,7 @@
 #include "settings/generalpage.h"
 #include "settings/guidisplaypage.h"
 #include "settings/guigeneralpage.h"
+#include "settings/guilayoutpage.h"
 #include "settings/guithemespage.h"
 #include "settings/guitrackdisplaypage.h"
 #include "settings/library/librarygeneralpage.h"
@@ -336,6 +337,7 @@ void Widgets::registerPages()
     new GuiGeneralPage(m_gui->layoutProvider(), m_gui->editableLayout(), m_settings, this);
     new GuiDisplayPage(m_settings, this);
     new GuiTrackDisplayPage(m_settings, this);
+    new GuiLayoutPage(m_gui->layoutProvider(), m_gui->editableLayout(), m_gui->widgetProvider(), m_settings, this);
     new GuiThemesPage(m_gui->themeRegistry(), m_settings, this);
     new TrackContextMenuPage(m_gui->trackSelection(), m_settings, this);
 


### PR DESCRIPTION
This updates layout handling so the selected layout is treated as persistent user state rather than only a preset which is applied. A new layout settings page supports changing all saved layout in a tree view, while the Layout menu reflects the active layout with checked state. Compatibility with the legacy or `Default` layout file is retained.

The layout settings page adds configurable widget margins through the layout tree. Margins are available for all registered widgets, are only saved when explicitly enabled.

`FyWidget` now also uses pimpl to store its private state, so future changes won't affect the object layout.

<img width="649" alt="image" src="https://github.com/user-attachments/assets/1401c0cb-8eab-4851-b19c-6b6c5d81ccba" />

