### PR TITLE
[core] Scripting: Add bounds check to $chop()

### DIFF
--- a/src/core/scripting/functions/stringfuncs.cpp
+++ b/src/core/scripting/functions/stringfuncs.cpp
@@ -201,7 +201,7 @@ QString chop(const QStringList& vec)
 
     bool numSuccess{false};
     const int num = vec.at(1).toInt(&numSuccess);
-    if(numSuccess && num >= 0) {
+    if(numSuccess && num >= 0 && num <= vec.at(0).size()) {
         return vec.at(0).chopped(num);
     }
 


### PR DESCRIPTION
This patch fixes undefined behavior when `$chop()` is called with `count` exceeding the length of `text`.