### PR TITLE
[oscilloscope] Add Oscilloscope visualisation plugin

### DIFF
--- a/src/core/engine/visualisationbackend.cpp
+++ b/src/core/engine/visualisationbackend.cpp
@@ -428,11 +428,37 @@ bool VisualisationBackend::getPcmWindowEndingAt(VisualisationSession::PcmWindow&
 
     WindowRange window;
     const int requestedFrames = std::max(1, m_format.framesForDuration(std::max<uint64_t>(1, durationMs)));
-    if(!resolveWindow(window, endTimeMs, requestedFrames, 1, WindowAnchor::End)) {
+    if(!resolvePcmWindowEndingAt(window, endTimeMs, requestedFrames, 1)) {
         return false;
     }
 
     return fillWindow(out, window.startFrame, window.frameCount, selection);
+}
+
+bool VisualisationBackend::resolvePcmWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
+                                                    int minimumFrameCount) const
+{
+    if(std::cmp_less(m_frameCount, minimumFrameCount) || !m_format.isValid() || m_format.sampleRate() <= 0
+       || m_format.channelCount() <= 0 || requestedFrameCount < minimumFrameCount) {
+        return false;
+    }
+
+    const uint64_t timeFrame       = msToFrames(endTimeMs, m_format.sampleRate());
+    const uint64_t clampedEndFrame = std::min(timeFrame, m_nextStreamFrame);
+    if(clampedEndFrame <= m_startStreamFrame) {
+        return false;
+    }
+
+    const uint64_t availableFrames = clampedEndFrame - m_startStreamFrame;
+    const int frameCount
+        = static_cast<int>(std::min<uint64_t>(static_cast<uint64_t>(requestedFrameCount), availableFrames));
+    if(frameCount < minimumFrameCount) {
+        return false;
+    }
+
+    out.startFrame = clampedEndFrame - static_cast<uint64_t>(frameCount);
+    out.frameCount = frameCount;
+    return true;
 }
 
 bool VisualisationBackend::getSpectrumWindow(VisualisationSession::SpectrumWindow& out, uint64_t centerTimeMs,

--- a/src/core/engine/visualisationbackend.h
+++ b/src/core/engine/visualisationbackend.h
@@ -98,6 +98,8 @@ private:
     [[nodiscard]] static uint64_t msToFrames(uint64_t ms, int sampleRate);
     [[nodiscard]] bool resolveWindow(WindowRange& out, uint64_t timeMs, int requestedFrameCount, int minimumFrameCount,
                                      WindowAnchor anchor) const;
+    [[nodiscard]] bool resolvePcmWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
+                                                int minimumFrameCount) const;
     [[nodiscard]] bool resolveSpectrumWindowEndingAt(WindowRange& out, uint64_t endTimeMs, int requestedFrameCount,
                                                      int minimumFrameCount) const;
     [[nodiscard]] uint64_t mapSourceTimeToVisualTime(uint32_t streamId, uint64_t sourceTimeMs) const;

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -12,6 +12,7 @@ set(FOOYIN_KNOWN_PLUGINS
     mediacontrol
     mpris
     notify
+    oscilloscope
     nowplaying
     openmpt
     pipewire
@@ -43,6 +44,7 @@ set(FOOYIN_DEFAULT_PLUGINS
     gme
     libarchive
     lyrics
+    oscilloscope
     openmpt
     pipewire
     quicktagger
@@ -121,6 +123,7 @@ fooyin_add_selected_plugin(filters)
 fooyin_add_selected_plugin(gme)
 fooyin_add_selected_plugin(libarchive)
 fooyin_add_selected_plugin(lyrics)
+fooyin_add_selected_plugin(oscilloscope)
 fooyin_add_selected_plugin(openmpt)
 fooyin_add_selected_plugin(pipewire)
 fooyin_add_selected_plugin(pulseaudio)

--- a/src/plugins/oscilloscope/CMakeLists.txt
+++ b/src/plugins/oscilloscope/CMakeLists.txt
@@ -1,0 +1,11 @@
+create_fooyin_plugin_internal(
+    oscilloscope
+    DEPENDS Fooyin::Gui
+    SOURCES oscilloscopecolours.h
+            oscilloscopeconfigwidget.cpp
+            oscilloscopeconfigwidget.h
+            oscilloscopeplugin.cpp
+            oscilloscopeplugin.h
+            oscilloscopewidget.cpp
+            oscilloscopewidget.h
+)

--- a/src/plugins/oscilloscope/oscilloscope.json.in
+++ b/src/plugins/oscilloscope/oscilloscope.json.in
@@ -1,0 +1,15 @@
+{
+    "Name" : "Oscilloscope",
+    "Version" : "${FOOYIN_VERSION}",
+    "Author" : "fooyin",
+    "Copyright" : "Copyright © 2026, Luke Taylor <luket@pm.me>",
+    "License" : [ "Fooyin is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
+                  "",
+                  "Fooyin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.",
+                  "",
+                  "You should have received a copy of the GNU General Public License along with Fooyin.  If not, see <http://www.gnu.org/licenses/>"
+                ],
+    "Category" : "Widgets",
+    "Description" : "Adds a live oscilloscope widget",
+    "Url" : "https://github.com/ludouzi/fooyin"
+}

--- a/src/plugins/oscilloscope/oscilloscopecolours.h
+++ b/src/plugins/oscilloscope/oscilloscopecolours.h
@@ -1,0 +1,83 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QColor>
+#include <QPalette>
+
+namespace Fooyin::Oscilloscope {
+class Colours
+{
+public:
+    enum class Type : uint8_t
+    {
+        Background = 0,
+        Waveform,
+        ZeroLine
+    };
+
+    void setColour(Type type, const QColor& colour)
+    {
+        switch(type) {
+            case Type::Background:
+                m_background = colour;
+                break;
+            case Type::Waveform:
+                m_waveform = colour;
+                break;
+            case Type::ZeroLine:
+                m_zeroLine = colour;
+                break;
+        }
+    }
+
+    [[nodiscard]] QColor colour(Type type, const QPalette& palette) const
+    {
+        switch(type) {
+            case Type::Background:
+                return m_background.isValid() ? m_background : palette.color(QPalette::Window);
+            case Type::Waveform:
+                return m_waveform.isValid() ? m_waveform : palette.color(QPalette::Text);
+            case Type::ZeroLine: {
+                if(m_zeroLine.isValid()) {
+                    return m_zeroLine;
+                }
+                QColor zeroLine{colour(Type::Waveform, palette)};
+                zeroLine.setAlpha(96);
+                return zeroLine;
+            }
+        }
+
+        return {};
+    }
+
+    [[nodiscard]] bool isEmpty() const
+    {
+        return !m_background.isValid() && !m_waveform.isValid() && !m_zeroLine.isValid();
+    }
+
+private:
+    QColor m_background;
+    QColor m_waveform;
+    QColor m_zeroLine;
+};
+} // namespace Fooyin::Oscilloscope
+
+Q_DECLARE_METATYPE(Fooyin::Oscilloscope::Colours)

--- a/src/plugins/oscilloscope/oscilloscopeconfigwidget.cpp
+++ b/src/plugins/oscilloscope/oscilloscopeconfigwidget.cpp
@@ -1,0 +1,178 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "oscilloscopeconfigwidget.h"
+
+#include "oscilloscopecolours.h"
+
+#include <gui/framerate.h>
+#include <gui/widgets/colourbutton.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QIntValidator>
+#include <QLabel>
+#include <QLineEdit>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Oscilloscope {
+OscilloscopeConfigDialog::OscilloscopeConfigDialog(OscilloscopeWidget* oscilloscope, QWidget* parent)
+    : WidgetConfigDialog{oscilloscope, tr("Oscilloscope Settings"), parent}
+    , m_curveDurationMs{new QComboBox(this)}
+    , m_zoomPercent{new QComboBox(this)}
+    , m_updateFps{new QComboBox(this)}
+    , m_downmixMode{new QComboBox(this)}
+    , m_showZeroLine{new QCheckBox(tr("Show zero line"), this)}
+    , m_colourGroup{new QGroupBox(tr("Custom colours"), this)}
+    , m_backgroundColour{new ColourButton(this)}
+    , m_waveformColour{new ColourButton(this)}
+    , m_zeroLineColour{new ColourButton(this)}
+{
+    auto* generalGroup  = new QGroupBox(tr("General"), this);
+    auto* generalLayout = new QGridLayout(generalGroup);
+
+    for(const int durationMs : OscilloscopeWidget::CurveDurationPresets) {
+        m_curveDurationMs->addItem(QString::number(durationMs), durationMs);
+    }
+    m_curveDurationMs->setEditable(true);
+    m_curveDurationMs->setInsertPolicy(QComboBox::NoInsert);
+    m_curveDurationMs->lineEdit()->setValidator(new QIntValidator(
+        OscilloscopeWidget::MinCurveDurationMs, OscilloscopeWidget::MaxCurveDurationMs, m_curveDurationMs));
+    m_curveDurationMs->setToolTip(tr("Time span of audio displayed across the oscilloscope"));
+
+    for(const int zoomPercent : OscilloscopeWidget::ZoomPresets) {
+        m_zoomPercent->addItem(QString::number(zoomPercent), zoomPercent);
+    }
+    m_zoomPercent->setEditable(true);
+    m_zoomPercent->setInsertPolicy(QComboBox::NoInsert);
+    m_zoomPercent->lineEdit()->setValidator(
+        new QIntValidator(OscilloscopeWidget::MinZoomPercent, OscilloscopeWidget::MaxZoomPercent, m_zoomPercent));
+    m_zoomPercent->setToolTip(tr("Vertical amplitude scale; high values may overlap stereo channels"));
+
+    for(const auto preset : Gui::FrameRate::Presets) {
+        const int fps = Gui::FrameRate::toFps(preset);
+        m_updateFps->addItem(tr("%1 fps").arg(fps), fps);
+    }
+    m_updateFps->setToolTip(tr("Maximum waveform refresh rate; lower values can reduce motion blending"));
+
+    m_downmixMode->addItem(tr("Stereo"), static_cast<int>(OscilloscopeWidget::DownmixMode::Stereo));
+    m_downmixMode->addItem(tr("Mono"), static_cast<int>(OscilloscopeWidget::DownmixMode::Mono));
+    m_downmixMode->setToolTip(tr("Display separate stereo channels or combine them into mono"));
+
+    int row = 0;
+    generalLayout->addWidget(new QLabel(tr("Curve duration (ms)") + ":"_L1, this), row, 0);
+    generalLayout->addWidget(m_curveDurationMs, row++, 1);
+    generalLayout->addWidget(new QLabel(tr("Zoom (%)") + ":"_L1, this), row, 0);
+    generalLayout->addWidget(m_zoomPercent, row++, 1);
+    generalLayout->addWidget(new QLabel(tr("Update FPS") + ":"_L1, this), row, 0);
+    generalLayout->addWidget(m_updateFps, row++, 1);
+    generalLayout->addWidget(new QLabel(tr("Downmix mode") + ":"_L1, this), row, 0);
+    generalLayout->addWidget(m_downmixMode, row++, 1);
+    generalLayout->addWidget(m_showZeroLine, row++, 0, 1, 2);
+    generalLayout->setColumnStretch(2, 1);
+
+    m_colourGroup->setCheckable(true);
+    auto* coloursLayout = new QGridLayout(m_colourGroup);
+
+    row = 0;
+    coloursLayout->addWidget(new QLabel(tr("Background colour") + ":"_L1, this), row, 0);
+    coloursLayout->addWidget(m_backgroundColour, row++, 1);
+    coloursLayout->addWidget(new QLabel(tr("Waveform colour") + ":"_L1, this), row, 0);
+    coloursLayout->addWidget(m_waveformColour, row++, 1);
+    coloursLayout->addWidget(new QLabel(tr("Zero line colour") + ":"_L1, this), row, 0);
+    coloursLayout->addWidget(m_zeroLineColour, row++, 1);
+    coloursLayout->setColumnStretch(1, 1);
+
+    auto* layout{contentLayout()};
+    layout->addWidget(generalGroup, 0, 0);
+    layout->addWidget(m_colourGroup, 0, 1);
+    layout->setRowStretch(layout->rowCount(), 1);
+
+    loadCurrentConfig();
+}
+
+OscilloscopeWidget::ConfigData OscilloscopeConfigDialog::config() const
+{
+    OscilloscopeWidget::ConfigData config{
+        .curveDurationMs = m_curveDurationMs->currentText().toInt(),
+        .zoomPercent     = m_zoomPercent->currentText().toInt(),
+        .updateFps       = m_updateFps->currentData().toInt(),
+        .downmixMode     = static_cast<OscilloscopeWidget::DownmixMode>(m_downmixMode->currentData().toInt()),
+        .showZeroLine    = m_showZeroLine->isChecked(),
+        .colours         = QVariant{},
+    };
+
+    if(m_colourGroup->isChecked()) {
+        Colours colours;
+        colours.setColour(Colours::Type::Background, m_backgroundColour->colour());
+        colours.setColour(Colours::Type::Waveform, m_waveformColour->colour());
+        colours.setColour(Colours::Type::ZeroLine, m_zeroLineColour->colour());
+        config.colours = QVariant::fromValue(colours);
+    }
+
+    return config;
+}
+
+void OscilloscopeConfigDialog::setConfig(const OscilloscopeWidget::ConfigData& config)
+{
+    const int durationIndex = m_curveDurationMs->findData(config.curveDurationMs);
+    if(durationIndex >= 0) {
+        m_curveDurationMs->setCurrentIndex(durationIndex);
+    }
+    else {
+        m_curveDurationMs->setEditText(QString::number(config.curveDurationMs));
+    }
+
+    const int zoomIndex = m_zoomPercent->findData(config.zoomPercent);
+    if(zoomIndex >= 0) {
+        m_zoomPercent->setCurrentIndex(zoomIndex);
+    }
+    else {
+        m_zoomPercent->setEditText(QString::number(config.zoomPercent));
+    }
+
+    const int nearestFps = Gui::FrameRate::nearestPresetFps(config.updateFps);
+    int fpsIndex         = m_updateFps->findData(nearestFps);
+    if(fpsIndex < 0) {
+        fpsIndex = m_updateFps->findData(OscilloscopeWidget::DefaultUpdateFps);
+    }
+    m_updateFps->setCurrentIndex(fpsIndex);
+
+    int downmixIndex = m_downmixMode->findData(static_cast<int>(config.downmixMode));
+    if(downmixIndex < 0) {
+        downmixIndex = m_downmixMode->findData(static_cast<int>(OscilloscopeWidget::DownmixMode::Stereo));
+    }
+    m_downmixMode->setCurrentIndex(downmixIndex);
+    m_showZeroLine->setChecked(config.showZeroLine);
+
+    const bool customColours = config.colours.isValid() && config.colours.canConvert<Colours>()
+                            && !config.colours.value<Colours>().isEmpty();
+    const Colours colours    = customColours ? config.colours.value<Colours>() : Colours{};
+
+    m_colourGroup->setChecked(customColours);
+    m_backgroundColour->setColour(colours.colour(Colours::Type::Background, widget()->palette()));
+    m_waveformColour->setColour(colours.colour(Colours::Type::Waveform, widget()->palette()));
+    m_zeroLineColour->setColour(colours.colour(Colours::Type::ZeroLine, widget()->palette()));
+}
+} // namespace Fooyin::Oscilloscope
+
+#include "moc_oscilloscopeconfigwidget.cpp"

--- a/src/plugins/oscilloscope/oscilloscopeconfigwidget.h
+++ b/src/plugins/oscilloscope/oscilloscopeconfigwidget.h
@@ -1,0 +1,57 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "oscilloscopewidget.h"
+
+#include <gui/configdialog.h>
+
+class QCheckBox;
+class QComboBox;
+class QGroupBox;
+
+namespace Fooyin {
+class ColourButton;
+
+namespace Oscilloscope {
+class OscilloscopeConfigDialog : public WidgetConfigDialog<OscilloscopeWidget, OscilloscopeWidget::ConfigData>
+{
+    Q_OBJECT
+
+public:
+    explicit OscilloscopeConfigDialog(OscilloscopeWidget* oscilloscope, QWidget* parent = nullptr);
+
+protected:
+    [[nodiscard]] OscilloscopeWidget::ConfigData config() const override;
+    void setConfig(const OscilloscopeWidget::ConfigData& config) override;
+
+private:
+    QComboBox* m_curveDurationMs;
+    QComboBox* m_zoomPercent;
+    QComboBox* m_updateFps;
+    QComboBox* m_downmixMode;
+    QCheckBox* m_showZeroLine;
+    QGroupBox* m_colourGroup;
+    ColourButton* m_backgroundColour;
+    ColourButton* m_waveformColour;
+    ColourButton* m_zeroLineColour;
+};
+} // namespace Oscilloscope
+} // namespace Fooyin

--- a/src/plugins/oscilloscope/oscilloscopeplugin.cpp
+++ b/src/plugins/oscilloscope/oscilloscopeplugin.cpp
@@ -1,0 +1,50 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "oscilloscopeplugin.h"
+
+#include "oscilloscopecolours.h"
+#include "oscilloscopewidget.h"
+
+#include <core/engine/enginecontroller.h>
+#include <core/player/playercontroller.h>
+#include <gui/widgetprovider.h>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Oscilloscope {
+void OscilloscopePlugin::initialise(const CorePluginContext& context)
+{
+    m_playerController = context.playerController;
+    m_engine           = context.engine;
+    m_settings         = context.settingsManager;
+}
+
+void OscilloscopePlugin::initialise(const GuiPluginContext& context)
+{
+    qRegisterMetaType<Colours>("Fooyin::Oscilloscope::Colours");
+
+    context.widgetProvider->registerWidget(
+        u"Oscilloscope"_s, [this]() { return new OscilloscopeWidget(m_engine, m_playerController, m_settings); },
+        tr("Oscilloscope"));
+    context.widgetProvider->setSubMenus(u"Oscilloscope"_s, {tr("Visualisations")});
+}
+} // namespace Fooyin::Oscilloscope
+
+#include "moc_oscilloscopeplugin.cpp"

--- a/src/plugins/oscilloscope/oscilloscopeplugin.h
+++ b/src/plugins/oscilloscope/oscilloscopeplugin.h
@@ -1,0 +1,45 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/plugins/coreplugin.h>
+#include <core/plugins/plugin.h>
+#include <gui/plugins/guiplugin.h>
+
+namespace Fooyin::Oscilloscope {
+class OscilloscopePlugin : public QObject,
+                           public Plugin,
+                           public CorePlugin,
+                           public GuiPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.fooyin.fooyin.plugin/1.0" FILE "oscilloscope.json")
+    Q_INTERFACES(Fooyin::Plugin Fooyin::CorePlugin Fooyin::GuiPlugin)
+
+public:
+    void initialise(const CorePluginContext& context) override;
+    void initialise(const GuiPluginContext& context) override;
+
+private:
+    PlayerController* m_playerController;
+    EngineController* m_engine;
+    SettingsManager* m_settings;
+};
+} // namespace Fooyin::Oscilloscope

--- a/src/plugins/oscilloscope/oscilloscopewidget.cpp
+++ b/src/plugins/oscilloscope/oscilloscopewidget.cpp
@@ -1,0 +1,558 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "oscilloscopewidget.h"
+
+#include "oscilloscopecolours.h"
+
+#include <core/engine/enginecontroller.h>
+#include <core/engine/visualisationservice.h>
+#include <core/player/playercontroller.h>
+#include <core/player/playerdefs.h>
+#include <gui/configdialog.h>
+#include <gui/framerate.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QActionGroup>
+#include <QBasicTimer>
+#include <QContextMenuEvent>
+#include <QElapsedTimer>
+#include <QJsonObject>
+#include <QMenu>
+#include <QPainter>
+#include <QPolygonF>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto CurveDurationKey = u"Oscilloscope/CurveDurationMs";
+constexpr auto ZoomKey          = u"Oscilloscope/ZoomPercent";
+constexpr auto UpdateFpsKey     = u"Oscilloscope/UpdateFps";
+constexpr auto DownmixModeKey   = u"Oscilloscope/DownmixMode";
+constexpr auto ShowZeroLineKey  = u"Oscilloscope/ShowZeroLine";
+constexpr auto ColoursKey       = u"Oscilloscope/Colours";
+
+constexpr auto StereoLaneGapPx  = 4.0F;
+constexpr auto MinLanePaddingPx = 2.0F;
+constexpr auto LanePaddingRatio = 0.05F;
+constexpr auto ClockSettleMs    = 150;
+constexpr auto ClockResetMs     = 300.0;
+
+#include "oscilloscopeconfigwidget.h"
+
+namespace Fooyin::Oscilloscope {
+OscilloscopeWidget::OscilloscopeWidget(EngineController* engine, PlayerController* playerController,
+                                       SettingsManager* settings, QWidget* parent)
+    : FyWidget{parent}
+    , m_settings{settings}
+    , m_session{engine->visualisationService()->createSession()}
+    , m_window{}
+    , m_active{false}
+    , m_paused{false}
+    , m_clockSettling{false}
+    , m_presentationTimeMs{0.0}
+{
+    m_session->requestBacklog(static_cast<uint64_t>(MaxCurveDurationMs));
+
+    handlePlayStateChanged(playerController->playState());
+
+    QObject::connect(playerController, &PlayerController::playStateChanged, this,
+                     &OscilloscopeWidget::handlePlayStateChanged);
+    QObject::connect(playerController, &PlayerController::currentTrackChanged, this, [this]() { clearWindow(false); });
+    QObject::connect(playerController, &PlayerController::positionMoved, this, [this]() { clearWindow(false); });
+
+    m_config = defaultConfig();
+    applyConfig(m_config);
+}
+
+QString OscilloscopeWidget::name() const
+{
+    return tr("Oscilloscope");
+}
+
+QString OscilloscopeWidget::layoutName() const
+{
+    return u"Oscilloscope"_s;
+}
+
+void OscilloscopeWidget::saveLayoutData(QJsonObject& layout)
+{
+    saveConfigToLayout(m_config, layout);
+}
+
+void OscilloscopeWidget::loadLayoutData(const QJsonObject& layout)
+{
+    applyConfig(configFromLayout(layout));
+}
+
+OscilloscopeWidget::ConfigData OscilloscopeWidget::factoryConfig() const
+{
+    return {};
+}
+
+OscilloscopeWidget::ConfigData OscilloscopeWidget::defaultConfig() const
+{
+    auto config{factoryConfig()};
+
+    config.curveDurationMs = m_settings->fileValue(CurveDurationKey, config.curveDurationMs).toInt();
+    config.zoomPercent     = m_settings->fileValue(ZoomKey, config.zoomPercent).toInt();
+    config.updateFps       = m_settings->fileValue(UpdateFpsKey, config.updateFps).toInt();
+    config.downmixMode
+        = static_cast<DownmixMode>(m_settings->fileValue(DownmixModeKey, static_cast<int>(config.downmixMode)).toInt());
+    config.showZeroLine = m_settings->fileValue(ShowZeroLineKey, config.showZeroLine).toBool();
+    config.colours      = m_settings->fileValue(ColoursKey, config.colours);
+
+    return config;
+}
+
+const OscilloscopeWidget::ConfigData& OscilloscopeWidget::currentConfig() const
+{
+    return m_config;
+}
+
+void OscilloscopeWidget::saveDefaults(const ConfigData& config) const
+{
+    auto validated{config};
+
+    validated.curveDurationMs = std::clamp(validated.curveDurationMs, MinCurveDurationMs, MaxCurveDurationMs);
+    validated.zoomPercent     = std::clamp(validated.zoomPercent, MinZoomPercent, MaxZoomPercent);
+    validated.updateFps       = Gui::FrameRate::nearestPresetFps(validated.updateFps);
+
+    if(!validated.colours.canConvert<Colours>()
+       || (validated.colours.isValid() && validated.colours.value<Colours>().isEmpty())) {
+        validated.colours = QVariant{};
+    }
+
+    m_settings->fileSet(CurveDurationKey, validated.curveDurationMs);
+    m_settings->fileSet(ZoomKey, validated.zoomPercent);
+    m_settings->fileSet(UpdateFpsKey, validated.updateFps);
+    m_settings->fileSet(DownmixModeKey, static_cast<int>(validated.downmixMode));
+    m_settings->fileSet(ShowZeroLineKey, validated.showZeroLine);
+    m_settings->fileSet(ColoursKey, validated.colours);
+}
+
+void OscilloscopeWidget::clearSavedDefaults() const
+{
+    m_settings->fileRemove(CurveDurationKey);
+    m_settings->fileRemove(ZoomKey);
+    m_settings->fileRemove(UpdateFpsKey);
+    m_settings->fileRemove(DownmixModeKey);
+    m_settings->fileRemove(ShowZeroLineKey);
+    m_settings->fileRemove(ColoursKey);
+}
+
+void OscilloscopeWidget::applyConfig(const ConfigData& config)
+{
+    auto validated{config};
+
+    validated.curveDurationMs = std::clamp(validated.curveDurationMs, MinCurveDurationMs, MaxCurveDurationMs);
+    validated.zoomPercent     = std::clamp(validated.zoomPercent, MinZoomPercent, MaxZoomPercent);
+    validated.updateFps       = Gui::FrameRate::nearestPresetFps(validated.updateFps);
+
+    if(!validated.colours.canConvert<Colours>()
+       || (validated.colours.isValid() && validated.colours.value<Colours>().isEmpty())) {
+        validated.colours = QVariant{};
+    }
+
+    m_config = validated;
+    updateSessionConfig();
+    update();
+}
+
+QSize OscilloscopeWidget::minimumSizeHint() const
+{
+    return {24, 18};
+}
+
+void OscilloscopeWidget::paintEvent(QPaintEvent* /*event*/)
+{
+    QPainter painter{this};
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    paint(painter, rect(), palette());
+}
+
+void OscilloscopeWidget::timerEvent(QTimerEvent* event)
+{
+    if(event->timerId() == m_updateTimer.timerId()) {
+        tick();
+    }
+    FyWidget::timerEvent(event);
+}
+
+void OscilloscopeWidget::contextMenuEvent(QContextMenuEvent* event)
+{
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* zeroLineAction = menu->addAction(tr("Show zero line"));
+    zeroLineAction->setCheckable(true);
+    zeroLineAction->setChecked(m_config.showZeroLine);
+    QObject::connect(zeroLineAction, &QAction::triggered, this, [this](bool checked) {
+        auto config{m_config};
+        config.showZeroLine = checked;
+        applyConfig(config);
+    });
+
+    auto* downmixMenu  = menu->addMenu(tr("Downmix mode"));
+    auto* downmixGroup = new QActionGroup(downmixMenu);
+    downmixGroup->setExclusive(true);
+
+    const auto addDownmixAction = [this, downmixMenu, downmixGroup](const QString& text, DownmixMode mode) {
+        auto* action = downmixMenu->addAction(text);
+        action->setActionGroup(downmixGroup);
+        action->setCheckable(true);
+        action->setChecked(m_config.downmixMode == mode);
+        QObject::connect(action, &QAction::triggered, this, [this, mode]() {
+            auto config{m_config};
+            config.downmixMode = mode;
+            applyConfig(config);
+        });
+    };
+
+    addDownmixAction(tr("Stereo"), DownmixMode::Stereo);
+    addDownmixAction(tr("Mono"), DownmixMode::Mono);
+
+    auto* durationMenu  = menu->addMenu(tr("Curve duration"));
+    auto* durationGroup = new QActionGroup(durationMenu);
+    durationGroup->setExclusive(true);
+
+    for(const int durationMs : CurveDurationPresets) {
+        auto* action = durationMenu->addAction(tr("%1 ms").arg(durationMs));
+        action->setActionGroup(durationGroup);
+        action->setCheckable(true);
+        action->setChecked(m_config.curveDurationMs == durationMs);
+        QObject::connect(action, &QAction::triggered, this, [this, durationMs]() {
+            auto config{m_config};
+            config.curveDurationMs = durationMs;
+            applyConfig(config);
+        });
+    }
+
+    auto* zoomMenu  = menu->addMenu(tr("Zoom"));
+    auto* zoomGroup = new QActionGroup(zoomMenu);
+    zoomGroup->setExclusive(true);
+
+    for(const int zoomPercent : ZoomPresets) {
+        auto* action = zoomMenu->addAction(tr("%1%").arg(zoomPercent));
+        action->setActionGroup(zoomGroup);
+        action->setCheckable(true);
+        action->setChecked(m_config.zoomPercent == zoomPercent);
+        QObject::connect(action, &QAction::triggered, this, [this, zoomPercent]() {
+            auto config{m_config};
+            config.zoomPercent = zoomPercent;
+            applyConfig(config);
+        });
+    }
+
+    menu->addSeparator();
+    addConfigureAction(menu, false);
+    menu->popup(event->globalPos());
+}
+
+void OscilloscopeWidget::openConfigDialog()
+{
+    showConfigDialog(new OscilloscopeConfigDialog(this, this));
+}
+
+void OscilloscopeWidget::handlePlayStateChanged(Player::PlayState state)
+{
+    m_paused = state == Player::PlayState::Paused;
+    m_active = state != Player::PlayState::Stopped;
+
+    if(state == Player::PlayState::Stopped) {
+        clearWindow(true);
+        return;
+    }
+
+    if(m_paused) {
+        m_updateTimer.stop();
+        m_presentationClock.invalidate();
+        return;
+    }
+
+    if(m_active && !m_paused) {
+        settlePresentationClock();
+        startUpdateTimer();
+    }
+}
+
+void OscilloscopeWidget::clearWindow(bool stopTimer)
+{
+    m_window = {};
+    m_presentationClock.invalidate();
+    m_presentationTimeMs = 0.0;
+
+    if(stopTimer) {
+        m_updateTimer.stop();
+        m_clockSettling = false;
+    }
+    else if(m_active && !m_paused) {
+        settlePresentationClock();
+        startUpdateTimer();
+    }
+
+    update();
+}
+
+int OscilloscopeWidget::displayedLanes() const
+{
+    return m_config.downmixMode == DownmixMode::Mono ? 1 : 2;
+}
+
+Colours OscilloscopeWidget::colours() const
+{
+    return m_config.colours.isValid() && m_config.colours.canConvert<Colours>() ? m_config.colours.value<Colours>()
+                                                                                : Colours{};
+}
+
+void OscilloscopeWidget::updateSessionConfig()
+{
+    m_session->requestBacklog(static_cast<uint64_t>(std::max(m_config.curveDurationMs, MaxCurveDurationMs)));
+    m_session->setChannelMode(m_config.downmixMode == DownmixMode::Mono ? VisualisationSession::ChannelMode::Mono
+                                                                        : VisualisationSession::ChannelMode::Default);
+
+    if(m_active && !m_paused) {
+        startUpdateTimer();
+    }
+}
+
+void OscilloscopeWidget::startUpdateTimer()
+{
+    m_updateTimer.start(Gui::FrameRate::intervalMsForFps(m_config.updateFps), Qt::PreciseTimer, this);
+}
+
+void OscilloscopeWidget::settlePresentationClock()
+{
+    m_presentationClock.invalidate();
+    m_clockSettling = true;
+    m_clockSettleTimer.restart();
+}
+
+void OscilloscopeWidget::tick()
+{
+    if(m_paused) {
+        m_updateTimer.stop();
+        return;
+    }
+
+    if(m_clockSettling) {
+        if(m_clockSettleTimer.elapsed() < ClockSettleMs) {
+            return;
+        }
+        m_clockSettling = false;
+    }
+
+    const uint64_t rawTimeMs = m_session->currentTimeMs();
+    if(rawTimeMs == 0) {
+        return;
+    }
+
+    if(!m_presentationClock.isValid()) {
+        m_presentationTimeMs = static_cast<double>(rawTimeMs);
+        m_presentationClock.start();
+    }
+    else {
+        const double elapsedMs = static_cast<double>(m_presentationClock.nsecsElapsed()) / 1'000'000.0;
+        m_presentationClock.restart();
+
+        const double predictedTimeMs = m_presentationTimeMs + std::max(0.0, elapsedMs);
+        const double clockErrorMs    = static_cast<double>(rawTimeMs) - predictedTimeMs;
+        m_presentationTimeMs = std::abs(clockErrorMs) > ClockResetMs ? static_cast<double>(rawTimeMs) : predictedTimeMs;
+    }
+
+    const auto visibleDurationMs  = static_cast<uint64_t>(m_config.curveDurationMs);
+    const auto presentationTimeMs = static_cast<uint64_t>(std::max(0.0, m_presentationTimeMs));
+
+    VisualisationSession::PcmWindow window;
+    if(m_session->getPcmWindowEndingAt(window, presentationTimeMs, visibleDurationMs)) {
+        const int requiredFrames = window.format.framesForDuration(visibleDurationMs);
+        if(window.frameCount < requiredFrames) {
+            return;
+        }
+
+        m_window = std::move(window);
+        update();
+    }
+}
+
+void OscilloscopeWidget::paint(QPainter& painter, const QRect& rect, const QPalette& palette) const
+{
+    const Colours customColours{colours()};
+    const QColor background = customColours.colour(Colours::Type::Background, palette);
+    const QColor waveform   = customColours.colour(Colours::Type::Waveform, palette);
+    const QColor zeroLine   = customColours.colour(Colours::Type::ZeroLine, palette);
+
+    painter.fillRect(rect, Qt::transparent);
+    if(background.alpha() > 0) {
+        painter.fillRect(rect, background);
+    }
+
+    const int laneCount = displayedLanes();
+    if(rect.width() <= 0 || rect.height() <= 0 || laneCount <= 0) {
+        return;
+    }
+
+    const float gap        = laneCount == 2 ? StereoLaneGapPx : 0.0F;
+    const float laneHeight = std::max(1.0F, (static_cast<float>(rect.height()) - gap) / static_cast<float>(laneCount));
+
+    QPen zeroPen{zeroLine};
+    zeroPen.setCosmetic(true);
+
+    for(int lane{0}; lane < laneCount; ++lane) {
+        const float top     = static_cast<float>(rect.top()) + (static_cast<float>(lane) * (laneHeight + gap));
+        const float centerY = top + (laneHeight * 0.5F);
+        if(m_config.showZeroLine) {
+            painter.setPen(zeroPen);
+            painter.drawLine(
+                QLineF{static_cast<float>(rect.left()), centerY, static_cast<float>(rect.right()), centerY});
+        }
+
+        if(!m_window.isValid() || m_window.format.channelCount() <= 0 || m_window.frameCount <= 0) {
+            continue;
+        }
+
+        const float lanePadding = std::max(MinLanePaddingPx, laneHeight * LanePaddingRatio);
+        const float amplitude   = std::max(1.0F, ((laneHeight - (lanePadding * 2.0F)) * 0.5F));
+        const auto samples      = m_window.interleavedSamples();
+        const int channels      = m_window.format.channelCount();
+        const int frames        = m_window.frameCount;
+
+        QPen waveformPen{waveform};
+        waveformPen.setCosmetic(true);
+        waveformPen.setCapStyle(Qt::RoundCap);
+        painter.setPen(waveformPen);
+
+        const int channelIndex
+            = m_config.downmixMode == DownmixMode::Mono || channels == 1 ? 0 : std::min(lane, channels - 1);
+        const float zoom    = static_cast<float>(m_config.zoomPercent) / 100.0F;
+        const auto sampleAt = [&](size_t frameIndex) {
+            return samples[(frameIndex * static_cast<size_t>(channels)) + static_cast<size_t>(channelIndex)] * zoom;
+        };
+
+        QPolygonF points;
+        const int deviceWidth = std::max(1, qRound(static_cast<qreal>(rect.width()) * devicePixelRatioF()));
+        const int pointCount  = std::min(frames, deviceWidth);
+        points.reserve(pointCount);
+
+        const float xScale
+            = pointCount > 1 ? static_cast<float>(rect.width() - 1) / static_cast<float>(pointCount - 1) : 0.0F;
+        for(int pointIndex{0}; pointIndex < pointCount; ++pointIndex) {
+            float sampleValue{0.0F};
+            if(pointCount == frames) {
+                sampleValue = sampleAt(static_cast<size_t>(pointIndex));
+            }
+            else {
+                const int beginFrame = static_cast<int>((static_cast<qint64>(pointIndex) * frames) / pointCount);
+                const int endFrame   = static_cast<int>((static_cast<qint64>(pointIndex + 1) * frames) / pointCount);
+                double sum{0.0};
+                for(int frameIndex{beginFrame}; frameIndex < endFrame; ++frameIndex) {
+                    sum += static_cast<double>(sampleAt(static_cast<size_t>(frameIndex)));
+                }
+                sampleValue = static_cast<float>(sum / static_cast<double>(endFrame - beginFrame));
+            }
+
+            const float drawX = static_cast<float>(rect.left()) + (static_cast<float>(pointIndex) * xScale);
+            const float drawY = centerY - (sampleValue * amplitude);
+            points.append(QPointF{drawX, drawY});
+        }
+
+        if(points.size() > 1) {
+            painter.drawPolyline(points);
+        }
+        else if(!points.isEmpty()) {
+            painter.drawPoint(points.constFirst());
+        }
+        painter.setPen(zeroPen);
+    }
+}
+
+OscilloscopeWidget::ConfigData OscilloscopeWidget::configFromLayout(const QJsonObject& layout) const
+{
+    ConfigData config{defaultConfig()};
+
+    if(layout.contains("CurveDurationMs"_L1)) {
+        config.curveDurationMs = layout.value("CurveDurationMs"_L1).toInt();
+    }
+    if(layout.contains("ZoomPercent"_L1)) {
+        config.zoomPercent = layout.value("ZoomPercent"_L1).toInt();
+    }
+    if(layout.contains("UpdateFps"_L1)) {
+        config.updateFps = layout.value("UpdateFps"_L1).toInt();
+    }
+    if(layout.contains("DownmixMode"_L1)) {
+        config.downmixMode = static_cast<DownmixMode>(layout.value("DownmixMode"_L1).toInt());
+    }
+    if(layout.contains("ShowZeroLine"_L1)) {
+        config.showZeroLine = layout.value("ShowZeroLine"_L1).toBool();
+    }
+
+    if(layout.contains("UseCustomColours"_L1)) {
+        if(layout.value("UseCustomColours"_L1).toBool()) {
+            Colours colours;
+
+            const auto setColour = [&layout, &colours](const QString& key, Colours::Type type) {
+                if(!layout.contains(key)) {
+                    return;
+                }
+
+                const QColor colour{layout.value(key).toString()};
+                if(colour.isValid()) {
+                    colours.setColour(type, colour);
+                }
+            };
+
+            setColour(u"BackgroundColour"_s, Colours::Type::Background);
+            setColour(u"WaveformColour"_s, Colours::Type::Waveform);
+            setColour(u"ZeroLineColour"_s, Colours::Type::ZeroLine);
+
+            if(!colours.isEmpty()) {
+                config.colours = QVariant::fromValue(colours);
+            }
+        }
+        else {
+            config.colours = QVariant{};
+        }
+    }
+
+    return config;
+}
+
+void OscilloscopeWidget::saveConfigToLayout(const ConfigData& config, QJsonObject& layout) const
+{
+    layout["CurveDurationMs"_L1] = config.curveDurationMs;
+    layout["ZoomPercent"_L1]     = config.zoomPercent;
+    layout["UpdateFps"_L1]       = config.updateFps;
+    layout["DownmixMode"_L1]     = static_cast<int>(config.downmixMode);
+    layout["ShowZeroLine"_L1]    = config.showZeroLine;
+
+    const bool customColours      = config.colours.isValid() && config.colours.canConvert<Colours>()
+                                 && !config.colours.value<Colours>().isEmpty();
+    layout["UseCustomColours"_L1] = customColours;
+
+    if(!customColours) {
+        return;
+    }
+
+    const auto colours            = config.colours.value<Colours>();
+    layout["BackgroundColour"_L1] = colours.colour(Colours::Type::Background, palette()).name(QColor::HexArgb);
+    layout["WaveformColour"_L1]   = colours.colour(Colours::Type::Waveform, palette()).name(QColor::HexArgb);
+    layout["ZeroLineColour"_L1]   = colours.colour(Colours::Type::ZeroLine, palette()).name(QColor::HexArgb);
+}
+} // namespace Fooyin::Oscilloscope
+
+#include "moc_oscilloscopewidget.cpp"

--- a/src/plugins/oscilloscope/oscilloscopewidget.h
+++ b/src/plugins/oscilloscope/oscilloscopewidget.h
@@ -1,0 +1,125 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/visualisationservice.h>
+#include <core/player/playerdefs.h>
+#include <gui/fywidget.h>
+
+#include <QBasicTimer>
+#include <QElapsedTimer>
+#include <QVariant>
+
+#include <array>
+
+class QJsonObject;
+class QPainter;
+class QPalette;
+
+namespace Fooyin {
+class EngineController;
+class PlayerController;
+class SettingsManager;
+
+namespace Oscilloscope {
+class Colours;
+
+class OscilloscopeWidget : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    enum class DownmixMode : uint8_t
+    {
+        Stereo = 0,
+        Mono
+    };
+
+    static constexpr int MinCurveDurationMs     = 25;
+    static constexpr int MaxCurveDurationMs     = 1000;
+    static constexpr int DefaultCurveDurationMs = 150;
+    static constexpr std::array<int, 8> CurveDurationPresets{100, 200, 300, 400, 500, 600, 700, 800};
+    static constexpr int MinZoomPercent     = 50;
+    static constexpr int MaxZoomPercent     = 800;
+    static constexpr int DefaultZoomPercent = 100;
+    static constexpr int DefaultUpdateFps   = 30;
+    static constexpr std::array<int, 9> ZoomPresets{50, 75, 100, 150, 200, 300, 400, 600, 800};
+
+    struct ConfigData
+    {
+        int curveDurationMs{DefaultCurveDurationMs};
+        int zoomPercent{DefaultZoomPercent};
+        int updateFps{DefaultUpdateFps};
+        DownmixMode downmixMode{DownmixMode::Stereo};
+        bool showZeroLine{false};
+        QVariant colours;
+    };
+
+    explicit OscilloscopeWidget(EngineController* engine, PlayerController* playerController, SettingsManager* settings,
+                                QWidget* parent = nullptr);
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
+
+    [[nodiscard]] ConfigData factoryConfig() const;
+    [[nodiscard]] ConfigData defaultConfig() const;
+    [[nodiscard]] const ConfigData& currentConfig() const;
+    void saveDefaults(const ConfigData& config) const;
+    void clearSavedDefaults() const;
+    void applyConfig(const ConfigData& config);
+
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void timerEvent(QTimerEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+    void openConfigDialog() override;
+
+private:
+    void handlePlayStateChanged(Player::PlayState state);
+    void clearWindow(bool stopTimer);
+    [[nodiscard]] int displayedLanes() const;
+    [[nodiscard]] Colours colours() const;
+    void updateSessionConfig();
+    void startUpdateTimer();
+    void settlePresentationClock();
+    void tick();
+    void paint(QPainter& painter, const QRect& rect, const QPalette& palette) const;
+    [[nodiscard]] ConfigData configFromLayout(const QJsonObject& layout) const;
+    void saveConfigToLayout(const ConfigData& config, QJsonObject& layout) const;
+
+    SettingsManager* m_settings;
+    VisualisationSessionPtr m_session;
+    ConfigData m_config;
+    VisualisationSession::PcmWindow m_window;
+    bool m_active;
+    bool m_paused;
+    bool m_clockSettling;
+    double m_presentationTimeMs;
+    QBasicTimer m_updateTimer;
+    QElapsedTimer m_presentationClock;
+    QElapsedTimer m_clockSettleTimer;
+};
+} // namespace Oscilloscope
+} // namespace Fooyin

--- a/tests/core/engine/visualisationbackendtest.cpp
+++ b/tests/core/engine/visualisationbackendtest.cpp
@@ -160,6 +160,22 @@ TEST(VisualisationBackendTest, DropsOldBacklogWhenScopedStreamGapExceedsToleranc
     EXPECT_EQ(window.frameCount, frameCount);
 }
 
+TEST(VisualisationBackendTest, EndAnchoredPcmWindowDoesNotReadAheadOfRequestedTime)
+{
+    static constexpr auto frameCount = 128;
+    static constexpr auto sampleRate = 1000;
+
+    Fooyin::VisualisationBackend backend;
+    const auto token = backend.registerSession();
+    backend.requestBacklog(token, 1000);
+    backend.appendFrame(makeStereoSineFrame(frameCount, sampleRate, 7, 19, 0));
+
+    Fooyin::VisualisationSession::PcmWindow window;
+    ASSERT_TRUE(backend.getPcmWindowEndingAt(window, 10, 100, {}));
+    EXPECT_EQ(window.startTimeMs, 0);
+    EXPECT_EQ(window.frameCount, 10);
+}
+
 TEST(VisualisationBackendTest, PreservesTimelineWhenPcmStreamChanges)
 {
     static constexpr auto frameCount = 100;


### PR DESCRIPTION
Add a configurable stereo/mono oscilloscope with adjustable duration, zoom, refresh rate and colours.

<img width="1741" height="340" alt="Screenshot_20260703_233900" src="https://github.com/user-attachments/assets/d3a3ffb8-d48a-45e5-83c9-efbe0c11e118" />
