### PR TITLE
[radiobrowser] Fix 32bit build

### DIFF
--- a/src/plugins/radiobrowser/radioiconprovider.cpp
+++ b/src/plugins/radiobrowser/radioiconprovider.cpp
@@ -52,7 +52,7 @@ QByteArray readReplyData(QNetworkReply* reply, const qsizetype maxBytes)
        || reply->bytesAvailable() <= 0) {
         return {};
     }
-    return reply->read(std::min(maxBytes, reply->bytesAvailable()));
+    return reply->read(std::min(static_cast<qint64>(maxBytes), reply->bytesAvailable()));
 }
 
 QSize calculateScaledSize(const QSize& originalSize, int maxSize)


### PR DESCRIPTION
```
/builddir/build/BUILD/fooyin-0.11.1-build/fooyin-0.11.1/src/plugins/radiobrowser/radioiconprovider.cpp: In function ‘QByteArray {anonymous}::readReplyData(QNetworkReply*, qsizetype)’:
/builddir/build/BUILD/fooyin-0.11.1-build/fooyin-0.11.1/src/plugins/radiobrowser/radioiconprovider.cpp:55:32: error: no matching function for call to ‘min(const qsizetype&, qint64)’
   55 |     return reply->read(std::min(maxBytes, reply->bytesAvailable()));
      |                        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```