### PR TITLE
feat: add independent sort field to filter column settings

### DIFF
--- a/src/plugins/filters/filtercolumneditordialog.cpp
+++ b/src/plugins/filters/filtercolumneditordialog.cpp
@@ -64,8 +64,9 @@ FilterColumnEditorWidget::FilterColumnEditorWidget(FilterColumnRegistry* columnR
     m_columnList->hideColumn(0);
     m_columnList->setExtendableColumn(1);
     m_columnList->verticalHeader()->hide();
-    m_columnList->horizontalHeader()->setStretchLastSection(true);
+    m_columnList->horizontalHeader()->setStretchLastSection(false);
     m_columnList->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_columnList->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
 
     m_openEditor->setText(tr("Script Editor"));
     m_columnList->addCustomTool(m_openEditor);
@@ -79,7 +80,7 @@ FilterColumnEditorWidget::FilterColumnEditorWidget(FilterColumnRegistry* columnR
     QObject::connect(m_openEditor, &QToolButton::clicked, this, [this]() {
         const auto selection    = m_columnList->selectionModel()->selectedIndexes();
         const QModelIndex index = selection.front();
-        ScriptEditor::openEditor(index.data().toString(), [this, index](const QString& script) {
+        ScriptEditor::openEditor(index.data(Qt::EditRole).toString(), [this, index](const QString& script) {
             m_model->setData(index, script, Qt::EditRole);
         });
     });
@@ -115,7 +116,8 @@ void FilterColumnEditorWidget::updateButtonState()
         selection, [](const QModelIndex& index) { return !index.data(Qt::UserRole).value<FilterColumn>().isDefault; });
 
     m_columnList->removeRowAction()->setEnabled(hasCustom);
-    m_openEditor->setEnabled(selection.size() == 1 && selection.front().column() == 2);
+    m_openEditor->setEnabled(selection.size() == 1
+                             && (selection.front().column() == 2 || selection.front().column() == 3));
 }
 
 FilterColumnEditorDialog::FilterColumnEditorDialog(FilterColumnRegistry* columnRegistry, QWidget* parent)

--- a/src/plugins/filters/filtercolumnregistry.cpp
+++ b/src/plugins/filters/filtercolumnregistry.cpp
@@ -36,11 +36,11 @@ FilterColumnRegistry::FilterColumnRegistry(SettingsManager* settings, QObject* p
 
 void FilterColumnRegistry::loadDefaults()
 {
-    addDefaultItem({.id = 0, .name = tr("Genre"), .field = u"%<genre>%"_s});
-    addDefaultItem({.id = 1, .name = tr("Album Artist"), .field = u"%<albumartist>%"_s});
-    addDefaultItem({.id = 2, .name = tr("Artist"), .field = u"%<artist>%"_s});
-    addDefaultItem({.id = 3, .name = tr("Album"), .field = u"%album%"_s});
-    addDefaultItem({.id = 4, .name = tr("Date"), .field = u"%date%"_s});
+    addDefaultItem({.id = 0, .name = tr("Genre"), .field = u"%<genre>%"_s, .sortField = {}});
+    addDefaultItem({.id = 1, .name = tr("Album Artist"), .field = u"%<albumartist>%"_s, .sortField = {}});
+    addDefaultItem({.id = 2, .name = tr("Artist"), .field = u"%<artist>%"_s, .sortField = {}});
+    addDefaultItem({.id = 3, .name = tr("Album"), .field = u"%album%"_s, .sortField = {}});
+    addDefaultItem({.id = 4, .name = tr("Date"), .field = u"%date%"_s, .sortField = {}});
 }
 } // namespace Fooyin::Filters
 

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -22,8 +22,6 @@
 #include <QDataStream>
 #include <QString>
 
-#include <tuple>
-
 namespace Fooyin::Filters {
 struct FilterColumn
 {
@@ -37,11 +35,7 @@ struct FilterColumn
     QString field;
     QString sortField;
 
-    bool operator==(const FilterColumn& other) const
-    {
-        return std::tie(id, index, name, field, sortField)
-            == std::tie(other.id, other.index, other.name, other.field, other.sortField);
-    }
+    bool operator==(const FilterColumn& other) const = default;
 
     [[nodiscard]] bool isValid() const
     {
@@ -73,11 +67,9 @@ struct FilterColumn
             stream >> column.index;
             stream >> column.name;
             stream >> column.field;
+
             if(version >= 2) {
                 stream >> column.sortField;
-            }
-            else {
-                column.sortField.clear();
             }
         }
         else {
@@ -85,7 +77,6 @@ struct FilterColumn
             stream >> column.index;
             stream >> column.name;
             stream >> column.field;
-            column.sortField.clear();
         }
 
         return stream;

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -22,18 +22,25 @@
 #include <QDataStream>
 #include <QString>
 
+#include <tuple>
+
 namespace Fooyin::Filters {
 struct FilterColumn
 {
+    static constexpr qint32 Magic   = -0x46434F4C;
+    static constexpr qint32 Version = 2;
+
     int id{-1};
     int index{-1};
     bool isDefault{false};
     QString name;
     QString field;
+    QString sortField;
 
     bool operator==(const FilterColumn& other) const
     {
-        return std::tie(id, index, name, field) == std::tie(other.id, other.index, other.name, other.field);
+        return std::tie(id, index, name, field, sortField)
+            == std::tie(other.id, other.index, other.name, other.field, other.sortField);
     }
 
     [[nodiscard]] bool isValid() const
@@ -43,19 +50,44 @@ struct FilterColumn
 
     friend QDataStream& operator<<(QDataStream& stream, const FilterColumn& column)
     {
+        stream << Magic;
+        stream << Version;
         stream << column.id;
         stream << column.index;
         stream << column.name;
         stream << column.field;
+        stream << column.sortField;
         return stream;
     }
 
     friend QDataStream& operator>>(QDataStream& stream, FilterColumn& column)
     {
-        stream >> column.id;
-        stream >> column.index;
-        stream >> column.name;
-        stream >> column.field;
+        qint32 magicOrId{-1};
+        stream >> magicOrId;
+
+        if(magicOrId == Magic) {
+            qint32 version{0};
+            stream >> version;
+
+            stream >> column.id;
+            stream >> column.index;
+            stream >> column.name;
+            stream >> column.field;
+            if(version >= 2) {
+                stream >> column.sortField;
+            }
+            else {
+                column.sortField.clear();
+            }
+        }
+        else {
+            column.id = magicOrId;
+            stream >> column.index;
+            stream >> column.name;
+            stream >> column.field;
+            column.sortField.clear();
+        }
+
         return stream;
     }
 };

--- a/src/plugins/filters/filteritem.cpp
+++ b/src/plugins/filters/filteritem.cpp
@@ -214,31 +214,14 @@ void FilterItem::setColumns(const QStringList& columns)
     invalidateIconCaches();
 }
 
+void FilterItem::setSortColumns(const QStringList& columns)
+{
+    m_sortColumns = columns.isEmpty() ? m_columns : columns;
+}
+
 void FilterItem::setRichColumns(const std::vector<RichText>& columns)
 {
-    const auto columnCount = static_cast<int>(m_columns.size());
-
-    if(std::cmp_greater(columns.size(), columnCount)) {
-        m_richColumns.assign(columns.cbegin(), columns.cbegin() + columnCount);
-
-        m_sortColumns.clear();
-        m_sortColumns.reserve(columnCount);
-
-        const int sortColumnCount = static_cast<int>(columns.size()) - columnCount;
-        for(int column{0}; column < columnCount; ++column) {
-            if(column < sortColumnCount) {
-                m_sortColumns.push_back(columns.at(columnCount + column).joinedText());
-            }
-            else {
-                m_sortColumns.push_back(m_columns.at(column));
-            }
-        }
-    }
-    else {
-        m_richColumns = columns;
-        m_sortColumns = m_columns;
-    }
-
+    m_richColumns = columns;
     invalidateIconCaches();
 }
 

--- a/src/plugins/filters/filteritem.cpp
+++ b/src/plugins/filters/filteritem.cpp
@@ -73,6 +73,7 @@ FilterItem::FilterItem(Md5Hash key, QStringList columns, FilterItem* parent)
     : TreeItem{parent}
     , m_key{std::move(key)}
     , m_columns{std::move(columns)}
+    , m_sortColumns{m_columns}
     , m_isSummary{false}
 {
     m_richColumns = plainColumnsToRichText(m_columns);
@@ -94,6 +95,14 @@ QString FilterItem::column(int column) const
         return {};
     }
     return m_columns.at(column);
+}
+
+QString FilterItem::sortColumn(int column) const
+{
+    if(column < 0 || column >= m_sortColumns.size()) {
+        return this->column(column);
+    }
+    return m_sortColumns.at(column);
 }
 
 const RichText& FilterItem::richColumn(int column) const
@@ -200,13 +209,36 @@ void FilterItem::updateIconCaptionColumns(const std::vector<int>& columnOrder) c
 void FilterItem::setColumns(const QStringList& columns)
 {
     m_columns     = columns;
+    m_sortColumns = m_columns;
     m_richColumns = plainColumnsToRichText(m_columns);
     invalidateIconCaches();
 }
 
 void FilterItem::setRichColumns(const std::vector<RichText>& columns)
 {
-    m_richColumns = columns;
+    const auto columnCount = static_cast<int>(m_columns.size());
+
+    if(std::cmp_greater(columns.size(), columnCount)) {
+        m_richColumns.assign(columns.cbegin(), columns.cbegin() + columnCount);
+
+        m_sortColumns.clear();
+        m_sortColumns.reserve(columnCount);
+
+        const int sortColumnCount = static_cast<int>(columns.size()) - columnCount;
+        for(int column{0}; column < columnCount; ++column) {
+            if(column < sortColumnCount) {
+                m_sortColumns.push_back(columns.at(columnCount + column).joinedText());
+            }
+            else {
+                m_sortColumns.push_back(m_columns.at(column));
+            }
+        }
+    }
+    else {
+        m_richColumns = columns;
+        m_sortColumns = m_columns;
+    }
+
     invalidateIconCaches();
 }
 
@@ -218,6 +250,7 @@ void FilterItem::setTrackIds(const TrackIds& trackIds)
 void FilterItem::removeColumn(int column)
 {
     m_columns.remove(column);
+    m_sortColumns.remove(column);
 
     if(column >= 0 && std::cmp_less(column, m_richColumns.size())) {
         m_richColumns.erase(m_richColumns.begin() + column);

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -69,6 +69,7 @@ public:
 
     [[nodiscard]] const QStringList& columns() const;
     [[nodiscard]] QString column(int column) const;
+    [[nodiscard]] QString sortColumn(int column) const;
     [[nodiscard]] const RichText& richColumn(int column) const;
     [[nodiscard]] QString iconLabel(const std::vector<int>& columnOrder) const;
     [[nodiscard]] IconCaptionLineList iconCaptionLines(const std::vector<int>& columnOrder,
@@ -97,6 +98,7 @@ private:
 
     Md5Hash m_key;
     QStringList m_columns;
+    QStringList m_sortColumns;
     std::vector<RichText> m_richColumns;
     TrackIds m_trackIds;
     bool m_isSummary;

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -80,6 +80,7 @@ public:
     [[nodiscard]] int firstTrackId() const;
 
     void setColumns(const QStringList& columns);
+    void setSortColumns(const QStringList& columns);
     void setRichColumns(const std::vector<RichText>& columns);
     void setTrackIds(const TrackIds& trackIds);
     void removeColumn(int column);

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -35,6 +35,7 @@
 #include <QMimeData>
 #include <QSize>
 
+#include <algorithm>
 #include <set>
 #include <utility>
 
@@ -86,14 +87,41 @@ bool rowMatchesItem(const Fooyin::Filters::FilterRow& row, const Fooyin::Filters
         return false;
     }
 
+    const int columnCount = item.columns().size();
     std::vector<Fooyin::RichText> richColumns;
-    richColumns.reserve(item.columns().size());
+    richColumns.reserve(columnCount);
 
-    for(int column = 0; column < item.columns().size(); ++column) {
+    for(int column = 0; column < columnCount; ++column) {
         richColumns.push_back(item.richColumn(column));
     }
 
-    return row.richColumns == richColumns;
+    const auto richColumnCount = std::cmp_greater(row.richColumns.size(), columnCount)
+                                   ? columnCount
+                                   : static_cast<int>(row.richColumns.size());
+    if(!std::ranges::equal(row.richColumns.cbegin(), row.richColumns.cbegin() + richColumnCount, richColumns.cbegin(),
+                           richColumns.cbegin() + richColumnCount)) {
+        return false;
+    }
+
+    if(richColumnCount != static_cast<int>(richColumns.size())) {
+        return false;
+    }
+
+    if(!std::cmp_greater(row.richColumns.size(), columnCount)) {
+        return true;
+    }
+
+    if(row.richColumns.size() != richColumns.size() + static_cast<size_t>(columnCount)) {
+        return false;
+    }
+
+    for(int column{0}; column < columnCount; ++column) {
+        if(row.richColumns.at(columnCount + column).joinedText() != item.sortColumn(column)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 } // namespace
 
@@ -118,7 +146,7 @@ bool FilterSortModel::lessThan(const QModelIndex& left, const QModelIndex& right
         return sortOrder() != Qt::AscendingOrder;
     }
 
-    const auto cmp = m_collator.compare(leftItem->column(left.column()), rightItem->column(right.column()));
+    const auto cmp = m_collator.compare(leftItem->sortColumn(left.column()), rightItem->sortColumn(right.column()));
 
     if(cmp == 0) {
         return false;

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -87,36 +87,24 @@ bool rowMatchesItem(const Fooyin::Filters::FilterRow& row, const Fooyin::Filters
         return false;
     }
 
-    const int columnCount = item.columns().size();
     std::vector<Fooyin::RichText> richColumns;
-    richColumns.reserve(columnCount);
+    richColumns.reserve(item.columns().size());
 
-    for(int column = 0; column < columnCount; ++column) {
+    for(int column{0}; std::cmp_less(column, item.columns().size()); ++column) {
         richColumns.push_back(item.richColumn(column));
     }
 
-    const auto richColumnCount = std::cmp_greater(row.richColumns.size(), columnCount)
-                                   ? columnCount
-                                   : static_cast<int>(row.richColumns.size());
-    if(!std::ranges::equal(row.richColumns.cbegin(), row.richColumns.cbegin() + richColumnCount, richColumns.cbegin(),
-                           richColumns.cbegin() + richColumnCount)) {
+    if(row.richColumns != richColumns) {
         return false;
     }
 
-    if(richColumnCount != static_cast<int>(richColumns.size())) {
+    const QStringList sortColumns = row.sortColumns.empty() ? row.columns : row.sortColumns;
+    if(sortColumns.size() != item.columns().size()) {
         return false;
     }
 
-    if(!std::cmp_greater(row.richColumns.size(), columnCount)) {
-        return true;
-    }
-
-    if(row.richColumns.size() != richColumns.size() + static_cast<size_t>(columnCount)) {
-        return false;
-    }
-
-    for(int column{0}; column < columnCount; ++column) {
-        if(row.richColumns.at(columnCount + column).joinedText() != item.sortColumn(column)) {
+    for(int column{0}; std::cmp_less(column, sortColumns.size()); ++column) {
+        if(sortColumns.at(column) != item.sortColumn(column)) {
             return false;
         }
     }
@@ -676,6 +664,7 @@ void FilterModel::setRows(const FilterColumnList& columns, const FilterRowList& 
             auto [it, _] = p->m_nodes.emplace(row.key, FilterItem{row.key, row.columns, parent});
             auto& item   = it->second;
 
+            item.setSortColumns(row.sortColumns);
             item.setRichColumns(row.richColumns);
             item.setTrackIds(row.trackIds);
             parent->appendChild(&item);
@@ -725,6 +714,7 @@ void FilterModel::setRows(const FilterColumnList& columns, const FilterRowList& 
         beginInsertRows({}, rowOffset + rowIndex, rowOffset + rowIndex);
         auto [it, _]  = p->m_nodes.emplace(row.key, FilterItem{row.key, row.columns, parent});
         auto& newItem = it->second;
+        newItem.setSortColumns(row.sortColumns);
         newItem.setRichColumns(row.richColumns);
         newItem.setTrackIds(row.trackIds);
         parent->insertChild(rowOffset + rowIndex, &newItem);
@@ -747,6 +737,7 @@ void FilterModel::setRows(const FilterColumnList& columns, const FilterRowList& 
         }
 
         item->setColumns(row.columns);
+        item->setSortColumns(row.sortColumns);
         item->setRichColumns(row.richColumns);
         item->setTrackIds(row.trackIds);
 

--- a/src/plugins/filters/filterrows.cpp
+++ b/src/plugins/filters/filterrows.cpp
@@ -26,6 +26,7 @@
 #include <gui/scripting/scriptformatter.h>
 #include <utils/crypto.h>
 
+#include <algorithm>
 #include <map>
 #include <ranges>
 #include <unordered_map>
@@ -41,6 +42,15 @@ struct ColumnData
     QStringList plainColumns;
     std::vector<RichText> richColumns;
 };
+
+RichText sortRichText(const QString& text)
+{
+    RichText richText;
+    if(!text.isEmpty()) {
+        richText.blocks.push_back({.text = text, .format = {}});
+    }
+    return richText;
+}
 
 RichText placeholderRichText()
 {
@@ -76,6 +86,29 @@ ColumnData buildColumnData(const QStringList& columns, ScriptFormatter& formatte
 
     return data;
 }
+
+QString sortColumnText(const QString& column, ScriptFormatter& formatter)
+{
+    return trimRichText(formatter.evaluate(column)).joinedText();
+}
+
+std::vector<QStringList> splitColumnValues(const QString& evaluated)
+{
+    std::vector<QStringList> values;
+
+    if(evaluated.contains(QLatin1String{Constants::UnitSeparator})) {
+        const QStringList rows = evaluated.split(QLatin1String{Constants::UnitSeparator});
+        values.reserve(rows.size());
+        for(const QString& row : rows) {
+            values.push_back(row.split(QLatin1String{Constants::RecordSeparator}));
+        }
+    }
+    else {
+        values.push_back(evaluated.split(QLatin1String{Constants::RecordSeparator}));
+    }
+
+    return values;
+}
 } // namespace
 
 FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumnList& columns, const TrackList& tracks,
@@ -91,6 +124,17 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
     std::ranges::transform(columns, std::back_inserter(fields),
                            [](const FilterColumn& column) { return column.field; });
 
+    const bool hasCustomSortField
+        = std::ranges::any_of(columns, [](const FilterColumn& column) { return !column.sortField.isEmpty(); });
+
+    QStringList sortFields;
+    if(hasCustomSortField) {
+        sortFields.reserve(columns.size());
+        std::ranges::transform(columns, std::back_inserter(sortFields), [](const FilterColumn& column) {
+            return column.sortField.isEmpty() ? column.field : column.sortField;
+        });
+    }
+
     ScriptParser parser;
     ScriptFormatter formatter;
     formatter.setBaseFont(context.font);
@@ -104,15 +148,23 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
     scriptContext.environment = &scriptEnvironment;
 
     std::map<RowKey, FilterRow> items;
+    const ParsedScript sortScript = hasCustomSortField ? parser.parse(sortFields.join("\036"_L1)) : ParsedScript{};
 
     for(const Track& track : tracks) {
         if(!track.isInLibrary()) {
             continue;
         }
 
-        const QString evaluated = parser.evaluate(script, track, scriptContext);
+        const QString evaluated                     = parser.evaluate(script, track, scriptContext);
+        const std::vector<QStringList> columnValues = splitColumnValues(evaluated);
 
-        auto addColumns = [&items, &formatter, &track](const QStringList& columnValues) {
+        std::vector<QStringList> sortValues;
+        if(hasCustomSortField) {
+            sortValues = splitColumnValues(parser.evaluate(sortScript, track, scriptContext));
+        }
+
+        auto addColumns = [&columns, &hasCustomSortField, &items, &formatter,
+                           &track](const QStringList& columnValues, const QStringList& sortColumnValues) {
             const ColumnData columnData = buildColumnData(columnValues, formatter);
             const RowKey key            = Utils::generateMd5Hash(columnData.plainColumns.join(QString{}));
 
@@ -123,19 +175,29 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
                 row.key         = key;
                 row.columns     = columnData.plainColumns;
                 row.richColumns = columnData.richColumns;
+
+                if(hasCustomSortField) {
+                    for(int column{0}; column < columnData.plainColumns.size(); ++column) {
+                        if(std::cmp_greater_equal(column, columns.size()) || columns.at(column).sortField.isEmpty()) {
+                            row.richColumns.push_back(sortRichText(columnData.plainColumns.value(column)));
+                        }
+                        else {
+                            row.richColumns.push_back(
+                                sortRichText(sortColumnText(sortColumnValues.value(column), formatter)));
+                        }
+                    }
+                }
             }
 
             row.trackIds.push_back(track.id());
         };
 
-        if(evaluated.contains(QLatin1String{Constants::UnitSeparator})) {
-            const QStringList values = evaluated.split(QLatin1String{Constants::UnitSeparator});
-            for(const QString& value : values) {
-                addColumns(value.split(QLatin1String{Constants::RecordSeparator}));
+        for(int index{0}; std::cmp_less(index, columnValues.size()); ++index) {
+            QStringList rowSortValues;
+            if(hasCustomSortField && !sortValues.empty()) {
+                rowSortValues = sortValues.at(std::min(index, static_cast<int>(sortValues.size()) - 1));
             }
-        }
-        else {
-            addColumns(evaluated.split(QLatin1String{Constants::RecordSeparator}));
+            addColumns(columnValues.at(index), rowSortValues);
         }
     }
 

--- a/src/plugins/filters/filterrows.cpp
+++ b/src/plugins/filters/filterrows.cpp
@@ -43,15 +43,6 @@ struct ColumnData
     std::vector<RichText> richColumns;
 };
 
-RichText sortRichText(const QString& text)
-{
-    RichText richText;
-    if(!text.isEmpty()) {
-        richText.blocks.push_back({.text = text, .format = {}});
-    }
-    return richText;
-}
-
 RichText placeholderRichText()
 {
     RichText richText;
@@ -120,7 +111,8 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
     }
 
     QStringList fields;
-    fields.reserve(columns.size());
+    fields.reserve(static_cast<qsizetype>(columns.size()));
+
     std::ranges::transform(columns, std::back_inserter(fields),
                            [](const FilterColumn& column) { return column.field; });
 
@@ -128,8 +120,9 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
         = std::ranges::any_of(columns, [](const FilterColumn& column) { return !column.sortField.isEmpty(); });
 
     QStringList sortFields;
+
     if(hasCustomSortField) {
-        sortFields.reserve(columns.size());
+        sortFields.reserve(static_cast<qsizetype>(columns.size()));
         std::ranges::transform(columns, std::back_inserter(sortFields), [](const FilterColumn& column) {
             return column.sortField.isEmpty() ? column.field : column.sortField;
         });
@@ -143,12 +136,14 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
     scriptEnvironment.setRatingStarSymbols(context.ratingSymbols);
     scriptEnvironment.setEvaluationPolicy(TrackListContextPolicy::Unresolved, {}, false, context.useVarious);
 
-    const ParsedScript script = parser.parse(fields.join("\036"_L1));
+    const ParsedScript script = parser.parse(fields.join(QLatin1StringView{Constants::RecordSeparator}));
     ScriptContext scriptContext;
     scriptContext.environment = &scriptEnvironment;
 
     std::map<RowKey, FilterRow> items;
-    const ParsedScript sortScript = hasCustomSortField ? parser.parse(sortFields.join("\036"_L1)) : ParsedScript{};
+    const ParsedScript sortScript = hasCustomSortField
+                                      ? parser.parse(sortFields.join(QLatin1StringView{Constants::RecordSeparator}))
+                                      : ParsedScript{};
 
     for(const Track& track : tracks) {
         if(!track.isInLibrary()) {
@@ -164,8 +159,8 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
         }
 
         auto addColumns = [&columns, &hasCustomSortField, &items, &formatter,
-                           &track](const QStringList& columnValues, const QStringList& sortColumnValues) {
-            const ColumnData columnData = buildColumnData(columnValues, formatter);
+                           &track](const QStringList& rowColumnValues, const QStringList& sortColumnValues) {
+            const ColumnData columnData = buildColumnData(rowColumnValues, formatter);
             const RowKey key            = Utils::generateMd5Hash(columnData.plainColumns.join(QString{}));
 
             auto [it, inserted] = items.try_emplace(key);
@@ -177,13 +172,15 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
                 row.richColumns = columnData.richColumns;
 
                 if(hasCustomSortField) {
+                    const bool pairSortColumns = sortColumnValues.size() == rowColumnValues.size();
+                    row.sortColumns.reserve(columnData.plainColumns.size());
                     for(int column{0}; column < columnData.plainColumns.size(); ++column) {
-                        if(std::cmp_greater_equal(column, columns.size()) || columns.at(column).sortField.isEmpty()) {
-                            row.richColumns.push_back(sortRichText(columnData.plainColumns.value(column)));
+                        if(!pairSortColumns || std::cmp_greater_equal(column, columns.size())
+                           || columns.at(column).sortField.isEmpty()) {
+                            row.sortColumns.push_back(columnData.plainColumns.value(column));
                         }
                         else {
-                            row.richColumns.push_back(
-                                sortRichText(sortColumnText(sortColumnValues.value(column), formatter)));
+                            row.sortColumns.push_back(sortColumnText(sortColumnValues.value(column), formatter));
                         }
                     }
                 }
@@ -192,10 +189,11 @@ FilterRowList buildFilterRows(LibraryManager* libraryManager, const FilterColumn
             row.trackIds.push_back(track.id());
         };
 
+        const bool pairSortRows = hasCustomSortField && columnValues.size() == sortValues.size();
         for(int index{0}; std::cmp_less(index, columnValues.size()); ++index) {
             QStringList rowSortValues;
-            if(hasCustomSortField && !sortValues.empty()) {
-                rowSortValues = sortValues.at(std::min(index, static_cast<int>(sortValues.size()) - 1));
+            if(pairSortRows) {
+                rowSortValues = sortValues.at(index);
             }
             addColumns(columnValues.at(index), rowSortValues);
         }
@@ -224,6 +222,12 @@ FilterRowList patchFilterRows(LibraryManager* libraryManager, const FilterColumn
 
     if(changedTrackIds.empty() && previousTracks == tracks) {
         return previousRows;
+    }
+
+    const bool hasCustomSortField
+        = std::ranges::any_of(columns, [](const FilterColumn& column) { return !column.sortField.isEmpty(); });
+    if(hasCustomSortField) {
+        return buildFilterRows(libraryManager, columns, tracks, context);
     }
 
     std::unordered_map<int, Track> previousTracksById;
@@ -288,6 +292,7 @@ FilterRowList patchFilterRows(LibraryManager* libraryManager, const FilterColumn
         auto [it, inserted] = patchedRows.try_emplace(row.key, row);
         if(!inserted) {
             it->second.columns     = row.columns;
+            it->second.sortColumns = row.sortColumns;
             it->second.richColumns = row.richColumns;
             std::ranges::copy(row.trackIds, std::back_inserter(it->second.trackIds));
         }

--- a/src/plugins/filters/filterrows.h
+++ b/src/plugins/filters/filterrows.h
@@ -38,6 +38,7 @@ struct FilterRow
 {
     RowKey key;
     QStringList columns;
+    QStringList sortColumns;
     std::vector<RichText> richColumns;
     TrackIds trackIds;
 };

--- a/src/plugins/filters/filterscolumnmodel.cpp
+++ b/src/plugins/filters/filterscolumnmodel.cpp
@@ -21,7 +21,9 @@
 
 #include "filtercolumnregistry.h"
 
+#include <QApplication>
 #include <QFont>
+#include <QPalette>
 
 using namespace Qt::StringLiterals;
 
@@ -80,7 +82,7 @@ void FiltersColumnModel::processQueue()
         const FilterColumn column           = node.column();
 
         switch(status) {
-            case(ColumnItem::Added): {
+            case ColumnItem::Added: {
                 if(column.field.isEmpty()) {
                     break;
                 }
@@ -95,7 +97,7 @@ void FiltersColumnModel::processQueue()
                 }
                 break;
             }
-            case(ColumnItem::Removed): {
+            case ColumnItem::Removed: {
                 if(m_columnsRegistry->removeById(column.id)) {
                     beginRemoveRows({}, node.row(), node.row());
                     m_root.removeChild(node.row());
@@ -107,7 +109,7 @@ void FiltersColumnModel::processQueue()
                 }
                 break;
             }
-            case(ColumnItem::Changed): {
+            case ColumnItem::Changed: {
                 if(m_columnsRegistry->changeItem(column)) {
                     if(const auto item = m_columnsRegistry->itemById(column.id)) {
                         node.changeColumn(item.value());
@@ -119,7 +121,7 @@ void FiltersColumnModel::processQueue()
                 }
                 break;
             }
-            case(ColumnItem::None):
+            case ColumnItem::None:
                 break;
         }
     }
@@ -182,20 +184,45 @@ QVariant FiltersColumnModel::data(const QModelIndex& index, int role) const
         return QVariant::fromValue(item->column());
     }
 
-    if(role == Qt::DisplayRole || role == Qt::EditRole) {
+    const FilterColumn& columnData = item->column();
+
+    if(role == Qt::ForegroundRole && index.column() == 3 && columnData.sortField.isEmpty()) {
+        return QApplication::palette().color(QPalette::PlaceholderText);
+    }
+
+    if(role == Qt::EditRole) {
         switch(index.column()) {
-            case(0):
-                return item->column().index;
-            case(1): {
-                const QString& name = item->column().name;
+            case 0:
+                return columnData.index;
+            case 1: {
+                return columnData.name;
+            }
+            case 2: {
+                return columnData.field;
+            }
+            case 3:
+                return columnData.sortField;
+            default:
+                break;
+        }
+    }
+
+    if(role == Qt::DisplayRole) {
+        switch(index.column()) {
+            case 0:
+                return columnData.index;
+            case 1: {
+                const QString& name = columnData.name;
                 return !name.isEmpty() ? name : u"<enter name here>"_s;
             }
-            case(2): {
-                const QString& field = item->column().field;
+            case 2: {
+                const QString& field = columnData.field;
                 return !field.isEmpty() ? field : u"<enter field here>"_s;
             }
-            case(3):
-                return item->column().sortField;
+            case 3: {
+                const QString& sortField = columnData.sortField;
+                return !sortField.isEmpty() ? sortField : tr("Use display script");
+            }
             default:
                 break;
         }

--- a/src/plugins/filters/filterscolumnmodel.cpp
+++ b/src/plugins/filters/filterscolumnmodel.cpp
@@ -153,14 +153,14 @@ QVariant FiltersColumnModel::headerData(int section, Qt::Orientation orientation
     }
 
     switch(section) {
-        case(0):
+        case 0:
             return tr("Index");
-        case(1):
+        case 1:
             return tr("Name");
-        case(2):
-            return tr("Field");
-        case(3):
-            return tr("Sort Field");
+        case 2:
+            return tr("Display Script");
+        case 3:
+            return tr("Sort Script");
         default:
             break;
     }
@@ -241,7 +241,7 @@ bool FiltersColumnModel::setData(const QModelIndex& index, const QVariant& value
     FilterColumn column = item->column();
 
     switch(index.column()) {
-        case(1): {
+        case 1: {
             if(value.toString() == u"<enter name here>"_s || column.name == value.toString()) {
                 if(item->status() == ColumnItem::Added) {
                     Q_EMIT pendingRowCancelled();
@@ -251,14 +251,14 @@ bool FiltersColumnModel::setData(const QModelIndex& index, const QVariant& value
             column.name = value.toString();
             break;
         }
-        case(2): {
+        case 2: {
             if(column.field == value.toString()) {
                 return false;
             }
             column.field = value.toString();
             break;
         }
-        case(3): {
+        case 3: {
             if(column.sortField == value.toString()) {
                 return false;
             }
@@ -285,7 +285,7 @@ QModelIndex FiltersColumnModel::index(int row, int column, const QModelIndex& pa
         return {};
     }
 
-    ColumnItem* item = m_root.child(row);
+    const ColumnItem* item = m_root.child(row);
 
     return createIndex(row, column, item);
 }

--- a/src/plugins/filters/filterscolumnmodel.cpp
+++ b/src/plugins/filters/filterscolumnmodel.cpp
@@ -157,6 +157,8 @@ QVariant FiltersColumnModel::headerData(int section, Qt::Orientation orientation
             return tr("Name");
         case(2):
             return tr("Field");
+        case(3):
+            return tr("Sort Field");
         default:
             break;
     }
@@ -192,6 +194,8 @@ QVariant FiltersColumnModel::data(const QModelIndex& index, int role) const
                 const QString& field = item->column().field;
                 return !field.isEmpty() ? field : u"<enter field here>"_s;
             }
+            case(3):
+                return item->column().sortField;
             default:
                 break;
         }
@@ -227,6 +231,13 @@ bool FiltersColumnModel::setData(const QModelIndex& index, const QVariant& value
             column.field = value.toString();
             break;
         }
+        case(3): {
+            if(column.sortField == value.toString()) {
+                return false;
+            }
+            column.sortField = value.toString();
+            break;
+        }
         default:
             break;
     }
@@ -259,7 +270,7 @@ int FiltersColumnModel::rowCount(const QModelIndex& /*parent*/) const
 
 int FiltersColumnModel::columnCount(const QModelIndex& /*parent*/) const
 {
-    return 3;
+    return 4;
 }
 
 bool FiltersColumnModel::removeRows(int row, int count, const QModelIndex& /*parent*/)

--- a/tests/plugins/filters/filterpipelinetest.cpp
+++ b/tests/plugins/filters/filterpipelinetest.cpp
@@ -185,7 +185,9 @@ TEST(FilterPipelineTest, PatchFilterRowsMovesUpdatedTrackBetweenBucketsAndPrunes
         return track;
     }();
 
-    const Filters::FilterColumnList columns{{.id = 0, .name = u"Genre"_s, .field = u"%<genre>%"_s}};
+    const Filters::FilterColumnList columns{
+        {.id = 0, .name = u"Genre"_s, .field = u"%<genre>%"_s, .sortField = {}},
+    };
     const Filters::FilterRowBuildContext context{
         .font          = {},
         .ratingSymbols = {u"*"_s, u"/"_s, u"-"_s},
@@ -220,7 +222,9 @@ TEST(FilterPipelineTest, PatchFilterRowsAddsNewTrackIntoExistingBucketInCurrentO
         return track;
     }();
 
-    const Filters::FilterColumnList columns{{.id = 0, .name = u"Genre"_s, .field = u"%<genre>%"_s}};
+    const Filters::FilterColumnList columns{
+        {.id = 0, .name = u"Genre"_s, .field = u"%<genre>%"_s, .sortField = {}},
+    };
     const Filters::FilterRowBuildContext context{
         .font          = {},
         .ratingSymbols = {u"*"_s, u"/"_s, u"-"_s},


### PR DESCRIPTION
## Summary

Filter columns get an optional sort field, so rows can be sorted by a script independent of the displayed text. The motivating case from #1279: show only `%year%` but sort albums from the same year by `%date% - %album%`. When the sort field is empty, sorting falls back to the displayed `field`, so existing filters are unchanged.

## Why this matters

@ludouzi confirmed the hidden-sort-column workaround works but agreed a dedicated sort field is cleaner, and the reporter noted the workaround re-sorts randomly when switching artists. The new field is wired through the same paths the displayed columns use, so it persists and round-trips like the rest of the column config.

## Changes

- `FilterColumn` gains a `sortField` QString with `operator==` and `QDataStream` read/write updated; an empty default keeps backward compatibility with existing saved layouts.
- `filterrows.cpp` evaluates `sortField` (falling back to `field`) into a per-column sort string on the `FilterItem`, and `FilterSortModel::lessThan` compares those sort strings instead of the displayed text.
- The column editor (`filterscolumnmodel`) exposes the sort script as an editable column in settings.

## Testing

Built locally; verified the sort field persists across restart, falls back to the displayed field when empty, and re-sorts correctly when switching the active filter selection.

Fixes #1279
