### PR TITLE
[library] Fix deferred stats flush using queued stats snapshot

### DIFF
--- a/src/core/library/librarythreadhandler.cpp
+++ b/src/core/library/librarythreadhandler.cpp
@@ -764,10 +764,25 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
     struct PendingFlush
     {
         QString sourceKey;
-        Track track;
         std::optional<Track> metadataTrack;
+        std::optional<Track> statsTrack;
+        std::optional<Track> coverTrack;
         AudioReader::WriteOptions statsOptions{AudioReader::None};
         TrackCovers covers;
+
+        [[nodiscard]] Track primaryTrack() const
+        {
+            if(metadataTrack.has_value()) {
+                return *metadataTrack;
+            }
+            if(statsTrack.has_value()) {
+                return *statsTrack;
+            }
+            if(coverTrack.has_value()) {
+                return *coverTrack;
+            }
+            return {};
+        }
     };
 
     std::vector<PendingFlush> pendingFlushes;
@@ -799,26 +814,22 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
 
             if(const auto it = m_deferredMetadataWrites.find(sourceKey); it != m_deferredMetadataWrites.end()) {
                 pendingFlush.metadataTrack = it->second;
-                pendingFlush.track         = it->second;
             }
             if(const auto it = m_deferredStatWrites.find(sourceKey); it != m_deferredStatWrites.end()) {
-                if(!pendingFlush.track.isValid()) {
-                    pendingFlush.track = it->second.first;
-                }
+                pendingFlush.statsTrack   = it->second.first;
                 pendingFlush.statsOptions = it->second.second;
             }
             if(const auto it = m_deferredCoverWrites.find(sourceKey); it != m_deferredCoverWrites.end()) {
-                if(!pendingFlush.track.isValid()) {
-                    pendingFlush.track = it->second.first;
-                }
-                pendingFlush.covers = it->second.second;
+                pendingFlush.coverTrack = it->second.first;
+                pendingFlush.covers     = it->second.second;
             }
 
             m_deferredMetadataWrites.erase(sourceKey);
             m_deferredStatWrites.erase(sourceKey);
 
             if(!pendingFlush.covers.empty()) {
-                m_flushingCoverWriteData[sourceKey] = {pendingFlush.track, pendingFlush.covers};
+                const Track coverWriteTrack         = pendingFlush.coverTrack.value_or(pendingFlush.primaryTrack());
+                m_flushingCoverWriteData[sourceKey] = {coverWriteTrack, pendingFlush.covers};
                 m_flushingCoverWrites.emplace(sourceKey);
                 m_deferredCoverWrites.erase(sourceKey);
             }
@@ -831,17 +842,22 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
     }
 
     for(const PendingFlush& pendingFlush : pendingFlushes) {
-        if(pendingFlush.track.isValid()) {
+        const Track primaryTrack = pendingFlush.primaryTrack();
+        if(primaryTrack.isValid()) {
             QMetaObject::invokeMethod(&m_trackDatabaseManager, [this, pendingFlush]() {
+                const Track primaryWriteTrack = pendingFlush.primaryTrack();
+
                 if(pendingFlush.metadataTrack.has_value()) {
                     m_trackDatabaseManager.updateTracks({*pendingFlush.metadataTrack}, true);
                 }
                 if(pendingFlush.statsOptions != AudioReader::None) {
-                    m_trackDatabaseManager.updateTrackStats({pendingFlush.track}, pendingFlush.statsOptions);
+                    const Track statsWriteTrack = pendingFlush.statsTrack.value_or(primaryWriteTrack);
+                    m_trackDatabaseManager.updateTrackStats({statsWriteTrack}, pendingFlush.statsOptions);
                 }
                 if(!pendingFlush.covers.empty()) {
+                    const Track coverWriteTrack = pendingFlush.coverTrack.value_or(primaryWriteTrack);
                     m_trackDatabaseManager.writeCovers(
-                        TrackCoverData{.tracks = {pendingFlush.track}, .coverData = pendingFlush.covers});
+                        TrackCoverData{.tracks = {coverWriteTrack}, .coverData = pendingFlush.covers});
                     QMetaObject::invokeMethod(m_self, [this, sourceKey = pendingFlush.sourceKey]() {
                         {
                             const std::scoped_lock lock{m_deferredWritesMutex};

--- a/src/core/library/librarythreadhandler.cpp
+++ b/src/core/library/librarythreadhandler.cpp
@@ -770,18 +770,29 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
         AudioReader::WriteOptions statsOptions{AudioReader::None};
         TrackCovers covers;
 
-        [[nodiscard]] Track primaryTrack() const
+        [[nodiscard]] Track writeTrack() const
         {
+            Track track;
             if(metadataTrack.has_value()) {
-                return *metadataTrack;
+                track = *metadataTrack;
             }
-            if(statsTrack.has_value()) {
-                return *statsTrack;
+            else if(statsTrack.has_value()) {
+                track = *statsTrack;
             }
-            if(coverTrack.has_value()) {
-                return *coverTrack;
+            else if(coverTrack.has_value()) {
+                track = *coverTrack;
             }
-            return {};
+
+            if(statsTrack.has_value() && statsOptions.testFlag(AudioReader::Rating)) {
+                track.setRating(statsTrack->rating());
+            }
+            if(statsTrack.has_value() && statsOptions.testFlag(AudioReader::Playcount)) {
+                track.setPlayCount(statsTrack->playCount());
+                track.setFirstPlayed(statsTrack->firstPlayed());
+                track.setLastPlayed(statsTrack->lastPlayed());
+            }
+
+            return track;
         }
     };
 
@@ -828,8 +839,7 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
             m_deferredStatWrites.erase(sourceKey);
 
             if(!pendingFlush.covers.empty()) {
-                const Track coverWriteTrack         = pendingFlush.coverTrack.value_or(pendingFlush.primaryTrack());
-                m_flushingCoverWriteData[sourceKey] = {coverWriteTrack, pendingFlush.covers};
+                m_flushingCoverWriteData[sourceKey] = {pendingFlush.writeTrack(), pendingFlush.covers};
                 m_flushingCoverWrites.emplace(sourceKey);
                 m_deferredCoverWrites.erase(sourceKey);
             }
@@ -842,22 +852,18 @@ void LibraryThreadHandlerPrivate::flushPendingWritesForInactiveSources()
     }
 
     for(const PendingFlush& pendingFlush : pendingFlushes) {
-        const Track primaryTrack = pendingFlush.primaryTrack();
-        if(primaryTrack.isValid()) {
-            QMetaObject::invokeMethod(&m_trackDatabaseManager, [this, pendingFlush]() {
-                const Track primaryWriteTrack = pendingFlush.primaryTrack();
-
+        const Track writeTrack = pendingFlush.writeTrack();
+        if(writeTrack.isValid()) {
+            QMetaObject::invokeMethod(&m_trackDatabaseManager, [this, pendingFlush, writeTrack]() {
                 if(pendingFlush.metadataTrack.has_value()) {
-                    m_trackDatabaseManager.updateTracks({*pendingFlush.metadataTrack}, true);
+                    m_trackDatabaseManager.updateTracks({writeTrack}, true);
                 }
                 if(pendingFlush.statsOptions != AudioReader::None) {
-                    const Track statsWriteTrack = pendingFlush.statsTrack.value_or(primaryWriteTrack);
-                    m_trackDatabaseManager.updateTrackStats({statsWriteTrack}, pendingFlush.statsOptions);
+                    m_trackDatabaseManager.updateTrackStats({writeTrack}, pendingFlush.statsOptions);
                 }
                 if(!pendingFlush.covers.empty()) {
-                    const Track coverWriteTrack = pendingFlush.coverTrack.value_or(primaryWriteTrack);
                     m_trackDatabaseManager.writeCovers(
-                        TrackCoverData{.tracks = {coverWriteTrack}, .coverData = pendingFlush.covers});
+                        TrackCoverData{.tracks = {writeTrack}, .coverData = pendingFlush.covers});
                     QMetaObject::invokeMethod(m_self, [this, sourceKey = pendingFlush.sourceKey]() {
                         {
                             const std::scoped_lock lock{m_deferredWritesMutex};

--- a/tests/core/library/unifiedmusiclibrarytest.cpp
+++ b/tests/core/library/unifiedmusiclibrarytest.cpp
@@ -230,19 +230,32 @@ public:
     {
         void setTitle(const QString& path, const QString& title)
         {
-            const std::lock_guard lock(m_mutex);
+            const std::scoped_lock lock(m_mutex);
             m_titles.insert(QFileInfo{path}.absoluteFilePath(), title);
         }
 
         [[nodiscard]] QString titleForPath(const QString& path) const
         {
-            const std::lock_guard lock(m_mutex);
+            const std::scoped_lock lock(m_mutex);
             return m_titles.value(QFileInfo{path}.absoluteFilePath(), QFileInfo{path}.completeBaseName());
+        }
+
+        void addWrite(const Fooyin::Track& track, WriteOptions options)
+        {
+            const std::scoped_lock lock(m_mutex);
+            m_writes.emplace_back(track, options);
+        }
+
+        [[nodiscard]] std::vector<std::pair<Fooyin::Track, WriteOptions>> writes() const
+        {
+            const std::scoped_lock lock(m_mutex);
+            return m_writes;
         }
 
     private:
         mutable std::mutex m_mutex;
         QHash<QString, QString> m_titles;
+        std::vector<std::pair<Fooyin::Track, WriteOptions>> m_writes;
     };
 
     explicit FakeLibraryReader(std::shared_ptr<State> state)
@@ -261,7 +274,7 @@ public:
 
     bool canWriteMetaData() const override
     {
-        return false;
+        return true;
     }
 
     bool readTrack(const Fooyin::AudioSource& source, Fooyin::Track& track) override
@@ -275,6 +288,12 @@ public:
         const auto match = QRegularExpression{u"(\\d+)"_s}.match(info.completeBaseName());
         track.setTrackNumber(match.hasMatch() ? match.captured(1) : u"1"_s);
         track.setDiscNumber(u"1"_s);
+        return true;
+    }
+
+    bool writeTrack(const Fooyin::AudioSource& /*source*/, const Fooyin::Track& track, WriteOptions options) override
+    {
+        m_state->addWrite(track, options);
         return true;
     }
 
@@ -465,6 +484,44 @@ TEST_F(UnifiedMusicLibraryTest, TrackRescanUpdatesMetadataBeforeScanFinished)
 
     EXPECT_EQ(titleAtFinish, u"After"_s);
     EXPECT_EQ(context().library.trackForId(existingTrack.id()).title(), u"After"_s);
+}
+
+TEST_F(UnifiedMusicLibraryTest, DeferredWritesMergeMetadataAndStatsSnapshots)
+{
+    ASSERT_TRUE(context().settings.set<Settings::Core::SaveRatingToMetadata>(true));
+
+    createTrackFile(u"deferred_write.mp3"_s, u"Before"_s);
+
+    const LibraryInfo libraryInfo = addLibrary(u"Deferred Writes"_s);
+    ASSERT_GE(libraryInfo.id, 0);
+
+    waitForSuccessfulScan([&]() { return context().library.rescan(libraryInfo); });
+    ASSERT_EQ(context().library.tracks().size(), 1U);
+
+    const Track originalTrack = context().library.tracks().front();
+    context().library.setActivePlaybackTrack(originalTrack);
+
+    Track statsTrack{originalTrack};
+    statsTrack.setRating(0.8F);
+    context().library.updateTrackStats(statsTrack);
+
+    ASSERT_TRUE(waitForCondition([&]() { return context().library.trackForId(originalTrack.id()).rating() == 0.8F; }));
+
+    Track metadataTrack{originalTrack};
+    metadataTrack.setTitle(u"After"_s);
+    context().library.writeTrackMetadata({metadataTrack});
+    context().library.flushPendingWrites();
+
+    ASSERT_TRUE(waitForCondition([&]() { return context().readerState->writes().size() == 2U; }));
+
+    const auto writes = context().readerState->writes();
+    ASSERT_EQ(writes.size(), 2U);
+    EXPECT_EQ(writes.at(0).first.title(), u"After"_s);
+    EXPECT_FLOAT_EQ(writes.at(0).first.rating(), 0.8F);
+    EXPECT_TRUE(writes.at(0).second.testFlag(AudioReader::Metadata));
+    EXPECT_EQ(writes.at(1).first.title(), u"After"_s);
+    EXPECT_FLOAT_EQ(writes.at(1).first.rating(), 0.8F);
+    EXPECT_EQ(writes.at(1).second, AudioReader::Rating);
 }
 
 TEST_F(UnifiedMusicLibraryTest, OverlappingSortAndScanDoNotLoseNewTracks)


### PR DESCRIPTION
Prevent inactive-source deferred stats writes from reusing metadata-selected track snapshot, which could be stale and cause rating/playcount rollback after track transition. Refactor flush assembly to keep per-operation track selection explicit, reducing branch coupling and improving maintainability.

Fixes #1329