### PR TITLE
fix: migrate TrackStats.Rating to REAL to match stored values

### DIFF
--- a/data/dbschema.xml
+++ b/data/dbschema.xml
@@ -378,4 +378,18 @@
             ALTER TABLE Tracks ADD COLUMN CreatedDate INTEGER;
         </sql>
     </revision>
+    <revision version="18">
+        <description>
+            Change TrackStats.Rating column affinity to REAL.
+        </description>
+        <sql>
+            ALTER TABLE TrackStats RENAME COLUMN Rating TO RatingOld;
+
+            ALTER TABLE TrackStats ADD COLUMN Rating REAL DEFAULT 0;
+
+            UPDATE TrackStats SET Rating = RatingOld;
+
+            ALTER TABLE TrackStats DROP COLUMN RatingOld;
+        </sql>
+    </revision>
 </schema>

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -30,7 +30,7 @@
 
 using namespace Qt::StringLiterals;
 
-constexpr auto CurrentSchemaVersion = 17;
+constexpr auto CurrentSchemaVersion = 18;
 
 namespace {
 Fooyin::DbConnection::DbParams dbConnectionParams()

--- a/tests/core/library/unifiedmusiclibrarytest.cpp
+++ b/tests/core/library/unifiedmusiclibrarytest.cpp
@@ -58,7 +58,7 @@
 
 using namespace Qt::StringLiterals;
 
-constexpr auto CurrentSchemaVersion = 17;
+constexpr auto CurrentSchemaVersion = 18;
 
 namespace {
 QCoreApplication* ensureCoreApplication()


### PR DESCRIPTION
## Summary
Adds DB schema revision 18 that changes the `TrackStats.Rating` column affinity from `INTEGER` to `REAL`, so the declared schema type matches the floating-point rating values fooyin actually stores.

## Why this matters
Resolves #1216. `trackdatabase.cpp` reads and writes ratings as `float` (`normaliseTrackRating(float)`, `value(...).toFloat()`, float binds), but the schema declared `Rating INTEGER DEFAULT 0`. SQLite's dynamic typing means no runtime error occurs, but external tooling that inspects the declared schema (the reporter was importing foobar2000 statistics via a script) sees the wrong type. The maintainer (@ludouzi) confirmed the mismatch and said a migration should be added.

## Changes
- `data/dbschema.xml`: new `<revision version="18">` retyping `TrackStats.Rating` to `REAL`, following the established rename-old / add-new / copy / drop-old pattern used by the revision 12 ReplayGain retype (SQLite cannot alter a column type in place).
- `src/core/database/database.cpp`: bump `CurrentSchemaVersion` from 17 to 18 so the upgrade engine (`upgradeDatabase` loops `while(nextVersion < targetVersion)`) actually applies the new revision.

## Testing
- `xmllint --noout data/dbschema.xml` passes.
- Verified existing rating read/write paths in `trackdatabase.cpp` round-trip values as `float` and do not depend on the INTEGER affinity, so existing data is preserved across the migration.
- Note: a full Qt build was not run locally; the change is a data-schema revision plus a one-line version constant bump following an existing, exercised migration pattern.

Fixes #1216

AI was used for assistance.
