### PR TITLE
Confirm before removing a playlist with a don't-ask-again option

### DIFF
--- a/include/gui/guisettings.h
+++ b/include/gui/guisettings.h
@@ -91,6 +91,7 @@ enum GuiSettings : uint32_t
     PlaylistSearchMode         = 34 | Type::Int,
     PlaylistSearchScript       = 35 | Type::String,
     DragOnlyAfterSelect        = 36 | Type::Bool,
+    PlaylistRemovalConfirm     = 37 | Type::Bool,
 };
 Q_ENUM_NS(GuiSettings)
 } // namespace Settings::Gui

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -36,6 +36,7 @@
 #include "menubar/playbackmenu.h"
 #include "menubar/viewmenu.h"
 #include "playlist/manager/playlistmanagerwidget.h"
+#include "playlist/playlistbox.h"
 #include "playlist/playlistcontroller.h"
 #include "playlist/playlistinteractor.h"
 #include "playlist/playlistuicontroller.h"
@@ -991,7 +992,9 @@ void GuiApplication::registerActions()
     removeCmd->setDefaultShortcut(QKeySequence{Qt::CTRL | Qt::Key_W});
     QObject::connect(removePlaylist, &QAction::triggered, m_mainWindow.get(), [this]() {
         if(auto* currentPlaylist = m_playlistController->currentPlaylist()) {
-            m_core->playlistHandler()->removePlaylist(currentPlaylist->id());
+            if(confirmPlaylistRemoval(m_settings, m_mainWindow.get())) {
+                m_core->playlistHandler()->removePlaylist(currentPlaylist->id());
+            }
         }
     });
 

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -202,6 +202,7 @@ GuiSettings::GuiSettings(SettingsManager* settingsManager)
     m_settings->createSetting<Internal::ImageAllocationLimit>(QImageReader::allocationLimit(),
                                                               u"Interface/ImageAllocationLimit"_s);
     m_settings->createSetting<DragOnlyAfterSelect>(true, u"Interface/DragOnlyAfterSelect"_s);
+    m_settings->createSetting<PlaylistRemovalConfirm>(true, u"Playlist/RemovalConfirm"_s);
     m_settings->createSetting<Internal::PlaylistTrackPreloadCount>(2000, u"Playlist/TrackPreloadCount"_s);
     m_settings->createSetting<Internal::PlaylistInlineTagEditing>(false, u"PlaylistWidget/InlineTagEditing"_s);
     m_settings->createSetting<Internal::ContextMenuTrackDisabledSections>(

--- a/src/gui/playlist/manager/playlistmanagerwidget.cpp
+++ b/src/gui/playlist/manager/playlistmanagerwidget.cpp
@@ -20,6 +20,7 @@
 #include "playlistmanagerwidget.h"
 
 #include "dialog/autoplaylistdialog.h"
+#include "playlist/playlistbox.h"
 #include "playlist/playlistcontroller.h"
 #include "playlist/playlistinteractor.h"
 #include "playlistmanagermodel.h"
@@ -449,7 +450,11 @@ void PlaylistManagerWidget::removePlaylist(const Playlist* playlist)
         return;
     }
 
-    m_playlistController->playlistHandler()->removePlaylist(playlist->id());
+    const auto playlistId = playlist->id();
+
+    if(confirmPlaylistRemoval(m_settings, this)) {
+        m_playlistController->playlistHandler()->removePlaylist(playlistId);
+    }
 }
 
 void PlaylistManagerWidget::editCurrentAutoPlaylist()

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -20,6 +20,7 @@
 #include "playlistorganiser.h"
 
 #include "dialog/autoplaylistdialog.h"
+#include "playlist/playlistbox.h"
 #include "playlist/playlistcontroller.h"
 #include "playlist/playlistinteractor.h"
 #include "playlistorganiserconfigwidget.h"
@@ -122,6 +123,33 @@ void restoreExpandedState(QTreeView* view, QAbstractItemModel* model, QByteArray
             }
         }
     }
+}
+
+bool containsPlaylist(const QModelIndex& index, QAbstractItemModel* model)
+{
+    if(!index.isValid()) {
+        return false;
+    }
+
+    std::stack<QModelIndex> indexes;
+    indexes.push(index);
+
+    while(!indexes.empty()) {
+        const QModelIndex currentIndex = indexes.top();
+        indexes.pop();
+
+        if(currentIndex.data(Fooyin::PlaylistOrganiserItem::ItemType).toInt()
+           == Fooyin::PlaylistOrganiserItem::PlaylistItem) {
+            return true;
+        }
+
+        const int childCount = model->rowCount(currentIndex);
+        for(int row{0}; row < childCount; ++row) {
+            indexes.push(model->index(row, 0, currentIndex));
+        }
+    }
+
+    return false;
 }
 
 class OrganiserTreeView : public QTreeView
@@ -264,7 +292,15 @@ PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistInter
         sortAndRestoreState(
             [this, indexes]() { m_model->sortGroupPlaylists(indexes, PlaylistOrganiserModel::SortOrder::Ascending); });
     });
-    QObject::connect(m_removePlaylist, &QAction::triggered, this, [this]() { m_model->removeItems(actionIndexes()); });
+    QObject::connect(m_removePlaylist, &QAction::triggered, this, [this]() {
+        const QModelIndexList indexes = actionIndexes();
+        const bool hasPlaylists       = std::ranges::any_of(
+            indexes, [this](const QModelIndex& index) { return containsPlaylist(index, m_model); });
+
+        if(!hasPlaylists || confirmPlaylistRemoval(m_settings, this)) {
+            m_model->removeItems(indexes);
+        }
+    });
     QObject::connect(m_renamePlaylist, &QAction::triggered, this, [this]() { m_organiserTree->edit(actionIndex()); });
     QObject::connect(m_newPlaylist, &QAction::triggered, this, [this]() { createPlaylist(actionIndex(), false); });
     QObject::connect(m_newAutoPlaylist, &QAction::triggered, this, [this]() { createPlaylist(actionIndex(), true); });

--- a/src/gui/playlist/playlistbox.cpp
+++ b/src/gui/playlist/playlistbox.cpp
@@ -75,8 +75,8 @@ bool confirmPlaylistRemoval(SettingsManager* settings, QWidget* parent)
     return true;
 }
 
-PlaylistBox::PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController, SettingsManager* settings,
-                         QWidget* parent)
+PlaylistBox::PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController,
+                         SettingsManager* settings, QWidget* parent)
     : FyWidget{parent}
     , m_actionManager{actionManager}
     , m_playlistController{playlistController}

--- a/src/gui/playlist/playlistbox.cpp
+++ b/src/gui/playlist/playlistbox.cpp
@@ -24,29 +24,63 @@
 
 #include <core/playlist/playlisthandler.h>
 #include <gui/guiconstants.h>
+#include <gui/guisettings.h>
 #include <gui/widgets/popuplineedit.h>
 #include <utils/actions/actionmanager.h>
 #include <utils/actions/command.h>
 #include <utils/actions/proxyaction.h>
 #include <utils/actions/widgetcontext.h>
 #include <utils/crypto.h>
+#include <utils/settings/settingsmanager.h>
 #include <utils/utils.h>
 
 #include <QAction>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QKeySequence>
 #include <QMainWindow>
 #include <QMenu>
+#include <QMessageBox>
 #include <QSignalBlocker>
 #include <QVBoxLayout>
 
 using namespace Qt::StringLiterals;
 
 namespace Fooyin {
-PlaylistBox::PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController, QWidget* parent)
+bool confirmPlaylistRemoval(SettingsManager* settings, QWidget* parent)
+{
+    if(!settings->value<Settings::Gui::PlaylistRemovalConfirm>()) {
+        return true;
+    }
+
+    QMessageBox message{parent};
+    message.setIcon(QMessageBox::Question);
+    message.setWindowTitle(PlaylistBox::tr("Remove Playlist"));
+    message.setText(PlaylistBox::tr("Remove the selected playlist?"));
+
+    auto* dontAskAgain = new QCheckBox(PlaylistBox::tr("Don't ask again"), &message);
+    message.setCheckBox(dontAskAgain);
+
+    message.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    message.setDefaultButton(QMessageBox::No);
+
+    if(message.exec() != QMessageBox::Yes) {
+        return false;
+    }
+
+    if(dontAskAgain->isChecked()) {
+        settings->set<Settings::Gui::PlaylistRemovalConfirm>(false);
+    }
+
+    return true;
+}
+
+PlaylistBox::PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController, SettingsManager* settings,
+                         QWidget* parent)
     : FyWidget{parent}
     , m_actionManager{actionManager}
     , m_playlistController{playlistController}
+    , m_settings{settings}
     , m_playlistHandler{m_playlistController->playlistHandler()}
     , m_playlistBox{new QComboBox(this)}
     , m_context{new WidgetContext(this, Context{IdList{Id{"Fooyin.Context.PlaylistSwitcher."}.append(id())}}, this)}
@@ -366,8 +400,11 @@ void PlaylistBox::cancelRenameEditor()
 void PlaylistBox::removeCurrentPlaylist()
 {
     if(auto* playlist = currentPlaylist()) {
+        const auto playlistId = playlist->id();
         closeRenameEditor();
-        m_playlistHandler->removePlaylist(playlist->id());
+        if(confirmPlaylistRemoval(m_settings, this)) {
+            m_playlistHandler->removePlaylist(playlistId);
+        }
     }
 }
 

--- a/src/gui/playlist/playlistbox.h
+++ b/src/gui/playlist/playlistbox.h
@@ -44,8 +44,8 @@ class PlaylistBox : public FyWidget
     Q_OBJECT
 
 public:
-    explicit PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController, SettingsManager* settings,
-                         QWidget* parent = nullptr);
+    explicit PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController,
+                         SettingsManager* settings, QWidget* parent = nullptr);
 
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;

--- a/src/gui/playlist/playlistbox.h
+++ b/src/gui/playlist/playlistbox.h
@@ -34,14 +34,17 @@ class Playlist;
 class PlaylistController;
 class PlaylistHandler;
 class PopupLineEdit;
+class SettingsManager;
 class WidgetContext;
+
+bool confirmPlaylistRemoval(SettingsManager* settings, QWidget* parent);
 
 class PlaylistBox : public FyWidget
 {
     Q_OBJECT
 
 public:
-    explicit PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController,
+    explicit PlaylistBox(ActionManager* actionManager, PlaylistController* playlistController, SettingsManager* settings,
                          QWidget* parent = nullptr);
 
     [[nodiscard]] QString name() const override;
@@ -70,6 +73,7 @@ private:
 
     ActionManager* m_actionManager;
     PlaylistController* m_playlistController;
+    SettingsManager* m_settings;
     PlaylistHandler* m_playlistHandler;
 
     QComboBox* m_playlistBox;

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -21,6 +21,7 @@
 
 #include "dialog/autoplaylistdialog.h"
 #include "internalguisettings.h"
+#include "playlistbox.h"
 #include "playlistcontroller.h"
 
 #include <core/player/playercontroller.h>
@@ -404,8 +405,11 @@ void PlaylistTabs::contextMenuEvent(QContextMenuEvent* event)
         if(playlist) {
             auto* removeAction
                 = new QAction(playlist->isAutoPlaylist() ? tr("Remove autoplaylist") : tr("Remove playlist"), menu);
-            QObject::connect(removeAction, &QAction::triggered, this,
-                             [this, id]() { m_playlistHandler->removePlaylist(id); });
+            QObject::connect(removeAction, &QAction::triggered, this, [this, id]() {
+                if(confirmPlaylistRemoval(m_settings, this)) {
+                    m_playlistHandler->removePlaylist(id);
+                }
+            });
 
             menu->addAction(removeAction);
         }
@@ -542,13 +546,17 @@ void PlaylistTabs::setupConnections()
         }
         else if(m_settings->value<Settings::Gui::Internal::PlaylistTabsMiddleClose>()) {
             const auto id = m_tabs->tabBar()->tabData(index).value<UId>();
-            m_playlistHandler->removePlaylist(id);
+            if(confirmPlaylistRemoval(m_settings, this)) {
+                m_playlistHandler->removePlaylist(id);
+            }
         }
     });
     QObject::connect(m_tabs, &SingleTabbedWidget::tabCloseRequested, this, [this](const int index) {
         if(index >= 0) {
             const auto id = m_tabs->tabBar()->tabData(index).value<UId>();
-            m_playlistHandler->removePlaylist(id);
+            if(confirmPlaylistRemoval(m_settings, this)) {
+                m_playlistHandler->removePlaylist(id);
+            }
         }
     });
     QObject::connect(m_tabs, &SingleTabbedWidget::tabBarDoubleClicked, this, [this](const int index) {

--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -186,7 +186,7 @@ void Widgets::registerWidgets()
 
     provider->registerWidget(
         u"PlaylistSwitcher"_s,
-        [this]() { return new PlaylistBox(m_gui->actionManager(), m_playlistController, m_window); },
+        [this]() { return new PlaylistBox(m_gui->actionManager(), m_playlistController, m_settings, m_window); },
         tr("Playlist Switcher"));
     provider->setSubMenus(u"PlaylistSwitcher"_s, {tr("Playlist")});
 


### PR DESCRIPTION
## Summary

Deleting a playlist now shows a Yes/No confirmation dialog before it is removed, with a "Don't ask again" checkbox so users who don't want the prompt can opt out. This guards against accidental one-click deletions, which is the case raised in the issue (a shared setup where operators removed playlists without realising it).

## Why this matters

Every playlist removal path called `PlaylistHandler::removePlaylist` directly with no guard, so a single context-menu click, a middle-click on a tab, the close button, or the Ctrl+W shortcut would permanently drop a playlist. The confirmation is routed through one shared helper (`confirmPlaylistRemoval`) so all of these entry points behave consistently:

- `PlaylistBox::removeCurrentPlaylist` (src/gui/playlist/playlistbox.cpp)
- `PlaylistManagerWidget::removePlaylist` (src/gui/playlist/manager/playlistmanagerwidget.cpp)
- `PlaylistTabs` context-menu remove, middle-click close, and tab-close (src/gui/playlist/playlisttabs.cpp)
- The global "Remove Playlist" action / Ctrl+W (src/gui/guiapplication.cpp)
- The playlist organiser remove action, which only prompts when the selection actually contains playlists (src/gui/playlist/organiser/playlistorganiser.cpp)

The preference is stored as a new `GuiSettings::PlaylistRemovalConfirm` boolean (key `Playlist/RemovalConfirm`, default on), registered in src/gui/internalguisettings.cpp. Ticking "Don't ask again" and confirming sets it to false, after which removals skip the dialog. Autoplaylists share the same paths, so they are covered too.

## Testing

Qt6 is not available in my build environment, so I verified by hand and with clang-format rather than a full build:

- `clang-format --dry-run --Werror` passes on all changed files against the repo `.clang-format`.
- Confirmed the new setting reads/writes use the existing templated `settings->value<...>()` / `settings->set<...>()` API and the registration matches the surrounding `createSetting<Name>(default, u"Group/Key"_s)` style.
- Grepped every `removePlaylist` entry point to confirm each now routes through `confirmPlaylistRemoval`.

Fixes #1301
