### PR TITLE
[gui] IconLoader: Fix pixmap DPR scaling

### DIFF
--- a/src/gui/iconloader.cpp
+++ b/src/gui/iconloader.cpp
@@ -235,7 +235,7 @@ void drawItemViewIcon(QPainter* painter, const QStyleOptionViewItem& option, con
     }
     const qreal dpr = option.widget ? option.widget->devicePixelRatioF() : qApp->devicePixelRatio();
 
-    QPixmap pixmap = icon.pixmap(rect.size() * dpr, dpr, mode);
+    QPixmap pixmap = icon.pixmap(rect.size(), dpr, mode);
     QPainter pixmapPainter{&pixmap};
     pixmapPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
     pixmapPainter.fillRect(pixmap.rect(), option.palette.color(group, role));


### PR DESCRIPTION
We pass the DPR into `QIcon::pixmap()` already so there is no need to scale the size. Fixes #1327 for me.