### PR TITLE
[gui] SelectionInfo: Refresh on metadata updates

### DIFF
--- a/src/gui/selectioninfo/infowidget.cpp
+++ b/src/gui/selectioninfo/infowidget.cpp
@@ -27,6 +27,7 @@
 
 #include <core/application.h>
 #include <core/coresettings.h>
+#include <core/library/musiclibrary.h>
 #include <core/player/playercontroller.h>
 #include <core/track.h>
 #include <gui/guiconstants.h>
@@ -227,10 +228,14 @@ InfoPanel::InfoPanel(Application* app, ActionManager* actionManager, TrackSelect
     m_view->header()->setSectionResizeMode(0, QHeaderView::Interactive);
     m_view->header()->setSectionResizeMode(1, QHeaderView::Fixed);
 
-    QObject::connect(selectionController, &TrackSelectionController::displaySelectionChanged, this,
-                     [this]() { m_resetTimer.start(50, this); });
-    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this,
-                     [this]() { m_resetTimer.start(50, this); });
+    const auto startResetTimer = [this] {
+        m_resetTimer.start(50, this);
+    };
+
+    QObject::connect(app->library(), &MusicLibrary::tracksMetadataChanged, this, startResetTimer);
+    QObject::connect(app->library(), &MusicLibrary::tracksUpdated, this, startResetTimer);
+    QObject::connect(selectionController, &TrackSelectionController::displaySelectionChanged, this, startResetTimer);
+    QObject::connect(m_playerController, &PlayerController::currentTrackChanged, this, startResetTimer);
     QObject::connect(m_model, &QAbstractItemModel::modelReset, this, [this]() { queueViewReset(); });
 
     setupActions();


### PR DESCRIPTION
Since [`1238269`](https://github.com/fooyin/fooyin/commit/123826953023d1e09545c880447899c3fd899775), selection info doesn't listen to `TrackSelectionController::selectionChanged()` anymore. This means that the previous live update path of `MusicLibrary::tracksMetadataChanged()` and `::tracksUpdated()` -> `TrackSelectionController::updateTracks()` -> `::selectionChanged()` doesn't work unless and until the user changes the track manually, otherwise e.g. playcount or RG updates won't be reflected. Fix by listening to the music library signals directly.

Edit: I only applied this to the standalone widget, not the constructor for the properties dialog, since my understanding is that the properties dialog is meant to be "static"/show metadata at the point where the file was opened. But I can change this if needed.