### PR TITLE
[core] Fix Stop After Current when in deferred metadata flush mode

### DIFF
--- a/src/core/playback/playbackordernavigator.cpp
+++ b/src/core/playback/playbackordernavigator.cpp
@@ -270,10 +270,13 @@ std::optional<PlaybackOrderNavigator::RequestedTrack> PlaybackOrderNavigator::se
     return {};
 }
 
-std::optional<PlaybackOrderNavigator::RequestedTrack> PlaybackOrderNavigator::selectPlayFromIdleState()
+std::optional<PlaybackOrderNavigator::RequestedTrack>
+PlaybackOrderNavigator::selectPlayFromIdleState(bool preferScheduledTrack)
 {
-    if(auto scheduledTrack = selectScheduledTrack()) {
-        return scheduledTrack;
+    if(preferScheduledTrack) {
+        if(auto scheduledTrack = selectScheduledTrack()) {
+            return scheduledTrack;
+        }
     }
 
     if(!m_queue->empty()) {
@@ -281,6 +284,12 @@ std::optional<PlaybackOrderNavigator::RequestedTrack> PlaybackOrderNavigator::se
             .track        = m_queue->nextTrack(),
             .isQueueTrack = true,
         };
+    }
+
+    if(!preferScheduledTrack) {
+        if(auto scheduledTrack = selectScheduledTrack()) {
+            return scheduledTrack;
+        }
     }
 
     if(m_playlistHandler) {

--- a/src/core/playback/playbackordernavigator.h
+++ b/src/core/playback/playbackordernavigator.h
@@ -59,7 +59,7 @@ public:
     [[nodiscard]] PlaylistTrack previewPlaybackRelativeTrack(int delta) const;
     std::optional<RequestedTrack> selectScheduledTrack();
     std::optional<RequestedTrack> selectPlaybackOrderTrack(int delta);
-    std::optional<RequestedTrack> selectPlayFromIdleState();
+    std::optional<RequestedTrack> selectPlayFromIdleState(bool preferScheduledTrack);
     PlaylistTrack restartPlaylist(RestartTarget target);
 
 private:

--- a/src/core/playback/playbacksession.cpp
+++ b/src/core/playback/playbacksession.cpp
@@ -23,7 +23,8 @@
 
 namespace Fooyin {
 PlaybackSession::PlaybackSession()
-    : m_isQueueTrack{false}
+    : m_scheduledTrackKind{ScheduledTrackKind::Normal}
+    , m_isQueueTrack{false}
     , m_currentItemId{0}
 { }
 
@@ -55,6 +56,11 @@ PlaylistTrack& PlaybackSession::currentTrack()
 const PlaylistTrack& PlaybackSession::scheduledTrack() const
 {
     return m_scheduledTrack;
+}
+
+PlaybackSession::ScheduledTrackKind PlaybackSession::scheduledTrackKind() const
+{
+    return m_scheduledTrackKind;
 }
 
 const std::optional<PlaylistTrack>& PlaybackSession::detachedCurrentPlaylistTrack() const
@@ -154,6 +160,7 @@ PlaybackSession::CommitResult PlaybackSession::commitRequest(const Player::Track
     m_isQueueTrack         = result.isQueueTrack;
     m_currentItemId        = itemId;
     m_scheduledTrack       = {};
+    m_scheduledTrackKind   = ScheduledTrackKind::Normal;
     m_pendingRequest.reset();
     m_detachedCurrentPlaylistTrack.reset();
 
@@ -179,9 +186,16 @@ void PlaybackSession::resetCurrentTrackState()
     m_detachedCurrentPlaylistTrack.reset();
 }
 
-void PlaybackSession::scheduleTrack(const PlaylistTrack& track)
+void PlaybackSession::scheduleTrack(const PlaylistTrack& track, ScheduledTrackKind kind)
 {
-    m_scheduledTrack = track;
+    m_scheduledTrack     = track;
+    m_scheduledTrackKind = track.isValid() ? kind : ScheduledTrackKind::Normal;
+}
+
+void PlaybackSession::clearScheduledTrack()
+{
+    m_scheduledTrack     = {};
+    m_scheduledTrackKind = ScheduledTrackKind::Normal;
 }
 
 void PlaybackSession::setDetachedCurrentPlaylistTrack(const PlaylistTrack& track)

--- a/src/core/playback/playbacksession.h
+++ b/src/core/playback/playbacksession.h
@@ -29,6 +29,12 @@ namespace Fooyin {
 class FYCORE_EXPORT PlaybackSession
 {
 public:
+    enum class ScheduledTrackKind
+    {
+        Normal = 0,
+        StopAfterCurrentResume,
+    };
+
     PlaybackSession();
 
     [[nodiscard]] PlaylistTrack* currentTrackPtr();
@@ -38,6 +44,7 @@ public:
     [[nodiscard]] const PlaylistTrack& currentTrack() const;
     [[nodiscard]] PlaylistTrack& currentTrack();
     [[nodiscard]] const PlaylistTrack& scheduledTrack() const;
+    [[nodiscard]] ScheduledTrackKind scheduledTrackKind() const;
     [[nodiscard]] const std::optional<PlaylistTrack>& detachedCurrentPlaylistTrack() const;
     [[nodiscard]] bool hasCurrentTrack() const;
     [[nodiscard]] bool isQueueTrack() const;
@@ -65,7 +72,8 @@ public:
     void clearPendingRequest();
     void clearCurrentTrack();
     void resetCurrentTrackState();
-    void scheduleTrack(const PlaylistTrack& track);
+    void scheduleTrack(const PlaylistTrack& track, ScheduledTrackKind kind = ScheduledTrackKind::Normal);
+    void clearScheduledTrack();
     void setDetachedCurrentPlaylistTrack(const PlaylistTrack& track);
     void clearDetachedCurrentPlaylistTrack();
 
@@ -77,6 +85,7 @@ public:
 private:
     PlaylistTrack m_currentTrack;
     PlaylistTrack m_scheduledTrack;
+    ScheduledTrackKind m_scheduledTrackKind;
     bool m_isQueueTrack;
     uint64_t m_currentItemId;
     Player::TrackChangeContext m_pendingChangeContext;

--- a/src/core/playback/playercontroller.cpp
+++ b/src/core/playback/playercontroller.cpp
@@ -737,7 +737,10 @@ bool PlayerControllerPrivate::applyTransportAction(const TransportAction& action
             m_self->stop();
             return false;
         case TransportAction::Type::AdvancePlaybackPositionAndStop:
-            m_navigator.selectPlaybackOrderTrack(1);
+            if(const auto selection = m_navigator.selectPlaybackOrderTrack(1);
+               selection.has_value() && selection->track.isValid()) {
+                m_session.scheduleTrack(selection->track);
+            }
             m_self->reset();
             m_self->stop();
             return false;

--- a/src/core/playback/playercontroller.cpp
+++ b/src/core/playback/playercontroller.cpp
@@ -297,7 +297,8 @@ Player::UpcomingTrack PlayerControllerPrivate::resolveUpcomingTrack() const
         return {};
     }
 
-    if(m_session.scheduledTrack().isValid()) {
+    if(m_session.scheduledTrack().isValid()
+       && m_session.scheduledTrackKind() == PlaybackSession::ScheduledTrackKind::Normal) {
         return {
             .track        = m_session.scheduledTrack(),
             .isQueueTrack = false,
@@ -308,6 +309,13 @@ Player::UpcomingTrack PlayerControllerPrivate::resolveUpcomingTrack() const
         return {
             .track        = m_queue.nextTrack(),
             .isQueueTrack = true,
+        };
+    }
+
+    if(m_session.scheduledTrack().isValid()) {
+        return {
+            .track        = m_session.scheduledTrack(),
+            .isQueueTrack = false,
         };
     }
 
@@ -637,6 +645,10 @@ void PlayerControllerPrivate::remapPlaylistReferences(const UId& fromPlaylistId,
         updateCurrentTrackPlaylist(toPlaylistId);
     }
 
+    if(auto* scheduledTrack = m_session.scheduledTrackPtr(); scheduledTrack->playlistId == fromPlaylistId) {
+        scheduledTrack->playlistId = toPlaylistId;
+    }
+
     emitUpcomingTrackChangedIfNeeded();
 }
 
@@ -739,7 +751,7 @@ bool PlayerControllerPrivate::applyTransportAction(const TransportAction& action
         case TransportAction::Type::AdvancePlaybackPositionAndStop:
             if(const auto selection = m_navigator.selectPlaybackOrderTrack(1);
                selection.has_value() && selection->track.isValid()) {
-                m_session.scheduleTrack(selection->track);
+                m_session.scheduleTrack(selection->track, PlaybackSession::ScheduledTrackKind::StopAfterCurrentResume);
             }
             m_self->reset();
             m_self->stop();
@@ -885,10 +897,15 @@ PlayerControllerPrivate::TransportAction PlayerControllerPrivate::selectAdvanceA
 
     if(reason == Player::AdvanceReason::ManualNext && m_session.canAcceptRequest()) {
         if(m_session.scheduledTrack().isValid()) {
-            return {
-                .type      = TransportAction::Type::RequestSelection,
-                .selection = m_navigator.selectScheduledTrack(),
-            };
+            if(m_session.scheduledTrackKind() == PlaybackSession::ScheduledTrackKind::Normal) {
+                return {
+                    .type      = TransportAction::Type::RequestSelection,
+                    .selection = m_navigator.selectScheduledTrack(),
+                };
+            }
+
+            m_navigator.selectScheduledTrack();
+            m_session.clearScheduledTrack();
         }
 
         if(const auto selection = m_navigator.selectPlaybackOrderTrack(1); selection && selection->track.isValid()) {
@@ -996,7 +1013,8 @@ PlayerControllerPrivate::TransportAction PlayerControllerPrivate::selectPlayActi
     if(m_session.isIdle()) {
         return {
             .type      = TransportAction::Type::RequestSelection,
-            .selection = m_navigator.selectPlayFromIdleState(),
+            .selection = m_navigator.selectPlayFromIdleState(m_session.scheduledTrackKind()
+                                                             == PlaybackSession::ScheduledTrackKind::Normal),
         };
     }
 

--- a/tests/core/playback/playbacksessiontest.cpp
+++ b/tests/core/playback/playbacksessiontest.cpp
@@ -83,7 +83,9 @@ TEST(PlaybackSessionTest, CommitRequestUsesPendingMetadataAndClearsPendingState)
 {
     PlaybackSession session;
     const PlaylistTrack track = makePlaylistTrack(u"/tmp/commit.flac"_s, 2, 1200, 1);
-    session.scheduleTrack(makePlaylistTrack(u"/tmp/scheduled.flac"_s, 3, 900, 4));
+    session.scheduleTrack(makePlaylistTrack(u"/tmp/scheduled.flac"_s, 3, 900, 4),
+                          PlaybackSession::ScheduledTrackKind::StopAfterCurrentResume);
+    EXPECT_EQ(session.scheduledTrackKind(), PlaybackSession::ScheduledTrackKind::StopAfterCurrentResume);
 
     const auto pendingRequest = session.requestTrackChange({
         .track        = track,
@@ -109,6 +111,7 @@ TEST(PlaybackSessionTest, CommitRequestUsesPendingMetadataAndClearsPendingState)
     EXPECT_FALSE(session.hasPendingRequest());
     EXPECT_TRUE(session.canAcceptRequest());
     EXPECT_FALSE(session.scheduledTrack().isValid());
+    EXPECT_EQ(session.scheduledTrackKind(), PlaybackSession::ScheduledTrackKind::Normal);
     EXPECT_TRUE(session.isQueueTrack());
     EXPECT_EQ(session.currentItemId(), 77);
 }

--- a/tests/core/playback/playercontrollertest.cpp
+++ b/tests/core/playback/playercontrollertest.cpp
@@ -843,6 +843,138 @@ TEST(PlayerControllerTest, StopAfterCurrentNaturalEndAdvancesPlaylistPositionBef
     EXPECT_EQ(request.track.track.id(), 72);
 }
 
+TEST(PlayerControllerTest, NextAfterStopAfterCurrentAdvancesPastResumeTrack)
+{
+    ensureCoreApplication();
+    SettingsManager settings{QDir::tempPath() + u"/fooyin_playercontroller_stop_current_next_test.ini"_s};
+    registerControllerSettings(settings);
+    PlaylistHandlerHarness harness{settings};
+    ASSERT_TRUE(harness.dbInitialised);
+
+    auto* playlist = harness.handler.createPlaylist(u"StopAfterCurrentNext"_s,
+                                                    {makeTrack(u"/tmp/stop-after-current-next-a.flac"_s, 73, 1000),
+                                                     makeTrack(u"/tmp/stop-after-current-next-b.flac"_s, 74, 1000),
+                                                     makeTrack(u"/tmp/stop-after-current-next-c.flac"_s, 75, 1000)});
+    ASSERT_NE(playlist, nullptr);
+
+    harness.handler.changeActivePlaylist(playlist);
+    playlist->changeCurrentIndex(0);
+
+    PlayerController controller{&settings, &harness.handler};
+    const auto committedTrack = playlist->playlistTrack(0);
+    ASSERT_TRUE(committedTrack.has_value());
+    controller.commitCurrentTrack(*committedTrack);
+
+    settings.set<Settings::Core::StopAfterCurrent>(true);
+    settings.set<Settings::Core::ResetStopAfterCurrent>(true);
+
+    controller.play();
+    controller.advance(Player::AdvanceReason::NaturalEnd);
+    controller.syncPlayStateFromEngine(Player::PlayState::Stopped);
+
+    ASSERT_EQ(playlist->currentTrackIndex(), 1);
+
+    QSignalSpy requestSpy{&controller, &PlayerController::trackChangeRequested};
+
+    controller.next();
+
+    ASSERT_EQ(requestSpy.count(), 1);
+    const auto request = requestSpy.takeFirst().front().value<Player::TrackChangeRequest>();
+    EXPECT_EQ(request.track.indexInPlaylist, 2);
+    EXPECT_EQ(request.track.track.id(), 75);
+}
+
+TEST(PlayerControllerTest, QueueAddedAfterStopAfterCurrentTakesPrecedenceOnPlay)
+{
+    ensureCoreApplication();
+    SettingsManager settings{QDir::tempPath() + u"/fooyin_playercontroller_stop_current_queue_test.ini"_s};
+    registerControllerSettings(settings);
+    PlaylistHandlerHarness harness{settings};
+    ASSERT_TRUE(harness.dbInitialised);
+
+    auto* playlist = harness.handler.createPlaylist(u"StopAfterCurrentQueue"_s,
+                                                    {makeTrack(u"/tmp/stop-after-current-queue-a.flac"_s, 76, 1000),
+                                                     makeTrack(u"/tmp/stop-after-current-queue-b.flac"_s, 77, 1000),
+                                                     makeTrack(u"/tmp/stop-after-current-queue-c.flac"_s, 78, 1000)});
+    ASSERT_NE(playlist, nullptr);
+
+    harness.handler.changeActivePlaylist(playlist);
+    playlist->changeCurrentIndex(0);
+
+    PlayerController controller{&settings, &harness.handler};
+    const auto committedTrack = playlist->playlistTrack(0);
+    const auto queuedTrack    = playlist->playlistTrack(2);
+    ASSERT_TRUE(committedTrack.has_value());
+    ASSERT_TRUE(queuedTrack.has_value());
+    controller.commitCurrentTrack(*committedTrack);
+
+    settings.set<Settings::Core::StopAfterCurrent>(true);
+    settings.set<Settings::Core::ResetStopAfterCurrent>(true);
+
+    controller.play();
+    controller.advance(Player::AdvanceReason::NaturalEnd);
+    controller.syncPlayStateFromEngine(Player::PlayState::Stopped);
+
+    ASSERT_EQ(playlist->currentTrackIndex(), 1);
+
+    controller.queueTrack(*queuedTrack);
+
+    QSignalSpy requestSpy{&controller, &PlayerController::trackChangeRequested};
+
+    controller.play();
+
+    ASSERT_EQ(requestSpy.count(), 1);
+    const auto request = requestSpy.takeFirst().front().value<Player::TrackChangeRequest>();
+    EXPECT_EQ(request.track, *queuedTrack);
+    EXPECT_TRUE(request.isQueueTrack);
+}
+
+TEST(PlayerControllerTest, NormalScheduleSupersedesStopAfterCurrentResumeAndQueue)
+{
+    ensureCoreApplication();
+    SettingsManager settings{QDir::tempPath() + u"/fooyin_playercontroller_stop_current_schedule_test.ini"_s};
+    registerControllerSettings(settings);
+    PlaylistHandlerHarness harness{settings};
+    ASSERT_TRUE(harness.dbInitialised);
+
+    auto* playlist = harness.handler.createPlaylist(
+        u"StopAfterCurrentSchedule"_s, {makeTrack(u"/tmp/stop-after-current-schedule-a.flac"_s, 79, 1000),
+                                        makeTrack(u"/tmp/stop-after-current-schedule-b.flac"_s, 80, 1000),
+                                        makeTrack(u"/tmp/stop-after-current-schedule-c.flac"_s, 81, 1000)});
+    ASSERT_NE(playlist, nullptr);
+
+    harness.handler.changeActivePlaylist(playlist);
+    playlist->changeCurrentIndex(0);
+
+    PlayerController controller{&settings, &harness.handler};
+    const auto committedTrack = playlist->playlistTrack(0);
+    const auto resumeTrack    = playlist->playlistTrack(1);
+    const auto scheduledTrack = playlist->playlistTrack(2);
+    ASSERT_TRUE(committedTrack.has_value());
+    ASSERT_TRUE(resumeTrack.has_value());
+    ASSERT_TRUE(scheduledTrack.has_value());
+    controller.commitCurrentTrack(*committedTrack);
+
+    settings.set<Settings::Core::StopAfterCurrent>(true);
+    settings.set<Settings::Core::ResetStopAfterCurrent>(true);
+
+    controller.play();
+    controller.advance(Player::AdvanceReason::NaturalEnd);
+    controller.syncPlayStateFromEngine(Player::PlayState::Stopped);
+
+    controller.scheduleNextTrack(*scheduledTrack);
+    controller.queueTrack(*resumeTrack);
+
+    QSignalSpy requestSpy{&controller, &PlayerController::trackChangeRequested};
+
+    controller.play();
+
+    ASSERT_EQ(requestSpy.count(), 1);
+    const auto request = requestSpy.takeFirst().front().value<Player::TrackChangeRequest>();
+    EXPECT_EQ(request.track, *scheduledTrack);
+    EXPECT_FALSE(request.isQueueTrack);
+}
+
 TEST(PlayerControllerTest, CommitingPlaylistTrackSyncsActivePlaylistIndex)
 {
     ensureCoreApplication();


### PR DESCRIPTION
When Stop After Current is enabled and there's pending metadata changes for current track, the track cursor doesn't advance forward upon playback stop. This PR schedules next track for proper pick-up.