### PR TITLE
[gui] Playlist: Only set font from resolved app style

### DIFF
--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -277,6 +277,8 @@ PlaylistWidget::PlaylistWidget(ActionManager* actionManager, PlaylistInteractor*
     applyInitialViewSettings();
     applyBackgroundSettings();
 
+    refreshViewStyle();
+
     m_model->playingTrackChanged(m_playerController->currentPlaylistTrack());
     m_model->playStateChanged(m_playlistController->playState());
     applySessionTexts();
@@ -1132,14 +1134,15 @@ void PlaylistWidget::applySessionTexts()
 void PlaylistWidget::refreshViewStyle()
 {
     const auto resolvedStyle = m_settings->value<Settings::Gui::ResolvedAppStyle>().value<ResolvedAppStyle>();
+    if(resolvedStyle.revision > 0) {
+        const QFont playlistFont = resolvedStyle.font(u"Fooyin::PlaylistView"_s);
+        m_playlistView->setFont(playlistFont);
+        m_header->setFont(playlistFont);
+        m_model->setFont(playlistFont);
 
-    const QFont playlistFont = resolvedStyle.font(u"Fooyin::PlaylistView"_s);
-    m_playlistView->setFont(playlistFont);
-    m_header->setFont(playlistFont);
-    m_model->setFont(playlistFont);
-
-    Gui::updateItemViewStyle(m_playlistView, resolvedStyle.palette);
-    updateVisibleCoverPins();
+        Gui::updateItemViewStyle(m_playlistView, resolvedStyle.palette);
+        updateVisibleCoverPins();
+    }
 }
 
 void PlaylistWidget::addSortMenu(QMenu* parent, bool disabled)

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -1085,7 +1085,6 @@ void PlaylistWidget::applyInitialViewSettings()
     setHeaderVisible(m_settings->value<PlaylistHeader>());
     setScrollbarVisible(m_settings->value<PlaylistScrollBar>());
     m_playlistView->setAlternatingRowColors(m_settings->value<PlaylistAltColours>());
-    m_model->setFont(QApplication::font("Fooyin::PlaylistView"));
 }
 
 void PlaylistWidget::updateMetadataEditTriggers(bool readOnly)


### PR DESCRIPTION
`PlaylistWidget` currently calls `setFont()` on its model in two places: `applyInitialViewSettings()` and `refreshViewStyle()`. This causes a race where the initial/system font sometimes wins out over a custom Default font (almost always on optimized builds and only on startup). Fix by removing the first call and letting `refreshViewStyle()` handle it.