### PR TITLE
[gui] Save window size on layout switch

### DIFF
--- a/include/gui/editablelayout.h
+++ b/include/gui/editablelayout.h
@@ -47,7 +47,7 @@ public:
     ~EditableLayout() override;
 
     void initialise();
-    FyLayout saveCurrentToLayout(const QString& name);
+    FyLayout saveCurrentToLayout(const QString& name, bool saveWindowSize);
 
     [[nodiscard]] FyWidget* root() const;
 

--- a/src/gui/dialog/exportlayoutdialog.cpp
+++ b/src/gui/dialog/exportlayoutdialog.cpp
@@ -106,14 +106,10 @@ QSize ExportLayoutDialog::sizeHint() const
 
 void ExportLayoutDialog::accept()
 {
-    auto layout = m_editableLayout->saveCurrentToLayout(m_nameEdit->text());
+    auto layout = m_editableLayout->saveCurrentToLayout(m_nameEdit->text(), m_saveWindowSize->isChecked());
     if(!layout.isValid()) {
         m_errorLabel->setText(tr("Failed to save the current layout"));
         return;
-    }
-
-    if(m_saveWindowSize->isChecked()) {
-        layout.saveWindowSize();
     }
 
     const auto currentTheme = m_settings->value<Settings::Gui::Theme>().value<FyTheme>();

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -715,10 +715,10 @@ FyLayout EditableLayout::saveCurrentToLayout(const QString& name, bool saveWindo
 
     const auto theme = p->m_settings->value<Settings::Gui::Theme>().value<FyTheme>();
     if(theme.isValid()) {
-        if(saveWindowSize) {
-            layout.saveWindowSize();
-        }
         layout.saveTheme(theme);
+    }
+    if(saveWindowSize) {
+        layout.saveWindowSize();
     }
 
     return layout;

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -688,7 +688,7 @@ void EditableLayout::initialise()
     p->changeLayout(p->m_layoutProvider->currentLayout());
 }
 
-FyLayout EditableLayout::saveCurrentToLayout(const QString& name)
+FyLayout EditableLayout::saveCurrentToLayout(const QString& name, bool saveWindowSize)
 {
     QJsonObject root;
     QJsonArray array;
@@ -715,6 +715,9 @@ FyLayout EditableLayout::saveCurrentToLayout(const QString& name)
 
     const auto theme = p->m_settings->value<Settings::Gui::Theme>().value<FyTheme>();
     if(theme.isValid()) {
+        if(saveWindowSize) {
+            layout.saveWindowSize();
+        }
         layout.saveTheme(theme);
     }
 
@@ -785,7 +788,7 @@ void EditableLayout::saveLayout()
 {
     const auto currentLayout = p->m_layoutProvider->currentLayout();
     const QString layoutName = currentLayout.name().isEmpty() ? u"Default"_s : currentLayout.name();
-    const auto layout        = saveCurrentToLayout(layoutName);
+    const auto layout        = saveCurrentToLayout(layoutName, false);
     if(layout.isValid()) {
         p->m_layoutProvider->changeLayout(layout);
         p->m_layoutProvider->saveCurrentLayout();

--- a/src/gui/layoutcommands.cpp
+++ b/src/gui/layoutcommands.cpp
@@ -60,20 +60,20 @@ bool LayoutChangeCommand::checkContainer()
 SwitchLayoutCommand::SwitchLayoutCommand(EditableLayoutPrivate* editableLayout, FyLayout layout)
     : LayoutChangeCommand{editableLayout->m_self}
     , m_editableLayout{editableLayout}
-    , m_oldLayout{m_layout->saveCurrentToLayout(editableLayout->m_layoutProvider->currentLayout().name())}
+    , m_oldLayout{m_layout->saveCurrentToLayout(editableLayout->m_layoutProvider->currentLayout().name(), true)}
     , m_newLayout{std::move(layout)}
 { }
 
 void SwitchLayoutCommand::undo()
 {
-    m_newLayout = m_layout->saveCurrentToLayout(m_newLayout.name());
+    m_newLayout = m_layout->saveCurrentToLayout(m_newLayout.name(), true);
     m_editableLayout->m_layoutProvider->saveLayout(m_newLayout);
     m_editableLayout->changeLayout(m_oldLayout);
 }
 
 void SwitchLayoutCommand::redo()
 {
-    m_oldLayout = m_layout->saveCurrentToLayout(m_oldLayout.name());
+    m_oldLayout = m_layout->saveCurrentToLayout(m_oldLayout.name(), true);
     m_editableLayout->m_layoutProvider->saveLayout(m_oldLayout);
     m_editableLayout->changeLayout(m_newLayout);
 }


### PR DESCRIPTION
Since #1267, layout switching saves the previous layout. We were already saving colors and fonts, but not the window size. This meant that switching from a layout would lose its window size, even if the user had previously manually saved it via the export dialog.

Fix: Allow `EditableLayout::saveCurrentToLayout()` to save the window size, controlled with an argument.

Note: I've been seeing a bug where switching layouts sometimes causes the current playlist to not be re-rendered/showing up empty (fixed by switching to another playlist and then back). For some reason, applying this patch makes it much rarer. Not sure what the relation is though!