### PR TITLE
[utils,gui] Honour preferred fallback encoding for low-confidence charset matches

### DIFF
--- a/src/gui/widgets.cpp
+++ b/src/gui/widgets.cpp
@@ -588,9 +588,10 @@ void Widgets::registerAdvancedSettings()
         Utils::PreferredFallbackEncodingSetting, QString{},
         {.category    = {tr("General"), tr("Text Encoding")},
          .label       = tr("Preferred fallback encoding"),
-         .description = tr("Encoding preferred when the best automatic match is Latin-compatible single-byte text"),
+         .description = tr("Encoding preferred when the best automatic match is low-confidence or Latin-compatible text"),
          .editor = AdvancedSettingRadioButtons{.options = {{.value = QString{}, .label = tr("Auto")},
-                                                           {.value = u"windows-1251"_s, .label = u"Windows-1251"_s}}},
+                                                           {.value = u"windows-1251"_s, .label = u"Windows-1251"_s},
+                                                           {.value = u"GB18030"_s, .label = u"GB18030"_s}}},
          .normalise = {},
          .validate  = {}});
     advancedSettingsRegistry->add(

--- a/src/utils/stringutils.cpp
+++ b/src/utils/stringutils.cpp
@@ -116,7 +116,13 @@ QString capitalise(const QString& str)
 
 QByteArray detectEncoding(const QByteArray& content, const DetectEncodingOptions& options)
 {
+    if(content.isEmpty()) {
+        return {};
+    }
+
     QByteArray encoding;
+    constexpr int32_t LowConfidenceFallbackThreshold{50};
+    int32_t encodingConfidence{100};
     UErrorCode status{U_ZERO_ERROR};
 
     UCharsetDetector* csd = ucsdet_open(&status);
@@ -153,11 +159,18 @@ QByteArray detectEncoding(const QByteArray& content, const DetectEncodingOptions
             }
 
             if(encoding.isEmpty()) {
+                UErrorCode confidenceStatus{U_ZERO_ERROR};
+                const int32_t confidence = ucsdet_getConfidence(matches[i], &confidenceStatus);
+                if(U_SUCCESS(confidenceStatus)) {
+                    encodingConfidence = confidence;
+                }
                 encoding = candidate;
             }
         }
 
-        if(!preferredFallbackEncoding.isEmpty() && isLatinEncoding(encoding)) {
+        // ICU confidence is 0-100; below 50 is ambiguous enough to honour the user's fallback.
+        if(!preferredFallbackEncoding.isEmpty()
+           && (isLatinEncoding(encoding) || encodingConfidence < LowConfidenceFallbackThreshold)) {
             encoding = preferredFallbackEncoding;
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ fooyin_add_test(test_guiutils gui/guiutilstest.cpp)
 fooyin_add_test(test_scriptformatter gui/scriptformattertest.cpp)
 
 fooyin_add_test(test_helpers utils/helperstest.cpp)
+fooyin_add_test(test_stringutils utils/stringutilstest.cpp)
 
 set(FILTERS_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/plugins/filters)
 set(FILTER_PIPELINE_TEST_SOURCES ${FILTERS_SOURCE_DIR}/filterpipeline.cpp ${FILTERS_SOURCE_DIR}/filterrows.cpp)

--- a/tests/utils/stringutilstest.cpp
+++ b/tests/utils/stringutilstest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <utils/stringutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+
+namespace Fooyin::Testing {
+TEST(UtilsStringTest, DetectEncodingKeepsHighConfidenceUtf8WithPreferredFallback)
+{
+    const QByteArray data = QByteArray::fromHex("48656c6c6f20e4b896e7958c");
+
+    EXPECT_EQ(Utils::detectEncoding(data, {.preferredFallbackEncoding = "GB18030"}), "UTF-8");
+}
+
+TEST(UtilsStringTest, DetectEncodingUsesPreferredFallbackForLowConfidenceCjkMatch)
+{
+    const QByteArray data = QByteArray::fromHex("b0aec4e3b2bbcac7c1bdc8fdccec");
+
+    EXPECT_EQ(Utils::detectEncoding(data, {.preferredFallbackEncoding = "GB18030"}), "GB18030");
+}
+
+TEST(UtilsStringTest, DetectEncodingKeepsTopMatchWithoutPreferredFallback)
+{
+    const QByteArray data = QByteArray::fromHex("b0aec4e3b2bbcac7c1bdc8fdccec");
+
+    EXPECT_EQ(Utils::detectEncoding(data), "windows-1256");
+}
+
+TEST(UtilsStringTest, DetectEncodingStillPrefersFallbackForLatinTopMatch)
+{
+    const QByteArray data
+        = QByteArray::fromHex("5449544c452022cff0e5e4e2e5f1f2ede8ea220a504552464f524d45522022caedff5a7a22");
+
+    EXPECT_EQ(Utils::detectEncoding(data, {.preferredFallbackEncoding = "windows-1251"}), "windows-1251");
+}
+
+TEST(UtilsStringTest, DetectEncodingReturnsEmptyForEmptyContent)
+{
+    EXPECT_TRUE(Utils::detectEncoding({}, {.preferredFallbackEncoding = "GB18030"}).isEmpty());
+}
+} // namespace Fooyin::Testing


### PR DESCRIPTION
## Summary

Broadens `Fooyin::Utils::detectEncoding` so a user-configured preferred fallback encoding is also honoured when ICU's top match is low-confidence, not only when it is a Latin single-byte encoding, and exposes `GB18030` as a selectable fallback in settings.

## Background

`detectEncoding` already supports the `Encoding/PreferredFallbackEncoding` setting, but it only applied that fallback when ICU's top auto-detected match was a Latin single-byte encoding. When ICU instead picks the wrong multi-byte CJK encoding, the configured fallback was ignored.

This is the lyrics half of #1288: an `インフェルノ (Inferno).lrc` file is GB18030-encoded, but ICU's detector guesses EUC-JP (likely because of the kana bytes near the start), so the lyrics render as mojibake even with a fallback configured. The setting also did not offer GB18030 as an option, so a user could not select it from the UI to correct the case at all.

## What changed

- `detectEncoding` now also honours the preferred fallback when the top auto-detected match has low ICU confidence (read via `ucsdet_getConfidence`), in addition to the existing Latin-match case. The preferred encoding still has to be able to decode the content (`canDecode`), and a high-confidence top match is left untouched, so existing correct detections are unaffected. Empty content returns early with no result.
- Added `GB18030` to the "Preferred fallback encoding" advanced setting and broadened its description to reflect that the fallback now also applies to low-confidence matches.

## Testing

Added `tests/utils/stringutilstest.cpp` (registered as `test_stringutils`) covering:

- a high-confidence UTF-8 match is unaffected by a preferred fallback;
- a low-confidence non-Latin match with a decodable preferred fallback returns the fallback;
- the top match wins when no fallback is configured;
- the existing Latin-misdetection fallback path still overrides;
- empty content returns an empty result.

## Scope

This addresses the lyrics/text encoding-detection half of the issue. The artist/track name garbling the reporter saw traced to the TagLib reader (confirmed in the thread by disabling that reader), which is a separate concern, so this references rather than closes the issue.

Refs #1288
