### PR TITLE
[gui] Improve properties dialog performance

### DIFF
--- a/include/gui/propertiesdialog.h
+++ b/include/gui/propertiesdialog.h
@@ -58,7 +58,7 @@ private:
     TrackList m_workingTracks;
     std::set<int> m_activeTrackIndexes;
     std::vector<int> m_pendingRevisions;
-    qsizetype m_pendingCount;
+    qsizetype m_pendingCount{0};
 };
 
 class FYGUI_EXPORT PropertiesTabWidget : public QWidget

--- a/include/gui/propertiesdialog.h
+++ b/include/gui/propertiesdialog.h
@@ -51,12 +51,14 @@ public:
 
     [[nodiscard]] bool hasChanges() const;
     [[nodiscard]] bool hasOnlyStatChanges() const;
-    [[nodiscard]] bool isTrackDirty(int index) const;
+    [[nodiscard]] int trackRevision(int index) const;
 
 private:
     TrackList m_originalTracks;
     TrackList m_workingTracks;
     std::set<int> m_activeTrackIndexes;
+    std::vector<int> m_pendingRevisions;
+    qsizetype m_pendingCount;
 };
 
 class FYGUI_EXPORT PropertiesTabWidget : public QWidget

--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -68,7 +68,7 @@ Fooyin::TrackList filterDuplicateTracks(const Fooyin::TrackList& tracks)
     filteredTracks.reserve(tracks.size());
 
     for(const auto& track : tracks) {
-        if(seenTracks.emplace(track.uniqueFilepath()).second) {
+        if(seenTracks.emplace(track.identityKey()).second) {
             filteredTracks.push_back(track);
         }
     }
@@ -100,7 +100,7 @@ void PropertiesDialogSession::reset(const TrackList& tracks)
     m_originalTracks         = workingTracks;
     m_workingTracks          = workingTracks;
     m_activeTrackIndexes.clear();
-    m_pendingRevisions.resize(static_cast<qsizetype>(workingTracks.size()));
+    m_pendingRevisions.assign(static_cast<qsizetype>(workingTracks.size()), 0);
     m_pendingCount = 0;
 }
 

--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -175,7 +175,7 @@ void PropertiesDialogSession::updateTracks(const TrackList& tracks)
             }
             m_pendingRevisions[index]++;
         }
-        else {
+        else if(m_pendingRevisions[index] > 0) {
             m_pendingRevisions[index] = 0;
             m_pendingCount            = std::max(qsizetype{0}, m_pendingCount - 1);
         }

--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <unordered_set>
 #include <utility>
 
 using namespace Qt::StringLiterals;
@@ -58,6 +59,23 @@ constexpr auto BaseWidthKey            = "PropertiesDialog/BaseWidth";
 constexpr auto PropertiesDialogContext = "Fooyin.Context.PropertiesDialog";
 
 namespace {
+Fooyin::TrackList filterDuplicateTracks(const Fooyin::TrackList& tracks)
+{
+    std::unordered_set<QString> seenTracks;
+    seenTracks.reserve(tracks.size());
+
+    Fooyin::TrackList filteredTracks;
+    filteredTracks.reserve(tracks.size());
+
+    for(const auto& track : tracks) {
+        if(seenTracks.emplace(track.uniqueFilepath()).second) {
+            filteredTracks.push_back(track);
+        }
+    }
+
+    return filteredTracks;
+}
+
 bool metadataEqual(const Fooyin::Track& lhs, const Fooyin::Track& rhs)
 {
     return lhs.metadata() == rhs.metadata() && lhs.serialiseExtraTags() == rhs.serialiseExtraTags()
@@ -78,8 +96,9 @@ bool editorEqual(const Fooyin::Track& lhs, const Fooyin::Track& rhs)
 namespace Fooyin {
 void PropertiesDialogSession::reset(const TrackList& tracks)
 {
-    m_originalTracks = tracks;
-    m_workingTracks  = tracks;
+    const auto workingTracks = filterDuplicateTracks(tracks);
+    m_originalTracks         = workingTracks;
+    m_workingTracks          = workingTracks;
     m_activeTrackIndexes.clear();
 }
 

--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -387,7 +387,9 @@ private:
     void apply();
     void updateTracks(const TrackList& tracks);
 
+    void buildScopePanel();
     void refreshScopePanel();
+    void updateScopePanelButtons(bool hasMultipleTracks);
     void refreshScopeNavigation();
     void switchScope();
     void applyTrackScope(PropertiesTabWidget* widget) const;
@@ -554,7 +556,7 @@ PropertiesDialogWidget::PropertiesDialogWidget(ActionManager* actionManager, Set
         }
     }
 
-    refreshScopePanel();
+    buildScopePanel();
     updateTabAvailability();
     currentTabChanged(m_tabWidget->currentIndex());
 }
@@ -708,19 +710,12 @@ void PropertiesDialogWidget::updateTabAvailability()
     }
 }
 
-void PropertiesDialogWidget::refreshScopePanel()
+void PropertiesDialogWidget::buildScopePanel()
 {
-    const TrackList& tracks           = m_session.workingTracks();
-    const bool hasMultipleTracks      = canShowScopePanel();
-    const auto* currentWidget         = currentTabWidget();
-    const bool hasPendingScopeChanges = currentWidget && currentWidget->hasPendingScopeChanges();
-    const bool pendingAllTracks       = hasPendingScopeChanges && m_session.isAllTracksScope();
-    const bool pendingAnyTracks       = hasPendingScopeChanges && !m_session.activeTrackIndexes().empty();
+    const TrackList& tracks      = m_session.workingTracks();
+    const bool hasMultipleTracks = canShowScopePanel();
 
-    m_scopeButton->setVisible(hasMultipleTracks);
-    m_scopeButton->setEnabled(hasMultipleTracks);
-    m_previousTrackButton->setVisible(hasMultipleTracks);
-    m_nextTrackButton->setVisible(hasMultipleTracks);
+    updateScopePanelButtons(hasMultipleTracks);
 
     const QSignalBlocker blocker{m_scopeList};
     m_scopeList->clear();
@@ -731,42 +726,67 @@ void PropertiesDialogWidget::refreshScopePanel()
         return;
     }
 
-    m_scopeList->addItem(((m_session.hasChanges() || pendingAllTracks || pendingAnyTracks) ? u"* "_s : QString{})
-                         + scopeLabel(-1));
+    m_scopeList->addItem(scopeLabel(-1));
+    for(size_t i{0}; i < tracks.size(); ++i) {
+        m_scopeList->addItem(scopeLabel(static_cast<int>(i)));
+    }
+
+    m_scopeList->item(0)->setSelected(true);
+    m_scopeList->setCurrentRow(0);
+
+    setScopePanelVisible(m_scopePanelPreferredVisible, false);
+    refreshScopeNavigation();
+}
+
+void PropertiesDialogWidget::refreshScopePanel()
+{
+    const TrackList& tracks      = m_session.workingTracks();
+    const bool hasMultipleTracks = canShowScopePanel();
+
+    updateScopePanelButtons(hasMultipleTracks);
+
+    if(!hasMultipleTracks) {
+        setScopePanelVisible(m_scopePanelPreferredVisible, false);
+        refreshScopeNavigation();
+        return;
+    }
+
+    const auto* currentWidget         = currentTabWidget();
+    const bool hasPendingScopeChanges = currentWidget && currentWidget->hasPendingScopeChanges();
+    const bool pendingAllTracks       = hasPendingScopeChanges && m_session.isAllTracksScope();
+    const bool pendingAnyTracks       = hasPendingScopeChanges && !m_session.activeTrackIndexes().empty();
+
+    if(auto* allTracksItem = m_scopeList->item(0)) {
+        const bool markAllTracksPending = m_session.hasChanges() || pendingAllTracks || pendingAnyTracks;
+        allTracksItem->setText((markAllTracksPending ? u"* "_s : QString{}) + scopeLabel(-1));
+    }
 
     for(size_t i{0}; i < tracks.size(); ++i) {
         const int trackIndex = static_cast<int>(i);
-        const bool pendingTrack
-            = hasPendingScopeChanges && !pendingAllTracks && m_session.activeTrackIndexes().contains(trackIndex);
-        m_scopeList->addItem(((m_session.isTrackDirty(trackIndex) || pendingTrack) ? u"* "_s : QString{})
-                             + scopeLabel(trackIndex));
-    }
-
-    if(m_session.isAllTracksScope()) {
-        if(auto* item = m_scopeList->item(0)) {
-            item->setSelected(true);
-        }
-        m_scopeList->setCurrentRow(0);
-    }
-    else {
-        bool currentSet{false};
-        for(const int index : m_session.activeTrackIndexes()) {
-            if(index + 1 >= m_scopeList->count()) {
-                continue;
+        if(pendingAllTracks) {
+            if(auto* item = m_scopeList->item(trackIndex + 1)) {
+                item->setText(u"* "_s + scopeLabel(trackIndex));
             }
-
-            if(auto* item = m_scopeList->item(index + 1)) {
-                item->setSelected(true);
-                if(!currentSet) {
-                    m_scopeList->setCurrentRow(index + 1);
-                    currentSet = true;
-                }
+        }
+        else {
+            const bool pendingTrack = hasPendingScopeChanges && m_session.activeTrackIndexes().contains(trackIndex);
+            if(auto* item = m_scopeList->item(trackIndex + 1)) {
+                item->setText((pendingTrack || m_session.isTrackDirty(trackIndex) ? u"* "_s : QString{})
+                              + scopeLabel(trackIndex));
             }
         }
     }
 
     setScopePanelVisible(m_scopePanelPreferredVisible, false);
     refreshScopeNavigation();
+}
+
+void PropertiesDialogWidget::updateScopePanelButtons(bool hasMultipleTracks)
+{
+    m_scopeButton->setVisible(hasMultipleTracks);
+    m_scopeButton->setEnabled(hasMultipleTracks);
+    m_previousTrackButton->setVisible(hasMultipleTracks);
+    m_nextTrackButton->setVisible(hasMultipleTracks);
 }
 
 void PropertiesDialogWidget::setScopePanelVisible(bool visible, bool updatePreference)

--- a/src/gui/dialog/propertiesdialog.cpp
+++ b/src/gui/dialog/propertiesdialog.cpp
@@ -100,6 +100,8 @@ void PropertiesDialogSession::reset(const TrackList& tracks)
     m_originalTracks         = workingTracks;
     m_workingTracks          = workingTracks;
     m_activeTrackIndexes.clear();
+    m_pendingRevisions.resize(static_cast<qsizetype>(workingTracks.size()));
+    m_pendingCount = 0;
 }
 
 const TrackList& PropertiesDialogSession::originalTracks() const
@@ -166,6 +168,17 @@ void PropertiesDialogSession::updateTracks(const TrackList& tracks)
         if(workingIt == m_workingTracks.cend()) {
             continue;
         }
+        const auto index = std::distance(m_workingTracks.begin(), workingIt);
+        if(!editorEqual(m_originalTracks[index], updatedTrack)) {
+            if(m_pendingRevisions[index] == 0) {
+                m_pendingCount++;
+            }
+            m_pendingRevisions[index]++;
+        }
+        else {
+            m_pendingRevisions[index] = 0;
+            m_pendingCount            = std::max(qsizetype{0}, m_pendingCount - 1);
+        }
         *workingIt = updatedTrack;
     }
 }
@@ -173,21 +186,13 @@ void PropertiesDialogSession::updateTracks(const TrackList& tracks)
 void PropertiesDialogSession::acceptChanges()
 {
     m_originalTracks = m_workingTracks;
+    m_pendingRevisions.assign(m_originalTracks.size(), false);
+    m_pendingCount = 0;
 }
 
 bool PropertiesDialogSession::hasChanges() const
 {
-    if(m_originalTracks.size() != m_workingTracks.size()) {
-        return true;
-    }
-
-    for(size_t i{0}; i < m_originalTracks.size(); ++i) {
-        if(!editorEqual(m_originalTracks.at(i), m_workingTracks.at(i))) {
-            return true;
-        }
-    }
-
-    return false;
+    return m_pendingCount > 0 || m_originalTracks.size() != m_workingTracks.size();
 }
 
 bool PropertiesDialogSession::hasOnlyStatChanges() const
@@ -211,15 +216,15 @@ bool PropertiesDialogSession::hasOnlyStatChanges() const
     return hasStatChanges;
 }
 
-bool PropertiesDialogSession::isTrackDirty(int index) const
+int PropertiesDialogSession::trackRevision(int index) const
 {
     if(index < 0 || std::cmp_greater_equal(index, m_originalTracks.size())
-       || std::cmp_greater_equal(index, m_workingTracks.size())) {
-        return false;
+       || std::cmp_greater_equal(index, m_workingTracks.size())
+       || std::cmp_greater_equal(index, m_pendingRevisions.size())) {
+        return 0;
     }
 
-    return !editorEqual(m_originalTracks.at(static_cast<size_t>(index)),
-                        m_workingTracks.at(static_cast<size_t>(index)));
+    return m_pendingRevisions[index];
 }
 
 bool PropertiesTabWidget::canApply() const
@@ -432,6 +437,7 @@ private:
     bool m_scopePanelPreferredVisible{false};
     bool m_scopePanelVisible{false};
     int m_scopePanelReservedWidth{0};
+    std::vector<int> m_itemRevisions;
 };
 
 namespace {
@@ -726,6 +732,8 @@ void PropertiesDialogWidget::buildScopePanel()
         return;
     }
 
+    m_itemRevisions.resize(static_cast<qsizetype>(tracks.size()) + 1);
+
     m_scopeList->addItem(scopeLabel(-1));
     for(size_t i{0}; i < tracks.size(); ++i) {
         m_scopeList->addItem(scopeLabel(static_cast<int>(i)));
@@ -740,9 +748,7 @@ void PropertiesDialogWidget::buildScopePanel()
 
 void PropertiesDialogWidget::refreshScopePanel()
 {
-    const TrackList& tracks      = m_session.workingTracks();
     const bool hasMultipleTracks = canShowScopePanel();
-
     updateScopePanelButtons(hasMultipleTracks);
 
     if(!hasMultipleTracks) {
@@ -761,19 +767,20 @@ void PropertiesDialogWidget::refreshScopePanel()
         allTracksItem->setText((markAllTracksPending ? u"* "_s : QString{}) + scopeLabel(-1));
     }
 
+    const TrackList& tracks = m_session.workingTracks();
+
     for(size_t i{0}; i < tracks.size(); ++i) {
-        const int trackIndex = static_cast<int>(i);
-        if(pendingAllTracks) {
+        const int trackIndex    = static_cast<int>(i);
+        const bool pendingTrack = hasPendingScopeChanges && m_session.activeTrackIndexes().contains(trackIndex);
+        int revision            = m_session.trackRevision(trackIndex);
+        if(pendingTrack || revision != m_itemRevisions[trackIndex + 1]) {
             if(auto* item = m_scopeList->item(trackIndex + 1)) {
-                item->setText(u"* "_s + scopeLabel(trackIndex));
+                item->setText((pendingTrack || revision > 0 ? u"* "_s : QString{}) + scopeLabel(trackIndex));
             }
-        }
-        else {
-            const bool pendingTrack = hasPendingScopeChanges && m_session.activeTrackIndexes().contains(trackIndex);
-            if(auto* item = m_scopeList->item(trackIndex + 1)) {
-                item->setText((pendingTrack || m_session.isTrackDirty(trackIndex) ? u"* "_s : QString{})
-                              + scopeLabel(trackIndex));
+            if(pendingTrack) {
+                revision++;
             }
+            m_itemRevisions[trackIndex + 1] = revision;
         }
     }
 
@@ -838,6 +845,11 @@ void PropertiesDialogWidget::refreshScopeNavigation()
 
 void PropertiesDialogWidget::switchScope()
 {
+    if(!commitCurrentTabPendingChanges()) {
+        refreshScopePanel();
+        return;
+    }
+
     auto selectedIndexes = m_scopeList->selectionModel()->selectedRows();
 
     std::vector<int> selectedRows;
@@ -850,12 +862,6 @@ void PropertiesDialogWidget::switchScope()
     const int currentRow = m_scopeList->currentRow();
     if(selectedRows.empty() && currentRow >= 0) {
         selectedRows.emplace_back(currentRow);
-    }
-
-    if(!commitCurrentTabPendingChanges()) {
-        const QSignalBlocker blocker{m_scopeList};
-        refreshScopePanel();
-        return;
     }
 
     std::set<int> selectedTrackIndexes;


### PR DESCRIPTION
This PR addresses some issues related to the properties dialog.

We currently rebuild the scope list every time `refreshScopePanel()` is called (which happens a lot, including on selection changes). This causes CPU spikes and freezes on my machine when scrolling through large (> 2000) track lists using arrow keys. Most of the time is spent doing metadata comparisons. So:

* Disallow duplicate track items.
* Add `buildScopePanel()` to only build the list on widget construction, and make
  `refreshScopePanel()` only refresh existing items. This also fixes shift + arrow key selections.
* Add a cache for pending track changes to the session and widget to avoid the metadata comparisons.

When the tag editor is enabled, it still takes some time to open the properties dialog with big track lists due to the info populator reading and adding track metadata. I don't think this can be avoided, but perhaps it could be done asynchronously?

I also found two bugs while testing that existed before this PR: editing the lyrics in the lyrics tab will mark the track as pending, but changing them back will not unmark them. Editing the RG data does not mark the track as pending at all.