### PR TITLE
Fix weird keyboard behaviour in fileops delete dialogue

### DIFF
--- a/src/plugins/fileops/fileopsdeletedialog.cpp
+++ b/src/plugins/fileops/fileopsdeletedialog.cpp
@@ -62,6 +62,7 @@ FileOpsDeleteDialog::FileOpsDeleteDialog(const TrackList& tracks, SettingsManage
     auto* deleteButton = buttons->addButton(tr("Delete"), QDialogButtonBox::DestructiveRole);
     auto* cancelButton = buttons->addButton(QDialogButtonBox::Cancel);
     cancelButton->setDefault(true);
+    cancelButton->setFocus(Qt::ActiveWindowFocusReason);
     layout->addWidget(buttons);
 
     QObject::connect(deleteButton, &QPushButton::clicked, this, [this, dontAsk, settings]() {


### PR DESCRIPTION
When deleting a file, a dialogue opens. In this dialogue the "Cancel" button should be focused, as it is highlighted.
The "Confirm"-Button is left to the "Cancel"-button. 

But when pressing the left arrow to focus "Confirm", the focus first switches to "Cancel" although it should already be on it. Only after pressing the left arrow again, it focuses the "Confirm" button.
This behaviour is quite annoying and unintuitive.

Please see these pictures that were taken after opening the dialogue and pressing the left arrow button exactly once:
|Before the fix|After the fix|
|---|---|
|<img width="296" height="210" alt="grafik" src="https://github.com/user-attachments/assets/80bebfef-4421-4791-b2d1-baa3cc00e768" />|<img width="285" height="207" alt="grafik" src="https://github.com/user-attachments/assets/7566af9d-a425-4641-9d7d-961cefaa1fdd" />|

(Please disregard the language)
What's important is, that while pressing the left arrow once in the current release only puts the focus on "Cancel", it puts the focus on "Confirm" with the fix.