### PR TITLE
[core,gui,scrobbler] Introduce dual playback threshold

### DIFF
--- a/include/core/coresettings.h
+++ b/include/core/coresettings.h
@@ -92,6 +92,7 @@ enum CoreSettings : uint32_t
     OpenFileAddDirectory          = 41 | Type::Bool,
     AddFoldersIgnorePlaylists     = 42 | Type::Bool,
     PlaylistPreventDuplicates     = 43 | Type::Bool,
+    PlayedThresholdTime           = 44 | Type::Int,
 };
 Q_ENUM_NS(CoreSettings)
 } // namespace Settings::Core

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -85,6 +85,7 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
     m_settings->createSetting<SaveRatingToMetadata>(false, u"Library/SaveRatingToFile"_s);
     m_settings->createSetting<SavePlaycountToMetadata>(false, u"Library/SavePlaycountToFile"_s);
     m_settings->createSetting<PlayedThreshold>(0.5, u"Playback/PlayedThreshold"_s);
+    m_settings->createSetting<PlayedThresholdTime>(240000, u"Playback/PlayedThresholdTime"_s);
     m_settings->createSetting<ExternalSortScript>(u"%filepath%"_s, u"Library/ExternalSortScript"_s);
     m_settings->createSetting<LibraryViewPlaylistSortScript>(QString{}, u"Library/LibraryViewPlaylistSortScript"_s);
     m_settings->createTempSetting<Shutdown>(false);

--- a/src/core/playback/playbackprogresstracker.cpp
+++ b/src/core/playback/playbackprogresstracker.cpp
@@ -19,6 +19,7 @@
 
 #include "playbackprogresstracker.h"
 
+#include <algorithm>
 #include <utility>
 
 namespace Fooyin {
@@ -48,7 +49,8 @@ void PlaybackProgressTracker::reset()
     m_counted               = false;
 }
 
-void PlaybackProgressTracker::onTrackCommitted(uint64_t totalDurationMs, double playedThresholdFraction)
+void PlaybackProgressTracker::onTrackCommitted(uint64_t totalDurationMs, double playedThresholdFraction,
+                                               uint64_t playedThresholdTimeMs)
 {
     m_totalDuration   = totalDurationMs;
     m_position        = 0;
@@ -59,7 +61,9 @@ void PlaybackProgressTracker::onTrackCommitted(uint64_t totalDurationMs, double 
     m_counted         = false;
 
     if(m_totalDuration > 200) {
-        m_playedThreshold = static_cast<uint64_t>(static_cast<double>(m_totalDuration - 200) * playedThresholdFraction);
+        const auto playedThresholdFractionMs
+            = static_cast<uint64_t>(static_cast<double>(m_totalDuration - 200) * playedThresholdFraction);
+        m_playedThreshold = std::min(playedThresholdFractionMs, playedThresholdTimeMs);
     }
 }
 

--- a/src/core/playback/playbackprogresstracker.h
+++ b/src/core/playback/playbackprogresstracker.h
@@ -38,7 +38,7 @@ public:
     PlaybackProgressTracker();
 
     void reset();
-    void onTrackCommitted(uint64_t totalDurationMs, double playedThresholdFraction);
+    void onTrackCommitted(uint64_t totalDurationMs, double playedThresholdFraction, uint64_t playedThresholdTimeMs);
     bool restartTracking();
 
     [[nodiscard]] PositionUpdate restorePosition(uint64_t posMs);

--- a/src/core/playback/playercontroller.cpp
+++ b/src/core/playback/playercontroller.cpp
@@ -1369,7 +1369,8 @@ void PlayerController::commitCurrentTrack(const Player::TrackChangeRequest& requ
     p->saveActiveTrack();
     p->m_cursor.onTrackCommitted();
     p->m_progressTracker.onTrackCommitted(p->m_session.currentTrack().track.duration(),
-                                          p->m_settings->value<Settings::Core::PlayedThreshold>());
+                                          p->m_settings->value<Settings::Core::PlayedThreshold>(),
+                                          p->m_settings->value<Settings::Core::PlayedThresholdTime>());
     p->updateBitrate(0);
 
     if(result.isQueueTrack) {

--- a/src/gui/settings/playback/playbackpage.cpp
+++ b/src/gui/settings/playback/playbackpage.cpp
@@ -77,6 +77,7 @@ private:
     QDoubleSpinBox* m_volumeStep;
 
     SliderEditor* m_playedSlider;
+    SliderEditor* m_playedTimeSlider;
     ScriptLineEdit* m_shuffleAlbumsGroup;
     ScriptLineEdit* m_shuffleAlbumsSort;
 };
@@ -98,7 +99,8 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     , m_seekStep{new QSpinBox(this)}
     , m_seekStepLarge{new QSpinBox(this)}
     , m_volumeStep{new QDoubleSpinBox(this)}
-    , m_playedSlider{new SliderEditor(tr("Played threshold"), this)}
+    , m_playedSlider{new SliderEditor(tr("Played threshold (%)"), this)}
+    , m_playedTimeSlider{new SliderEditor(tr("Played threshold (time)"), this)}
     , m_shuffleAlbumsGroup{new ScriptLineEdit(this)}
     , m_shuffleAlbumsSort{new ScriptLineEdit(this)}
 {
@@ -120,13 +122,17 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     auto* generalGroup       = new QGroupBox(tr("General"), this);
     auto* generalGroupLayout = new QGridLayout(generalGroup);
 
-    const auto playedToolTip
-        = tr("The percentage of a track that must be listened to before it is counted as 'played'");
+    const auto playedToolTip = tr("Track is counted as 'played' once either threshold is reached");
     m_playedSlider->setToolTip(playedToolTip);
+    m_playedTimeSlider->setToolTip(playedToolTip);
 
     m_playedSlider->setRange(0, 100);
     m_playedSlider->setSingleStep(25);
     m_playedSlider->setSuffix(u" %"_s);
+
+    m_playedTimeSlider->setRange(30, 600);
+    m_playedTimeSlider->setSingleStep(30);
+    m_playedTimeSlider->setSuffix(u" s"_s);
 
     int row{0};
     generalGroupLayout->addWidget(m_restoreActivePlaylistState, row, 0, 1, 2);
@@ -141,6 +147,7 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     generalGroupLayout->addWidget(m_skipUnavailable, row++, 2, 1, 2);
     generalGroupLayout->addWidget(m_stopIfActiveDeleted, row++, 0, 1, 4);
     generalGroupLayout->addWidget(m_playedSlider, row++, 0, 1, 4);
+    generalGroupLayout->addWidget(m_playedTimeSlider, row++, 0, 1, 4);
     generalGroupLayout->setColumnStretch(1, 1);
     generalGroupLayout->setColumnStretch(3, 1);
 
@@ -218,6 +225,7 @@ void PlaybackPageWidget::load()
     const double playedThreshold = m_settings->value<Settings::Core::PlayedThreshold>();
     const auto playedPercent     = static_cast<int>(playedThreshold * 100);
     m_playedSlider->setValue(playedPercent);
+    m_playedTimeSlider->setValue(m_settings->value<Settings::Core::PlayedThresholdTime>() / 1000);
 
     m_shuffleAlbumsGroup->setText(m_settings->value<Settings::Core::ShuffleAlbumsGroupScript>());
     m_shuffleAlbumsSort->setText(m_settings->value<Settings::Core::ShuffleAlbumsSortScript>());
@@ -247,6 +255,7 @@ void PlaybackPageWidget::apply()
     const int playedPercent    = m_playedSlider->value();
     const auto playedThreshold = static_cast<double>(playedPercent) / 100;
     m_settings->set<Settings::Core::PlayedThreshold>(playedThreshold);
+    m_settings->set<Settings::Core::PlayedThresholdTime>(m_playedTimeSlider->value() * 1000);
 
     m_settings->set<Settings::Core::ShuffleAlbumsGroupScript>(m_shuffleAlbumsGroup->text());
     m_settings->set<Settings::Core::ShuffleAlbumsSortScript>(m_shuffleAlbumsSort->text());
@@ -270,6 +279,7 @@ void PlaybackPageWidget::reset()
     m_settings->reset<Settings::Gui::SeekStepLarge>();
     m_settings->reset<Settings::Gui::VolumeStep>();
     m_settings->reset<Settings::Core::PlayedThreshold>();
+    m_settings->reset<Settings::Core::PlayedThresholdTime>();
     m_settings->reset<Settings::Core::ShuffleAlbumsGroupScript>();
     m_settings->reset<Settings::Core::ShuffleAlbumsSortScript>();
 }

--- a/src/plugins/scrobbler/scrobbler.cpp
+++ b/src/plugins/scrobbler/scrobbler.cpp
@@ -36,15 +36,6 @@ using namespace Qt::StringLiterals;
 constexpr auto NowPlayingRefreshIntervalMs  = 180000;
 constexpr auto NowPlayingFinalRefreshLeadMs = 180000;
 constexpr auto MinNowPlayingRefreshDelayMs  = 1000;
-constexpr auto MinScrobbleTrackDurationMs   = 30000;
-constexpr auto MaxScrobbleThresholdMs       = 240000;
-
-namespace {
-uint64_t scrobbleThresholdMs(uint64_t durationMs)
-{
-    return std::min<uint64_t>(durationMs / 2, MaxScrobbleThresholdMs);
-}
-} // namespace
 
 namespace Fooyin::Scrobbler {
 Scrobbler::Scrobbler(PlayerController* playerController, std::shared_ptr<NetworkAccessManager> network,
@@ -52,7 +43,6 @@ Scrobbler::Scrobbler(PlayerController* playerController, std::shared_ptr<Network
     : m_playerController{playerController}
     , m_network{std::move(network)}
     , m_settings{settings}
-    , m_scrobbledCurrentTrack{false}
 {
     addDefaultServices();
     restoreServices();
@@ -63,8 +53,8 @@ Scrobbler::Scrobbler(PlayerController* playerController, std::shared_ptr<Network
         service->resumePendingSubmissions();
     }
 
-    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this, &Scrobbler::currentTrackChanged);
-    QObject::connect(m_playerController, &PlayerController::positionChanged, this, &Scrobbler::updateScrobbleThreshold);
+    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this, &Scrobbler::updateNowPlaying);
+    QObject::connect(m_playerController, &PlayerController::trackPlayed, this, &Scrobbler::scrobble);
     QObject::connect(m_playerController, &PlayerController::playStateChanged, this, &Scrobbler::handlePlayStateChanged);
 }
 
@@ -90,17 +80,9 @@ ScrobblerService* Scrobbler::service(const QString& name) const
     return nullptr;
 }
 
-void Scrobbler::currentTrackChanged(const Track& track)
-{
-    m_scrobbledCurrentTrack = false;
-    updateNowPlaying(track);
-}
-
 void Scrobbler::handlePlayStateChanged(Player::PlayState state, Player::PlayState previous)
 {
     if(previous == Player::PlayState::Stopped && state == Player::PlayState::Playing) {
-        m_scrobbledCurrentTrack = false;
-
         const Track track = m_playerController->currentTrack();
         for(auto& service : m_services) {
             service->restartScrobbleSession(track);
@@ -117,27 +99,6 @@ void Scrobbler::scrobble(const Track& track)
             service->scrobble(track);
         }
     }
-}
-
-bool Scrobbler::currentTrackReachedScrobbleThreshold() const
-{
-    const Track track = m_playerController->currentTrack();
-    if(!track.isValid() || track.isRemote() || !track.hasArtists() || track.title().isEmpty()
-       || track.duration() < MinScrobbleTrackDurationMs) {
-        return false;
-    }
-
-    return m_playerController->currentTimeListened() >= scrobbleThresholdMs(track.duration());
-}
-
-void Scrobbler::updateScrobbleThreshold()
-{
-    if(m_scrobbledCurrentTrack || !currentTrackReachedScrobbleThreshold()) {
-        return;
-    }
-
-    m_scrobbledCurrentTrack = true;
-    scrobble(m_playerController->currentTrack());
 }
 
 std::unique_ptr<ScrobblerService> Scrobbler::createCustomService(const ServiceDetails& details)

--- a/src/plugins/scrobbler/scrobbler.h
+++ b/src/plugins/scrobbler/scrobbler.h
@@ -63,10 +63,7 @@ protected:
     void timerEvent(QTimerEvent* event) override;
 
 private:
-    void currentTrackChanged(const Track& track);
     void handlePlayStateChanged(Player::PlayState state, Player::PlayState previous);
-    [[nodiscard]] bool currentTrackReachedScrobbleThreshold() const;
-    void updateScrobbleThreshold();
 
     [[nodiscard]] int nextNowPlayingRefreshDelay() const;
     void updateNowPlaying(const Track& track);
@@ -82,7 +79,6 @@ private:
 
     std::vector<std::unique_ptr<ScrobblerService>> m_services;
     QBasicTimer m_nowPlayingTimer;
-    bool m_scrobbledCurrentTrack;
 };
 } // namespace Scrobbler
 } // namespace Fooyin

--- a/tests/core/playback/playbackprogresstrackertest.cpp
+++ b/tests/core/playback/playbackprogresstrackertest.cpp
@@ -25,7 +25,7 @@ namespace Fooyin::Testing {
 TEST(PlaybackProgressTrackerTest, CountsPlaybackTimeAndPlayedThresholdOnce)
 {
     PlaybackProgressTracker tracker;
-    tracker.onTrackCommitted(1000, 0.5);
+    tracker.onTrackCommitted(1000, 0.5, 240000);
 
     const auto firstUpdate = tracker.updatePosition(100);
     EXPECT_EQ(firstUpdate.positionMs, 100);
@@ -49,7 +49,7 @@ TEST(PlaybackProgressTrackerTest, CountsPlaybackTimeAndPlayedThresholdOnce)
 TEST(PlaybackProgressTrackerTest, SeekPreventsSkippedTimeFromCounting)
 {
     PlaybackProgressTracker tracker;
-    tracker.onTrackCommitted(2000, 0.5);
+    tracker.onTrackCommitted(2000, 0.5, 240000);
 
     const auto initialUpdate = tracker.updatePosition(100);
     EXPECT_EQ(initialUpdate.positionMs, 100);
@@ -69,7 +69,7 @@ TEST(PlaybackProgressTrackerTest, SeekPreventsSkippedTimeFromCounting)
 TEST(PlaybackProgressTrackerTest, ResetAndBitrateUpdatesBehaveAsExpected)
 {
     PlaybackProgressTracker tracker;
-    tracker.onTrackCommitted(3000, 0.5);
+    tracker.onTrackCommitted(3000, 0.5, 240000);
     const auto playbackUpdate = tracker.updatePosition(1200);
     EXPECT_EQ(playbackUpdate.positionMs, 1200);
 
@@ -94,7 +94,7 @@ TEST(PlaybackProgressTrackerTest, ResetAndBitrateUpdatesBehaveAsExpected)
 TEST(PlaybackProgressTrackerTest, RestoredProgressPreservesPartialThresholdProgress)
 {
     PlaybackProgressTracker tracker;
-    tracker.onTrackCommitted(1000, 0.5);
+    tracker.onTrackCommitted(1000, 0.5, 240000);
 
     const auto restoredUpdate = tracker.restoreProgress(500, 350);
     EXPECT_EQ(restoredUpdate.positionMs, 500);
@@ -112,7 +112,7 @@ TEST(PlaybackProgressTrackerTest, RestoredProgressPreservesPartialThresholdProgr
 TEST(PlaybackProgressTrackerTest, ResetPositionPreventsLateEndSampleFromCountingSkippedTrackTime)
 {
     PlaybackProgressTracker tracker;
-    tracker.onTrackCommitted(10000, 0.99);
+    tracker.onTrackCommitted(10000, 0.99, 240000);
 
     const auto initialUpdate = tracker.updatePosition(1000);
     EXPECT_FALSE(initialUpdate.reachedPlayedThreshold);
@@ -130,5 +130,32 @@ TEST(PlaybackProgressTrackerTest, ResetPositionPreventsLateEndSampleFromCounting
     const auto lateEndUpdate = tracker.updatePosition(10000);
     EXPECT_FALSE(lateEndUpdate.reachedPlayedThreshold);
     EXPECT_EQ(tracker.timeListened(), 1000);
+}
+
+TEST(PlaybackProgressTrackerTest, EarlierElapsedThresholdWins)
+{
+    PlaybackProgressTracker tracker;
+    tracker.onTrackCommitted(10000, 0.9, 4000);
+
+    EXPECT_EQ(tracker.playedThreshold(), 4000);
+
+    const auto preThresholdUpdate = tracker.updatePosition(3000);
+    EXPECT_FALSE(preThresholdUpdate.reachedPlayedThreshold);
+
+    const auto thresholdUpdate = tracker.updatePosition(4000);
+    EXPECT_TRUE(thresholdUpdate.reachedPlayedThreshold);
+    EXPECT_TRUE(tracker.playedThresholdReached());
+}
+
+TEST(PlaybackProgressTrackerTest, EarlierPercentageThresholdWins)
+{
+    PlaybackProgressTracker tracker;
+    tracker.onTrackCommitted(1000, 0.25, 60000);
+
+    EXPECT_EQ(tracker.playedThreshold(), 200);
+
+    const auto thresholdUpdate = tracker.updatePosition(200);
+    EXPECT_TRUE(thresholdUpdate.reachedPlayedThreshold);
+    EXPECT_TRUE(tracker.playedThresholdReached());
 }
 } // namespace Fooyin::Testing

--- a/tests/core/playback/playercontrollertest.cpp
+++ b/tests/core/playback/playercontrollertest.cpp
@@ -75,6 +75,7 @@ void registerControllerSettings(SettingsManager& settings)
     settings.createSetting<Settings::Core::StopAfterCurrent>(false, u"Playback/StopAfterCurrent"_s);
     settings.createSetting<Settings::Core::ResetStopAfterCurrent>(false, u"Playback/ResetStopAfterCurrent"_s);
     settings.createSetting<Settings::Core::PlayedThreshold>(0.5, u"Playback/PlayedThreshold"_s);
+    settings.createSetting<Settings::Core::PlayedThresholdTime>(240000, u"Playback/PlayedThresholdTime"_s);
     settings.createSetting<Settings::Core::RewindPreviousTrack>(false, u"Playlist/RewindPreviousTrack"_s);
     settings.createSetting<Settings::Core::PlaybackQueueStopWhenFinished>(false,
                                                                           u"Playback/PlaybackQueueStopWhenFinished"_s);
@@ -379,6 +380,29 @@ TEST(PlayerControllerTest, TrackPlayedEmitsOnceAfterCrossingThreshold)
     const QVariantList playedArgs = playedSpy.takeFirst();
     ASSERT_EQ(playedArgs.size(), 1);
     EXPECT_EQ(playedArgs.front().value<Track>(), makeTrack(u"/tmp/played.flac"_s, 13, 1000));
+}
+
+TEST(PlayerControllerTest, TrackPlayedUsesEarlierElapsedThreshold)
+{
+    ensureCoreApplication();
+    SettingsManager settings{QDir::tempPath() + u"/fooyin_playercontroller_elapsed_track_played_test.ini"_s};
+    registerControllerSettings(settings);
+    settings.set<Settings::Core::PlayedThreshold>(0.9);
+    settings.set<Settings::Core::PlayedThresholdTime>(30000);
+    PlayerController controller{&settings, nullptr};
+
+    QSignalSpy playedSpy{&controller, &PlayerController::trackPlayed};
+
+    controller.commitCurrentTrack(makeTrack(u"/tmp/elapsed-played.flac"_s, 23, 120000));
+    controller.setCurrentPosition(29000);
+    EXPECT_EQ(playedSpy.count(), 0);
+
+    controller.setCurrentPosition(30000);
+
+    ASSERT_EQ(playedSpy.count(), 1);
+    const QVariantList playedArgs = playedSpy.takeFirst();
+    ASSERT_EQ(playedArgs.size(), 1);
+    EXPECT_EQ(playedArgs.front().value<Track>(), makeTrack(u"/tmp/elapsed-played.flac"_s, 23, 120000));
 }
 
 TEST(PlayerControllerTest, RestartingCurrentTrackAfterStoppedCountsListenedTime)


### PR DESCRIPTION
This PR proposes a better (imo) approach to tackle #1152. Inspired by Pano Scrobbler, it adds a second, time-based threshold, so that playcount threshold is uniformerly managed across all components. The first threshold reached wins.

Min: 30 seconds.
Default: 4 minutes.
Max: 10 minutes.

<img width="1437" height="709" alt="image" src="https://github.com/user-attachments/assets/d56c83be-3671-45a5-8a11-7706588326ea" />

P.S. Not sure if extra flexibility like disabling a threshold is really necessary. But if so, just say the word.