### PR TITLE
[core] Always defer playcount updates on current track

### DIFF
--- a/src/core/library/librarythreadhandler.cpp
+++ b/src/core/library/librarythreadhandler.cpp
@@ -980,10 +980,10 @@ void LibraryThreadHandlerPrivate::flushTrackStatsUpdates()
 
         if(isActiveSource(track)) {
             AudioReader::WriteOptions deferredOptions{AudioReader::None};
-            if(pendingUpdate.writeRating && m_settings->value<Settings::Core::SaveRatingToMetadata>()) {
+            if(pendingUpdate.writeRating) {
                 deferredOptions |= AudioReader::Rating;
             }
-            if(pendingUpdate.writePlaycount && m_settings->value<Settings::Core::SavePlaycountToMetadata>()) {
+            if(pendingUpdate.writePlaycount) {
                 deferredOptions |= AudioReader::Playcount;
             }
             queuePendingStatWrite(track, deferredOptions);


### PR DESCRIPTION
This patch fixes an edge case, reproducible as follows:

1. Disable the "Save playcounts to file tags when possible" setting.
2. Play a track.
3. Edit any metadata of the current track.
4. Wait until the playcount increments. The selection info playcount will update accordingly.
5. Switch to a different track (so pending updates are flushed) and then back to the first track. Selection info will now show the previous playcount instead. This can only be fixed by restarting fooyin.

When repeating steps 2 to 5, all but the newest increment will be discarded (e.g. if the initial playcount was 5, doing these steps three times will result in the DB playcount being 6 instead of 8).

This is because when we have a pending metadata flush, `flushPendingWritesForInactiveSources()` will use a stale playcount since we never added the new one to `m_deferredStatWrites`. I haven't been able to reproduce this for ratings.

Fix: Queue the playcount update even if the setting to save to file tags is false. The setting is checked again by the track database manager so it is safe to do.