### PR TITLE
[tageditor] Fix renaming extended tags

### DIFF
--- a/src/plugins/tageditor/tageditoritem.cpp
+++ b/src/plugins/tageditor/tageditoritem.cpp
@@ -354,13 +354,13 @@ void TagEditorItem::applyChanges(const TagEditorField& field)
     m_field = field;
 
     if(m_titleChanged) {
-        m_field.name = m_changedTitle;
+        m_field.name     = m_changedTitle;
+        m_values         = m_changedValues;
+        m_valueCharCount = std::accumulate(m_values.cbegin(), m_values.cend(), 0,
+                                           [](int sum, const QString& str) { return sum + str.length(); });
+        m_value          = m_changedValue;
     }
 
-    m_values         = m_changedValues;
-    m_valueCharCount = std::accumulate(m_values.cbegin(), m_values.cend(), 0,
-                                       [](int sum, const QString& str) { return sum + str.length(); });
-    m_value          = m_changedValue;
     reset();
 }
 

--- a/src/plugins/tageditor/tageditoritem.cpp
+++ b/src/plugins/tageditor/tageditoritem.cpp
@@ -354,7 +354,9 @@ void TagEditorItem::applyChanges(const TagEditorField& field)
     m_field = field;
 
     if(m_titleChanged) {
-        m_field.name     = m_changedTitle;
+        m_field.name = m_changedTitle;
+    }
+    if(m_valueChanged) {
         m_values         = m_changedValues;
         m_valueCharCount = std::accumulate(m_values.cbegin(), m_values.cend(), 0,
                                            [](int sum, const QString& str) { return sum + str.length(); });

--- a/src/plugins/tageditor/tageditormodel.cpp
+++ b/src/plugins/tageditor/tageditormodel.cpp
@@ -511,17 +511,18 @@ void TagEditorModel::applyChanges()
                         return tag.second.title() == node.title();
                     });
                     if(fieldIt != p->m_tags.end()) {
-                        auto tagItem      = p->m_tags.extract(fieldIt);
-                        field.scriptField = tagItem.key();
+                        const QString changedTitle = node.changedTitle();
+                        auto tagItem               = p->m_tags.extract(fieldIt);
+                        field.scriptField          = tagItem.key();
                         if(p->updateTrackMetadata(field, {})) {
-                            const QString key = node.changedTitle();
-                            tagItem.key()     = key;
+                            tagItem.key() = changedTitle;
                             p->m_tags.insert(std::move(tagItem));
                         }
+                        field.scriptField = changedTitle;
                     }
                 }
 
-                if(p->updateTrackMetadata(node.field(), node.valueChanged() ? node.changedValue() : node.value(),
+                if(p->updateTrackMetadata(field, node.valueChanged() ? node.changedValue() : node.value(),
                                           node.splitTrackValues())) {
                     node.applyChanges(field);
                     node.setSplitTrackValues(false);


### PR DESCRIPTION
This patch fixes tag renames in the tag editor not being saved.

We were using `node.field()` instead of the modified `field` for the `updateTracksMetadata()` call, which led to the original tag name being saved instead. We also weren't showing the value of the renamed field until the tab was switched or the widget was reopened.