### PR TITLE
fix: preserve literal < and > in playlist script output

### DIFF
--- a/src/gui/scripting/scriptformatter.cpp
+++ b/src/gui/scripting/scriptformatter.cpp
@@ -180,10 +180,30 @@ void ScriptFormatterPrivate::errorAt(const ScriptScanner::Token& token, const QS
     m_errors.emplace_back(currentError);
 }
 
+namespace {
+// The formatter shares the query scanner, which also emits TokLeftAngle/TokRightAngle
+// for the keyword words "LESS"/"GREATER". A real bracket delimiter has the bracket
+// character as its value, so check the value rather than the type alone.
+bool isLiteralAngle(const ScriptScanner::Token& token, QChar bracket)
+{
+    return token.value.size() == 1 && token.value.front() == bracket;
+}
+
+bool isLeftAngle(const ScriptScanner::Token& token)
+{
+    return token.type == ScriptScanner::TokLeftAngle && isLiteralAngle(token, u'<');
+}
+
+bool isRightAngle(const ScriptScanner::Token& token)
+{
+    return token.type == ScriptScanner::TokRightAngle && isLiteralAngle(token, u'>');
+}
+} // namespace
+
 void ScriptFormatterPrivate::expression()
 {
     advance();
-    if(m_previous.type == ScriptScanner::TokLeftAngle) {
+    if(isLeftAngle(m_previous)) {
         formatBlock();
     }
     else if(m_previous.type == ScriptScanner::TokEscape) {
@@ -197,13 +217,29 @@ void ScriptFormatterPrivate::expression()
 
 void ScriptFormatterPrivate::formatBlock()
 {
-    const FormatTag tag = parseFormatTag(readTagContent());
-    consume(ScriptScanner::TokRightAngle, u"Expected '>' after expression"_s);
+    const QString rawContent   = readTagContent();
+    const bool hasClosingAngle = isRightAngle(m_current);
+    const FormatTag tag        = parseFormatTag(rawContent);
 
-    if(tag.name.isEmpty()) {
-        error(u"Format option not found"_s);
+    // A genuine formatting tag opens with '<' immediately followed by a recognised
+    // formatter name and closes with '>'. Anything else (e.g. "<3", "a < b >",
+    // "<notatag>") is literal text the user wants shown verbatim, so emit the original
+    // "<...>" sequence instead of dropping it. Option validity is left to
+    // processFormat() so a known tag with a bad option still renders its inner text.
+    const bool isFormatTag = hasClosingAngle && !rawContent.isEmpty() && !rawContent.front().isSpace()
+                          && ScriptFormatterRegistry::isKnown(tag.name);
+
+    if(!isFormatTag) {
+        m_currentBlock.text += u'<';
+        m_currentBlock.text += rawContent;
+        if(hasClosingAngle) {
+            m_currentBlock.text += u'>';
+            advance();
+        }
         return;
     }
+
+    consume(ScriptScanner::TokRightAngle, u"Expected '>' after expression"_s);
 
     processFormat(tag);
     closeBlock();
@@ -213,12 +249,15 @@ QString ScriptFormatterPrivate::readTagContent()
 {
     QString content;
 
-    while(m_current.type != ScriptScanner::TokRightAngle && m_current.type != ScriptScanner::TokEos) {
+    // Stop at a nested '<' as well as '>'/EOS: a real formatting tag never contains
+    // a '<' in its content, so encountering one means the current '<' is literal text
+    // and must not consume the following tag's opening delimiter.
+    while(!isRightAngle(m_current) && !isLeftAngle(m_current) && m_current.type != ScriptScanner::TokEos) {
         content.append(m_current.value);
         advance();
     }
 
-    return content.trimmed();
+    return content;
 }
 
 QString ScriptFormatterPrivate::peekClosingTagName()

--- a/tests/gui/scriptformattertest.cpp
+++ b/tests/gui/scriptformattertest.cpp
@@ -142,4 +142,77 @@ TEST_F(ScriptFormatterTest, Link)
     EXPECT_EQ(u"https://example.com"_s, result.blocks.front().format.link);
     EXPECT_TRUE(result.blocks.front().format.font.underline());
 }
+
+namespace {
+QString blockText(const RichText& result)
+{
+    QString text;
+    for(const auto& block : result.blocks) {
+        text += block.text;
+    }
+    return text;
+}
+} // namespace
+
+TEST_F(ScriptFormatterTest, LiteralAngleBracketsWithSpaces)
+{
+    const auto result = m_formattter.evaluate(u"a < b > c"_s);
+    EXPECT_EQ(u"a < b > c"_s, blockText(result));
+}
+
+TEST_F(ScriptFormatterTest, LiteralLessThanNumber)
+{
+    const auto result = m_formattter.evaluate(u"I <3 this"_s);
+    EXPECT_EQ(u"I <3 this"_s, blockText(result));
+}
+
+TEST_F(ScriptFormatterTest, UnknownTagKeptLiteral)
+{
+    const auto result = m_formattter.evaluate(u"<notatag>rest"_s);
+    EXPECT_EQ(u"<notatag>rest"_s, blockText(result));
+}
+
+TEST_F(ScriptFormatterTest, BoldStillFormatsWithLiteralPreserved)
+{
+    const auto result = m_formattter.evaluate(u"<b>bold</b>"_s);
+    ASSERT_EQ(1, result.size());
+    EXPECT_TRUE(result.blocks.front().format.font.bold());
+    EXPECT_EQ(u"bold"_s, result.blocks.front().text);
+}
+
+TEST_F(ScriptFormatterTest, LiteralBeforeFormattingTag)
+{
+    const auto result = m_formattter.evaluate(u"I <3 <b>this</b>"_s);
+    EXPECT_EQ(u"I <3 this"_s, blockText(result));
+
+    bool foundBold{false};
+    for(const auto& block : result.blocks) {
+        if(block.text == u"this"_s) {
+            foundBold = block.format.font.bold();
+        }
+    }
+    EXPECT_TRUE(foundBold);
+}
+
+TEST_F(ScriptFormatterTest, LiteralInsideFormattingTag)
+{
+    const auto result = m_formattter.evaluate(u"<b>I <3 this</b>"_s);
+    ASSERT_EQ(1, result.size());
+    EXPECT_TRUE(result.blocks.front().format.font.bold());
+    EXPECT_EQ(u"I <3 this"_s, result.blocks.front().text);
+}
+
+TEST_F(ScriptFormatterTest, LiteralUppercaseKeywordTag)
+{
+    // "LESS"/"GREATER" are scanner keywords that share the angle token types; they must
+    // still round-trip as literal text rather than be mistaken for bracket delimiters.
+    const auto result = m_formattter.evaluate(u"<LESS>"_s);
+    EXPECT_EQ(u"<LESS>"_s, blockText(result));
+}
+
+TEST_F(ScriptFormatterTest, LiteralKeywordWordPreserved)
+{
+    const auto result = m_formattter.evaluate(u"5 LESS than 6"_s);
+    EXPECT_EQ(u"5 LESS than 6"_s, blockText(result));
+}
 } // namespace Fooyin::Testing


### PR DESCRIPTION
## Summary
Literal `<` and `>` characters now display in the playlist instead of being silently dropped. A title like `<3` or `a > b` renders as written, with no need for the `\<` escape workaround.

## Why this matters
The playlist runs script output through a second formatting pass, and `ScriptFormatter` treated every `<...>` sequence as a formatting tag (issue #1224). Unrecognised angle-bracket content was consumed and discarded. In `src/gui/scripting/scriptformatter.cpp`, `formatBlock()` now only enters tag processing when the text after `<` is a recognised formatter (via `ScriptFormatterRegistry::isKnown`) that closes with `>`; otherwise it emits the original `<...>` text verbatim. `readTagContent()` stops at a nested `<` so a literal `<` cannot swallow a following real tag, and angle detection checks the token value so the scanner keywords `LESS`/`GREATER` are not mistaken for bracket characters. Known tags with bad options still fall through to `processFormat()` and render their inner text.

## Testing
Added cases to `tests/gui/scriptformattertest.cpp` covering literal brackets with spaces (`a < b > c`), `I <3 this`, an unknown tag kept literal (`<notatag>rest`), literal text mixed with real formatting (`I <3 <b>this</b>` and `<b>I <3 this</b>`), and the keyword words (`<LESS>`, `5 LESS than 6`). Existing bold/italic/colour/link tests continue to assert no regression. The Qt6 toolchain is not installed in this environment, so the suite was not run here; clang-format passes on both files.

Fixes #1224
