### PR TITLE
[tageditor] Fix new extended tags being duplicated by a rename

### DIFF
--- a/src/plugins/tageditor/tageditormodel.cpp
+++ b/src/plugins/tageditor/tageditormodel.cpp
@@ -513,7 +513,6 @@ void TagEditorModel::applyChanges()
                     if(fieldIt != p->m_tags.end()) {
                         const QString changedTitle = node.changedTitle();
                         auto tagItem               = p->m_tags.extract(fieldIt);
-                        field.scriptField          = tagItem.key();
                         if(p->updateTrackMetadata(field, {})) {
                             tagItem.key() = changedTitle;
                             p->m_tags.insert(std::move(tagItem));


### PR DESCRIPTION
This patch just fixes one edge case I'd missed in my last PR, which is that when you add an extended tag, apply, rename it and apply again without closing the tag editor inbetween, two tags get saved: the original and the renamed one. The cause is that we set the script field to be updated to the key from `m_tags`, which is still the default field text at this point, so we clear a non-existent tag and never get rid of the original one.