### PR TITLE
[core,gui] Add configurable audio conversion

### DIFF
--- a/include/core/engine/audioencoder.h
+++ b/include/core/engine/audioencoder.h
@@ -1,0 +1,96 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/engine/audiobuffer.h>
+#include <core/engine/conversion/conversiondefs.h>
+
+#include <QString>
+
+#include <functional>
+#include <vector>
+
+namespace Fooyin {
+struct EncoderParameterRange
+{
+    double minimum{0.0};
+    double maximum{0.0};
+    double step{1.0};
+
+    [[nodiscard]] bool isValid() const
+    {
+        return maximum > minimum && step > 0.0;
+    }
+};
+
+struct EncoderCapabilities
+{
+    std::vector<EncoderMode> modes;
+    EncoderParameterRange bitrateKbps;
+    EncoderParameterRange quality;
+    EncoderParameterRange compressionLevel;
+};
+
+struct AudioEncoderInfo
+{
+    QString id;
+    QString backendId;
+    QString name;
+    QString description;
+    EncoderProfile profile;
+    EncoderCapabilities capabilities{};
+    std::function<int(const EncoderProfile&)> estimateBitrateKbps;
+    bool supportsMetadata{false};
+    bool supportsPictures{false};
+};
+
+class FYCORE_EXPORT AudioEncoder
+{
+public:
+    struct Result
+    {
+        bool ok{false};
+        QString error;
+
+        static Result success()
+        {
+            return {.ok = true, .error = {}};
+        }
+
+        static Result failure(QString message)
+        {
+            return {.ok = false, .error = std::move(message)};
+        }
+    };
+
+    virtual ~AudioEncoder() = default;
+
+    [[nodiscard]] virtual std::vector<AudioEncoderInfo> availableEncoders() const = 0;
+
+    virtual Result init(const QString& outputPath, const AudioFormat& inputFormat, const AudioEncoderSettings& settings)
+        = 0;
+    virtual Result write(const AudioBuffer& buffer) = 0;
+    virtual Result finish()                         = 0;
+};
+
+using EncoderCreator = std::function<std::unique_ptr<AudioEncoder>()>;
+} // namespace Fooyin

--- a/include/core/engine/audioencoderregistry.h
+++ b/include/core/engine/audioencoderregistry.h
@@ -1,6 +1,6 @@
 /*
  * Fooyin
- * Copyright © 2023, Luke Taylor <luket@pm.me>
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
  *
  * Fooyin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,36 +19,31 @@
 
 #pragma once
 
-#include "ffmpegutils.h"
+#include "fycore_export.h"
 
-extern "C"
-{
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-}
+#include <core/engine/audioencoder.h>
+
+#include <vector>
 
 namespace Fooyin {
-class Codec
+class FYCORE_EXPORT AudioEncoderRegistry
 {
 public:
-    Codec() = default;
-    Codec(CodecContextPtr context, AVStream* stream);
+    void addEncoderBackend(const QString& id, const QString& name, EncoderCreator creator);
 
-    Codec(Codec&& other) noexcept;
-    Codec& operator=(Codec&& other) noexcept;
+    [[nodiscard]] std::vector<AudioEncoderInfo> availableEncoders() const;
+    [[nodiscard]] std::unique_ptr<AudioEncoder> createEncoder(const QString& encoderId) const;
 
-    Codec(const Codec& other)            = delete;
-    Codec& operator=(const Codec& other) = delete;
-
-    [[nodiscard]] bool isValid() const;
-
-    [[nodiscard]] AVCodecContext* context() const;
-    [[nodiscard]] AVStream* stream() const;
-    [[nodiscard]] int streamIndex() const;
-    [[nodiscard]] bool isPlanar() const;
+    void reset();
 
 private:
-    CodecContextPtr m_context;
-    AVStream* m_stream;
+    struct Backend
+    {
+        QString id;
+        QString name;
+        EncoderCreator creator;
+    };
+
+    std::vector<Backend> m_backends;
 };
 } // namespace Fooyin

--- a/include/core/engine/audioloader.h
+++ b/include/core/engine/audioloader.h
@@ -152,6 +152,12 @@ public:
     [[nodiscard]] std::vector<std::unique_ptr<AudioDecoder>> decodersForTrack(const Track& track) const;
     //! Create metadata reader candidates for `file`, ordered by configured priority.
     [[nodiscard]] std::vector<std::unique_ptr<AudioReader>> readersForFile(const QString& file) const;
+    /*!
+     * Create metadata reader candidates for `file`, ordered by configured priority.
+     * When @p includeDisabled is @c true, candidates disabled for metadata reading are also returned.
+     */
+    [[nodiscard]] std::vector<std::unique_ptr<AudioReader>> readersForFile(const QString& file,
+                                                                           bool includeDisabled) const;
     //! Create metadata reader candidates for `track`, ordered by configured priority.
     [[nodiscard]] std::vector<std::unique_ptr<AudioReader>> readersForTrack(const Track& track) const;
     //! Create the highest-priority archive reader backend for `file`, if any.

--- a/include/core/engine/conversion/conversiondefs.h
+++ b/include/core/engine/conversion/conversiondefs.h
@@ -1,0 +1,148 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/engine/audioformat.h>
+#include <core/engine/enginedefs.h>
+#include <core/track.h>
+
+#include <QString>
+
+namespace Fooyin {
+enum class DitherMode : uint8_t
+{
+    Never = 0,
+    LossySourceOnly,
+    Always,
+};
+
+enum class EncoderMode : uint8_t
+{
+    Default = 0,
+    VariableBitrate,
+    ConstrainedVariableBitrate,
+    ConstantQuality,
+    AverageBitrate,
+    ConstantBitrate,
+    LosslessCompression,
+};
+
+struct EncoderProfile
+{
+    QString id;
+    QString name;
+    QString extension;
+    QString containerName;
+    QString codecName;
+    EncoderMode mode{EncoderMode::Default};
+    int bitrateKbps{0};
+    double quality{0.0};
+    int compressionLevel{-1};
+};
+
+struct AudioEncoderSettings
+{
+    EncoderProfile profile;
+    SampleFormat outputSampleFormat{SampleFormat::Unknown};
+    DitherMode ditherMode{DitherMode::Never};
+};
+
+enum class DestinationMode : uint8_t
+{
+    Ask = 0,
+    SourceFolder,
+    FixedFolder,
+};
+
+enum class ExistingFileMode : uint8_t
+{
+    Ask = 0,
+    Skip,
+    Overwrite,
+};
+
+enum class OutputStyle : uint8_t
+{
+    IndividualFiles = 0,
+    MultiTrackFiles,
+    MergeTracks,
+};
+
+enum class ConversionReplayGainMode : uint8_t
+{
+    None = 0,
+    Track,
+    Album,
+};
+
+struct ConversionDestination
+{
+    DestinationMode mode{DestinationMode::Ask};
+    QString fixedFolder;
+    QString filenamePattern{QStringLiteral("%title%")};
+    ExistingFileMode existingFileMode{ExistingFileMode::Ask};
+    OutputStyle outputStyle{OutputStyle::IndividualFiles};
+};
+
+struct ConversionProcessing
+{
+    bool transferMetadata{true};
+    bool transferRating{true};
+    bool transferPlaycount{false};
+    bool transferPictures{true};
+    ConversionReplayGainMode replayGainMode{ConversionReplayGainMode::None};
+    bool replayGainPreventClipping{true};
+    double replayGainPreampDb{0.0};
+    double replayGainWithoutInfoPreampDb{0.0};
+    Engine::DspChain dspChain;
+    bool preserveDspStateBetweenTracks{false};
+};
+
+struct ConversionPreview
+{
+    bool enabled{false};
+    int lengthPercentage{20};
+};
+
+struct ConversionOther
+{
+    QString copyFilesPattern;
+    bool verifyOutput{false};
+};
+
+struct ConversionPreset
+{
+    QString id;
+    QString name;
+    AudioEncoderSettings encoder;
+    ConversionDestination destination;
+    ConversionProcessing processing;
+    ConversionPreview preview;
+    ConversionOther other;
+};
+
+struct ConversionJob
+{
+    TrackList tracks;
+    ConversionPreset preset;
+};
+} // namespace Fooyin

--- a/include/core/engine/conversion/conversionpathresolver.h
+++ b/include/core/engine/conversion/conversionpathresolver.h
@@ -1,0 +1,66 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/engine/conversion/conversiondefs.h>
+
+#include <QCoreApplication>
+#include <QString>
+
+#include <vector>
+
+namespace Fooyin {
+enum class ConversionPathStatus : uint8_t
+{
+    Ready = 0,
+    Skipped,
+    NeedsOverwriteDecision,
+    Error,
+};
+
+struct ConversionPathResult
+{
+    Track track;
+    TrackList tracks;
+    QString outputPath;
+    ConversionPathStatus status{ConversionPathStatus::Error};
+    QString error;
+};
+
+class FYCORE_EXPORT ConversionPathResolver
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::ConversionPathResolver)
+
+public:
+    struct Request
+    {
+        TrackList tracks;
+        ConversionDestination destination;
+        QString extension;
+        QString askFolder;
+    };
+
+    static std::vector<ConversionPathResult> resolve(const Request& request);
+    static QString previewPath(const Track& track, const ConversionDestination& destination, const QString& extension,
+                               const QString& askFolder = {});
+};
+} // namespace Fooyin

--- a/include/core/engine/conversion/conversionrunner.h
+++ b/include/core/engine/conversion/conversionrunner.h
@@ -1,0 +1,81 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/engine/audioencoderregistry.h>
+#include <core/engine/audioloader.h>
+#include <core/engine/conversion/conversionpathresolver.h>
+
+#include <QStringList>
+
+#include <functional>
+
+namespace Fooyin {
+class DspRegistry;
+
+enum class ConversionResultStatus : uint8_t
+{
+    Succeeded = 0,
+    Skipped,
+    Failed,
+    Cancelled,
+};
+
+struct ConversionTrackResult
+{
+    Track sourceTrack;
+    QString outputPath;
+    ConversionResultStatus status{ConversionResultStatus::Failed};
+    QString error;
+    QStringList warnings;
+};
+
+struct ConversionProgress
+{
+    int trackIndex{0};
+    int trackCount{0};
+    QString sourcePath;
+    QString outputPath;
+    uint64_t sourcePositionMs{0};
+    uint64_t sourceDurationMs{0};
+};
+
+namespace ConversionRunner {
+using ProgressCallback     = std::function<void(const ConversionProgress&)>;
+using CancelCallback       = std::function<bool()>;
+using ExistingFileCallback = std::function<ExistingFileMode(const QString&)>;
+
+struct Request
+{
+    AudioLoader* audioLoader{nullptr};
+    AudioEncoderRegistry* encoderRegistry{nullptr};
+    DspRegistry* dspRegistry{nullptr};
+    ConversionJob job;
+    QString askFolder;
+    ProgressCallback progressCallback;
+    CancelCallback cancelCallback;
+    ExistingFileCallback existingFileCallback;
+};
+
+FYCORE_EXPORT std::vector<ConversionTrackResult> run(const Request& request);
+}; // namespace ConversionRunner
+} // namespace Fooyin

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -111,6 +111,7 @@ constexpr auto ArtworkAttach       = "Fooyin.Menu.Artwork.Attach";
 constexpr auto Tagging             = "Fooyin.Menu.Tagging";
 constexpr auto TrackFinalSeparator = "Fooyin.Menu.Track.FinalSeparator";
 constexpr auto Utilities           = "Fooyin.Menu.Utilities";
+constexpr auto Convert             = "Fooyin.Menu.Convert";
 } // namespace Context
 } // namespace Menus
 
@@ -219,6 +220,9 @@ constexpr auto SearchArtwork             = "Tracks.SearchArtwork";
 constexpr auto SearchArtworkQuick        = "Tracks.SearchArtworkQuick";
 constexpr auto ExportArtwork             = "Tracks.ExportArtwork";
 constexpr auto RemoveArtwork             = "Tracks.RemoveArtwork";
+constexpr auto Convert                   = "Tracks.Convert";
+constexpr auto ConvertDefault            = "Tracks.Convert.Default";
+constexpr auto ConvertLastUsed           = "Tracks.Convert.LastUsed";
 constexpr auto OpenProperties            = "Tracks.OpenProperties";
 constexpr auto TogglePropertiesTrackList = "Tracks.Properties.ToggleTrackList";
 constexpr auto PropertiesPreviousTrack   = "Tracks.Properties.PreviousTrack";

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,10 +3,15 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/core/coresettings.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audiobuffer.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audioconverter.h
+    ${CMAKE_SOURCE_DIR}/include/core/engine/audioencoder.h
+    ${CMAKE_SOURCE_DIR}/include/core/engine/audioencoderregistry.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audioformat.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audioinput.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audioloader.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/audiooutput.h
+    ${CMAKE_SOURCE_DIR}/include/core/engine/conversion/conversiondefs.h
+    ${CMAKE_SOURCE_DIR}/include/core/engine/conversion/conversionpathresolver.h
+    ${CMAKE_SOURCE_DIR}/include/core/engine/conversion/conversionrunner.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/dsp/dspnode.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/dsp/dspplugin.h
     ${CMAKE_SOURCE_DIR}/include/core/engine/dsp/processingbuffer.h
@@ -79,6 +84,7 @@ set(SOURCES
     engine/audioanalysisbus.h
     engine/audiobuffer.cpp
     engine/audioconverter.cpp
+    engine/audioencoderregistry.cpp
     engine/audioengine.cpp
     engine/audioengine.h
     engine/audioformat.cpp
@@ -86,6 +92,10 @@ set(SOURCES
     engine/audioloader.cpp
     engine/audioutils.cpp
     engine/audioutils.h
+    engine/conversion/conversionpathresolver.cpp
+    engine/conversion/conversionrunner.cpp
+    engine/conversion/outputtransaction.cpp
+    engine/conversion/outputtransaction.h
     engine/control/enginetaskqueue.cpp
     engine/control/enginetaskqueue.h
     engine/control/playbackintentreducer.cpp
@@ -143,6 +153,8 @@ set(SOURCES
     engine/input/archiveinput.h
     engine/input/ffmpeg/ffmpegcodec.cpp
     engine/input/ffmpeg/ffmpegcodec.h
+    engine/input/ffmpeg/ffmpegencoder.cpp
+    engine/input/ffmpeg/ffmpegencoder.h
     engine/input/ffmpeg/ffmpegframe.cpp
     engine/input/ffmpeg/ffmpegframe.h
     engine/input/ffmpeg/ffmpeginput.cpp

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -27,6 +27,7 @@
 #include "engine/enginehandler.h"
 #include "engine/enginehelpers.h"
 #include "engine/input/archiveinput.h"
+#include "engine/input/ffmpeg/ffmpegencoder.h"
 #include "engine/input/ffmpeg/ffmpeginput.h"
 #include "engine/input/taglibparser.h"
 #include "internalcoresettings.h"
@@ -41,6 +42,7 @@
 
 #include <core/coresettings.h>
 #include <core/engine/audiobuffer.h>
+#include <core/engine/audioencoderregistry.h>
 #include <core/engine/audioloader.h>
 #include <core/engine/dsp/dspplugin.h>
 #include <core/engine/outputplugin.h>
@@ -95,6 +97,7 @@ Application::Application(QObject* parent)
     , m_coreSettings{m_settings}
     , m_database{new Database(this)}
     , m_audioLoader{std::make_shared<AudioLoader>()}
+    , m_audioEncoderRegistry{std::make_unique<AudioEncoderRegistry>()}
     , m_dspRegistry{std::make_unique<DspRegistry>()}
     , m_dspChainStore{std::make_unique<DspChainStore>(m_settings, m_dspRegistry.get())}
     , m_networkManager{std::make_shared<NetworkAccessManager>(m_settings)}
@@ -273,6 +276,11 @@ std::shared_ptr<AudioLoader> Application::audioLoader() const
     return m_audioLoader;
 }
 
+AudioEncoderRegistry* Application::audioEncoderRegistry() const
+{
+    return m_audioEncoderRegistry.get();
+}
+
 std::shared_ptr<NetworkAccessManager> Application::networkManager() const
 {
     return m_networkManager;
@@ -341,6 +349,8 @@ void Application::registerPlaylistParsers()
 
 void Application::registerInputs()
 {
+    m_audioEncoderRegistry->addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s,
+                                              []() { return std::make_unique<FFmpegEncoder>(); });
     m_audioLoader->addDecoder(
         u"Archive"_s, [this]() { return std::make_unique<ArchiveDecoder>(m_audioLoader); }, -1, true);
     m_audioLoader->addReader(

--- a/src/core/application.h
+++ b/src/core/application.h
@@ -36,6 +36,7 @@
 
 namespace Fooyin {
 class AudioLoader;
+class AudioEncoderRegistry;
 class Database;
 class DspChainStore;
 class DspRegistry;
@@ -79,6 +80,7 @@ public:
     [[nodiscard]] EngineController* engine() const;
     [[nodiscard]] std::shared_ptr<PlaylistLoader> playlistLoader() const;
     [[nodiscard]] std::shared_ptr<AudioLoader> audioLoader() const;
+    [[nodiscard]] AudioEncoderRegistry* audioEncoderRegistry() const;
     [[nodiscard]] std::shared_ptr<NetworkAccessManager> networkManager() const;
     [[nodiscard]] std::shared_ptr<RemoteIoService> remoteIoService() const;
     [[nodiscard]] SortingRegistry* sortingRegistry() const;
@@ -109,6 +111,7 @@ private:
     TranslationLoader m_translations;
     Database* m_database;
     std::shared_ptr<AudioLoader> m_audioLoader;
+    std::unique_ptr<AudioEncoderRegistry> m_audioEncoderRegistry;
     std::unique_ptr<DspRegistry> m_dspRegistry;
     std::unique_ptr<DspChainStore> m_dspChainStore;
     std::shared_ptr<NetworkAccessManager> m_networkManager;

--- a/src/core/engine/audioencoderregistry.cpp
+++ b/src/core/engine/audioencoderregistry.cpp
@@ -1,0 +1,89 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/audioencoderregistry.h>
+
+namespace Fooyin {
+void AudioEncoderRegistry::addEncoderBackend(const QString& id, const QString& name, EncoderCreator creator)
+{
+    if(id.isEmpty() || !creator) {
+        return;
+    }
+
+    std::erase_if(m_backends, [&id](const Backend& backend) { return backend.id == id; });
+    m_backends.emplace_back(id, name, std::move(creator));
+}
+
+std::vector<AudioEncoderInfo> AudioEncoderRegistry::availableEncoders() const
+{
+    std::vector<AudioEncoderInfo> encoders;
+
+    for(const Backend& backend : m_backends) {
+        const auto encoder = backend.creator();
+        if(!encoder) {
+            continue;
+        }
+
+        const auto encoderInfos = encoder->availableEncoders();
+        for(AudioEncoderInfo info : encoderInfos) {
+            if(info.backendId.isEmpty()) {
+                info.backendId = backend.id;
+            }
+            if(info.id.isEmpty()) {
+                info.id = info.profile.id;
+            }
+            if(info.id.isEmpty()) {
+                continue;
+            }
+            encoders.push_back(std::move(info));
+        }
+    }
+
+    return encoders;
+}
+
+std::unique_ptr<AudioEncoder> AudioEncoderRegistry::createEncoder(const QString& encoderId) const
+{
+    if(encoderId.isEmpty()) {
+        return {};
+    }
+
+    for(const Backend& backend : m_backends) {
+        auto probe = backend.creator();
+        if(!probe) {
+            continue;
+        }
+
+        const auto infos   = probe->availableEncoders();
+        const bool matches = std::ranges::any_of(infos, [&encoderId](const AudioEncoderInfo& info) {
+            return info.id == encoderId || (!info.profile.id.isEmpty() && info.profile.id == encoderId);
+        });
+        if(matches) {
+            return backend.creator();
+        }
+    }
+
+    return {};
+}
+
+void AudioEncoderRegistry::reset()
+{
+    m_backends.clear();
+}
+} // namespace Fooyin

--- a/src/core/engine/audioloader.cpp
+++ b/src/core/engine/audioloader.cpp
@@ -95,11 +95,12 @@ void sortLoaderEntries(std::vector<T>& entries)
 }
 
 template <typename EntryT, typename CreatorT>
-CreatorT selectTrackIoCreator(const std::vector<EntryT>& loaders, const QString& ext, bool isInArchive)
+CreatorT selectTrackIoCreator(const std::vector<EntryT>& loaders, const QString& ext, bool isInArchive,
+                              bool includeDisabled = false)
 {
     CreatorT ret;
     for(const auto& loader : loaders) {
-        if(!loader.enabled) {
+        if(!includeDisabled && !loader.enabled) {
             continue;
         }
         if(isInArchive) {
@@ -118,12 +119,13 @@ CreatorT selectTrackIoCreator(const std::vector<EntryT>& loaders, const QString&
 }
 
 template <typename EntryT, typename CreatorT, typename CapabilityFn>
-CreatorT selectRemoteTrackIoCreator(const std::vector<EntryT>& loaders, CapabilityFn&& capabilityFn)
+CreatorT selectRemoteTrackIoCreator(const std::vector<EntryT>& loaders, CapabilityFn&& capabilityFn,
+                                    bool includeDisabled = false)
 {
     CreatorT ret;
 
     for(const auto& loader : loaders) {
-        if(!loader.enabled || loader.isArchiveWrapper) {
+        if((!includeDisabled && !loader.enabled) || loader.isArchiveWrapper) {
             continue;
         }
 
@@ -388,7 +390,7 @@ bool AudioLoader::canWriteMetadata(const Track& track) const
         return false;
     }
 
-    for(auto& reader : readersForTrack(track)) {
+    for(auto& reader : readersForFile(track.filepath(), true)) {
         bool initSuccess{true};
         if(track.isInArchive()) {
             initSuccess = reader->init({.filepath = track.filepath(), .device = nullptr, .archiveReader = nullptr});
@@ -605,6 +607,11 @@ std::vector<std::unique_ptr<AudioDecoder>> AudioLoader::decodersForTrack(const T
 
 std::vector<std::unique_ptr<AudioReader>> AudioLoader::readersForFile(const QString& file) const
 {
+    return readersForFile(file, false);
+}
+
+std::vector<std::unique_ptr<AudioReader>> AudioLoader::readersForFile(const QString& file, bool includeDisabled) const
+{
     const QString ext      = QFileInfo{file}.suffix().toLower();
     const bool isInArchive = Track::isArchivePath(file);
 
@@ -613,11 +620,12 @@ std::vector<std::unique_ptr<AudioReader>> AudioLoader::readersForFile(const QStr
         const std::shared_lock lock{p->m_mutex};
         if(Track::isRemotePath(file)) {
             creators = selectRemoteTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(
-                p->m_readers, [](const AudioReader& reader) { return reader.supportsRemoteSources(); });
+                p->m_readers, [](const AudioReader& reader) { return reader.supportsRemoteSources(); },
+                includeDisabled);
         }
         else {
-            creators = selectTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(p->m_readers, ext,
-                                                                                                    isInArchive);
+            creators = selectTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(
+                p->m_readers, ext, isInArchive, includeDisabled);
         }
     }
 
@@ -759,7 +767,7 @@ bool AudioLoader::writeTrackMetadata(const Track& track, AudioReader::WriteOptio
         return false;
     }
 
-    const auto readers = readersForTrack(track);
+    const auto readers = readersForFile(track.filepath(), true);
     for(const auto& reader : readers) {
         if(!reader->canWriteMetaData()) {
             continue;
@@ -795,7 +803,7 @@ bool AudioLoader::writeTrackCover(const Track& track, const TrackCovers& coverDa
         return false;
     }
 
-    const auto readers = readersForTrack(track);
+    const auto readers = readersForFile(track.filepath(), true);
     for(const auto& reader : readers) {
         if(!reader->canWriteCover()) {
             continue;

--- a/src/core/engine/conversion/conversionpathresolver.cpp
+++ b/src/core/engine/conversion/conversionpathresolver.cpp
@@ -1,0 +1,218 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/conversion/conversionpathresolver.h>
+
+#include <core/scripting/scriptparser.h>
+#include <utils/fileutils.h>
+
+#include <QDir>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+#include <map>
+#include <set>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+QString normaliseExtension(QString extension)
+{
+    extension = extension.trimmed();
+    while(extension.startsWith(u'.')) {
+        extension.remove(0, 1);
+    }
+    return extension.toLower();
+}
+
+QString sanitisePathSegment(QString segment)
+{
+    static const QRegularExpression invalidChars{uR"([<>:"|?*\x00-\x1f])"_s};
+
+    segment = segment.trimmed();
+    segment.replace(u'\\', u'/');
+    segment.replace(invalidChars, u"_"_s);
+
+    const QStringList parts = segment.split(u'/', Qt::SkipEmptyParts);
+    QStringList cleanParts;
+    cleanParts.reserve(parts.size());
+
+    for(QString part : parts) {
+        part = part.trimmed();
+        while(part.endsWith(u'.') || part.endsWith(u' ')) {
+            part.chop(1);
+        }
+        if(part.isEmpty() || part == u"."_s || part == u".."_s) {
+            continue;
+        }
+        cleanParts.push_back(part);
+    }
+
+    return cleanParts.join(u'/');
+}
+
+QString fallbackFilename(const Track& track)
+{
+    QString filename = track.effectiveTitle().trimmed();
+    if(filename.isEmpty()) {
+        filename = track.filename().trimmed();
+    }
+    return filename;
+}
+
+QString appendExtension(QString path, const QString& extension)
+{
+    const QString cleanExtension = normaliseExtension(extension);
+    if(cleanExtension.isEmpty()) {
+        return path;
+    }
+
+    if(path.endsWith(u'.' + cleanExtension, Qt::CaseInsensitive)) {
+        return path;
+    }
+
+    return path + u'.' + cleanExtension;
+}
+
+QString destinationFolder(const Track& track, const ConversionDestination& destination, const QString& askFolder)
+{
+    switch(destination.mode) {
+        case DestinationMode::Ask:
+            return QDir::cleanPath(askFolder);
+        case DestinationMode::SourceFolder:
+            return QDir::cleanPath(QFileInfo{track.filepath()}.absolutePath());
+        case DestinationMode::FixedFolder:
+            return QDir::cleanPath(destination.fixedFolder);
+    }
+
+    return {};
+}
+} // namespace
+
+std::vector<ConversionPathResult> ConversionPathResolver::resolve(const Request& request)
+{
+    if(request.tracks.empty()) {
+        return {};
+    }
+
+    std::vector<ConversionPathResult> results;
+
+    if(request.destination.outputStyle == OutputStyle::MergeTracks) {
+        const Track& track = request.tracks.front();
+        results.push_back({
+            .track      = track,
+            .tracks     = request.tracks,
+            .outputPath = previewPath(track, request.destination, request.extension, request.askFolder),
+            .status     = ConversionPathStatus::Error,
+            .error      = {},
+        });
+    }
+    else if(request.destination.outputStyle == OutputStyle::MultiTrackFiles) {
+        std::map<QString, size_t> groupIndices;
+        for(const Track& track : request.tracks) {
+            const QString outputPath = previewPath(track, request.destination, request.extension, request.askFolder);
+            const QString key        = Utils::File::cleanPath(outputPath).toCaseFolded();
+            if(const auto it = groupIndices.find(key); it != groupIndices.end()) {
+                results[it->second].tracks.push_back(track);
+                continue;
+            }
+            groupIndices.emplace(key, results.size());
+            results.push_back({
+                .track      = track,
+                .tracks     = {track},
+                .outputPath = outputPath,
+                .status     = ConversionPathStatus::Error,
+                .error      = {},
+            });
+        }
+    }
+    else {
+        std::set<QString> seenPaths;
+        results.reserve(request.tracks.size());
+        for(const Track& track : request.tracks) {
+            const QString outputPath = previewPath(track, request.destination, request.extension, request.askFolder);
+            const QString key        = Utils::File::cleanPath(outputPath).toCaseFolded();
+            ConversionPathResult result{
+                .track      = track,
+                .tracks     = {track},
+                .outputPath = outputPath,
+                .status     = ConversionPathStatus::Error,
+                .error      = {},
+            };
+            if(seenPaths.contains(key)) {
+                result.status = ConversionPathStatus::Error;
+                result.error  = tr("Duplicate output path");
+            }
+            else {
+                seenPaths.emplace(key);
+            }
+            results.push_back(std::move(result));
+        }
+    }
+
+    for(ConversionPathResult& result : results) {
+        if(result.status == ConversionPathStatus::Error && !result.error.isEmpty()) {
+            continue;
+        }
+        if(result.outputPath.isEmpty()) {
+            result.status = ConversionPathStatus::Error;
+            result.error  = tr("Could not resolve output path");
+            continue;
+        }
+
+        if(const QFileInfo info{result.outputPath}; !info.exists()) {
+            result.status = ConversionPathStatus::Ready;
+            continue;
+        }
+
+        switch(request.destination.existingFileMode) {
+            case ExistingFileMode::Skip:
+                result.status = ConversionPathStatus::Skipped;
+                break;
+            case ExistingFileMode::Overwrite:
+                result.status = ConversionPathStatus::Ready;
+                break;
+            case ExistingFileMode::Ask:
+                result.status = ConversionPathStatus::NeedsOverwriteDecision;
+                break;
+        }
+    }
+
+    return results;
+}
+
+QString ConversionPathResolver::previewPath(const Track& track, const ConversionDestination& destination,
+                                            const QString& extension, const QString& askFolder)
+{
+    const QString folder = destinationFolder(track, destination, askFolder);
+    if(folder.isEmpty()) {
+        return {};
+    }
+
+    ScriptParser parser;
+    QString filename = parser.evaluate(destination.filenamePattern, track).trimmed();
+    filename         = sanitisePathSegment(filename);
+    if(filename.isEmpty()) {
+        filename = sanitisePathSegment(fallbackFilename(track));
+    }
+
+    return QDir::cleanPath(QDir{folder}.filePath(appendExtension(filename, extension)));
+}
+} // namespace Fooyin

--- a/src/core/engine/conversion/conversionrunner.cpp
+++ b/src/core/engine/conversion/conversionrunner.cpp
@@ -1,0 +1,1096 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/conversion/conversionrunner.h>
+
+#include "engine/output/postprocessor/replaygainprocessor.h"
+
+#include "outputtransaction.h"
+
+#include <core/engine/audioconverter.h>
+#include <core/engine/dsp/dspchain.h>
+#include <core/engine/dsp/dspregistry.h>
+#include <core/engine/dsp/processingbuffer.h>
+#include <core/engine/dsp/processingbufferlist.h>
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QMimeDatabase>
+#include <QSaveFile>
+#include <QScopeGuard>
+
+#include <array>
+#include <expected>
+#include <limits>
+#include <optional>
+#include <set>
+#include <span>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+constexpr size_t TargetReadBytes = 256UL * 1024;
+
+namespace Fooyin {
+namespace {
+bool shouldCancel(const ConversionRunner::Request& request)
+{
+    return request.cancelCallback && request.cancelCallback();
+}
+
+void reportProgress(const ConversionRunner::Request& request, int index, const Track& track, const QString& outputPath,
+                    uint64_t positionMs)
+{
+    if(!request.progressCallback) {
+        return;
+    }
+
+    request.progressCallback({
+        .trackIndex       = index,
+        .trackCount       = static_cast<int>(request.job.tracks.size()),
+        .sourcePath       = track.filepath(),
+        .outputPath       = outputPath,
+        .sourcePositionMs = positionMs,
+        .sourceDurationMs = track.duration(),
+    });
+}
+
+ConversionTrackResult failedResult(const Track& track, const QString& outputPath, QString error)
+{
+    return {
+        .sourceTrack = track,
+        .outputPath  = outputPath,
+        .status      = ConversionResultStatus::Failed,
+        .error       = std::move(error),
+        .warnings    = {},
+    };
+}
+
+bool profileSupportsPictures(const AudioEncoderRegistry& registry, const QString& profileId)
+{
+    const auto encoders = registry.availableEncoders();
+    const auto it = std::ranges::find_if(encoders, [&profileId](const auto& info) { return info.id == profileId; });
+    return it != encoders.end() && it->supportsPictures;
+}
+
+TrackCovers readCovers(const AudioLoader& loader, const Track& track)
+{
+    constexpr std::array coverTypes{
+        Track::Cover::Front,
+        Track::Cover::Back,
+        Track::Cover::Artist,
+        Track::Cover::Other,
+    };
+
+    static const QMimeDatabase mimeDb;
+    TrackCovers covers;
+
+    for(const Track::Cover type : coverTypes) {
+        QByteArray data = loader.readTrackCover(track, type);
+        if(data.isEmpty()) {
+            continue;
+        }
+        covers.emplace(type, CoverImage{.mimeType = mimeDb.mimeTypeForData(data).name(), .data = std::move(data)});
+    }
+
+    return covers;
+}
+
+QStringList copySidecarFiles(const QString& pattern, const TrackList& tracks, const QString& outputPath,
+                             std::set<QString>& handledCopies)
+{
+    QStringList filters;
+
+    const auto parts = pattern.split(u';', Qt::SkipEmptyParts);
+    for(QString filter : parts) {
+        filter = filter.trimmed();
+        if(!filter.isEmpty()) {
+            filters.push_back(std::move(filter));
+        }
+    }
+
+    if(filters.isEmpty()) {
+        return {};
+    }
+
+    QStringList warnings;
+    std::set<QString> sourceFolders;
+
+    const QFileInfo outputInfo{outputPath};
+    const QDir destination = outputInfo.absoluteDir();
+
+    for(const Track& track : tracks) {
+        const QDir source        = QFileInfo{track.filepath()}.absoluteDir();
+        const QString sourcePath = source.absolutePath();
+        if(sourceFolders.contains(sourcePath)) {
+            continue;
+        }
+        sourceFolders.emplace(sourcePath);
+
+        const QFileInfoList files
+            = source.entryInfoList(filters, QDir::Files | QDir::Readable | QDir::NoDotAndDotDot, QDir::Name);
+        for(const QFileInfo& file : files) {
+            const QString sourceFile      = file.absoluteFilePath();
+            const QString destinationFile = destination.filePath(file.fileName());
+            if(sourceFile == outputInfo.absoluteFilePath() || sourceFile == destinationFile) {
+                continue;
+            }
+
+            const QString copyKey = sourceFile + u'\n' + destinationFile;
+            if(handledCopies.contains(copyKey)) {
+                continue;
+            }
+            handledCopies.insert(copyKey);
+
+            if(QFileInfo::exists(destinationFile)) {
+                warnings.push_back(u"Sidecar file already exists: %1"_s.arg(file.fileName()));
+                continue;
+            }
+            if(!QFile::copy(sourceFile, destinationFile)) {
+                warnings.push_back(u"Failed to copy sidecar file: %1"_s.arg(file.fileName()));
+            }
+        }
+    }
+
+    return warnings;
+}
+
+QString verifyOutput(const AudioLoader& loader, const QString& outputPath)
+{
+    auto loaded = loader.loadDecoderForTrack(Track{outputPath}, AudioDecoder::NoLooping);
+    if(!loaded.decoder || !loaded.format) {
+        return u"Converted output could not be opened"_s;
+    }
+
+    loaded.decoder->start();
+
+    const auto stopDecoder = qScopeGuard([&loaded] { loaded.decoder->stop(); });
+    for(int attempt{0}; attempt < 1000; ++attempt) {
+        const auto result = loaded.decoder->readAudio(TargetReadBytes);
+        if(result.status == AudioDecoder::ReadStatus::DecodedAudio && result.buffer.isValid()) {
+            return {};
+        }
+        if(result.status == AudioDecoder::ReadStatus::EndOfStream || result.status == AudioDecoder::ReadStatus::Error) {
+            return !result.error.isEmpty() ? result.error : u"Converted output contains no decodable audio"_s;
+        }
+    }
+    return u"Converted output verification did not complete"_s;
+}
+
+struct PcmHashResult
+{
+    bool ok{false};
+    AudioFormat format;
+    QByteArray hash;
+    uint64_t frames{0};
+    QString error;
+};
+
+uint64_t framesForDuration(uint64_t durationMs, int sampleRate)
+{
+    const uint64_t secs = durationMs / 1000;
+    const uint64_t rem  = durationMs % 1000;
+
+    const auto sRate = static_cast<uint64_t>(sampleRate);
+
+    if(secs > static_cast<uint64_t>(std::numeric_limits<int>::max()) / sRate) {
+        return std::numeric_limits<int>::max();
+    }
+
+    const uint64_t frames = (secs * sRate) + ((rem * sRate) / 1000);
+
+    return static_cast<int>(frames);
+}
+
+AudioBuffer trimBuffer(const AudioBuffer& buffer, int frames)
+{
+    if(!buffer.isValid() || frames < 0 || frames >= buffer.frameCount()) {
+        return buffer;
+    }
+
+    const auto bytes = static_cast<size_t>(buffer.format().bytesForFrames(frames));
+    return {buffer.constData().first(bytes), buffer.format(), buffer.startTime()};
+}
+
+PcmHashResult pcmHashFailure(QString error)
+{
+    PcmHashResult result;
+    result.error = std::move(error);
+    return result;
+}
+
+PcmHashResult calculatePcmHash(const AudioLoader& loader, const Track& track,
+                               std::optional<AudioFormat> comparisonFormat, SampleFormat sampleFormat)
+{
+    auto loaded = loader.loadDecoderForTrack(track, AudioDecoder::NoLooping);
+    if(!loaded.decoder || !loaded.format) {
+        return pcmHashFailure(u"PCM verification could not open input"_s);
+    }
+
+    AudioFormat format = comparisonFormat.value_or(*loaded.format);
+    if(!comparisonFormat && sampleFormat != SampleFormat::Unknown) {
+        format.setSampleFormat(sampleFormat);
+    }
+
+    if(loaded.format->sampleRate() != format.sampleRate() || loaded.format->channelCount() != format.channelCount()) {
+        return pcmHashFailure(u"PCM verification format mismatch"_s);
+    }
+
+    loaded.decoder->start();
+    const auto stopDecoder = qScopeGuard([&loaded] { loaded.decoder->stop(); });
+
+    if(track.offset() > 0) {
+        if(!loaded.decoder->isSeekable()) {
+            return pcmHashFailure(u"PCM verification cannot seek to the track segment"_s);
+        }
+        loaded.decoder->seek(track.offset());
+    }
+
+    std::optional<uint64_t> framesRemaining;
+    if(track.isBoundedSegment() && track.duration() > 0) {
+        const uint64_t duration = track.duration();
+        framesRemaining         = framesForDuration(duration, loaded.format->sampleRate());
+    }
+
+    QCryptographicHash hash{QCryptographicHash::Sha256};
+    uint64_t frames{0};
+
+    while(true) {
+        auto result = loaded.decoder->readAudio(TargetReadBytes);
+        if(result.status == AudioDecoder::ReadStatus::NeedMoreInput) {
+            continue;
+        }
+        if(result.status == AudioDecoder::ReadStatus::EndOfStream) {
+            break;
+        }
+        if(result.status == AudioDecoder::ReadStatus::Error) {
+            return pcmHashFailure(!result.error.isEmpty() ? result.error : u"PCM verification decode failed"_s);
+        }
+
+        AudioBuffer buffer{result.buffer};
+
+        if(framesRemaining) {
+            const int count
+                = static_cast<int>(std::min<uint64_t>(*framesRemaining, static_cast<uint64_t>(buffer.frameCount())));
+            buffer = trimBuffer(buffer, count);
+            *framesRemaining -= static_cast<uint64_t>(count);
+        }
+
+        const AudioBuffer converted = buffer.format() == format ? buffer : Audio::convert(buffer, format);
+        if(!converted.isValid()) {
+            return pcmHashFailure(u"PCM verification conversion failed"_s);
+        }
+
+        const auto bytes = converted.constData();
+        hash.addData(QByteArrayView{reinterpret_cast<const char*>(bytes.data()), static_cast<qsizetype>(bytes.size())});
+        frames += static_cast<uint64_t>(converted.frameCount());
+
+        if(framesRemaining && *framesRemaining == 0) {
+            break;
+        }
+    }
+
+    PcmHashResult result;
+    result.ok     = true;
+    result.format = format;
+    result.hash   = hash.result();
+    result.frames = frames;
+    return result;
+}
+
+bool supportsLosslessPcmVerification(const ConversionPreset& preset)
+{
+    const auto& processing = preset.processing;
+    const auto& profile    = preset.encoder.profile;
+    const bool lossless    = profile.mode == EncoderMode::LosslessCompression
+                          || profile.codecName.startsWith(u"pcm_"_s, Qt::CaseInsensitive);
+    return lossless && preset.encoder.ditherMode == DitherMode::Never && !preset.preview.enabled
+        && processing.replayGainMode == ConversionReplayGainMode::None && processing.dspChain.empty();
+}
+
+QString verifyLosslessPcm(const AudioLoader& loader, const Track& source, const QString& outputPath,
+                          const ConversionPreset& preset)
+{
+    const PcmHashResult expected = calculatePcmHash(loader, source, {}, preset.encoder.outputSampleFormat);
+    if(!expected.ok) {
+        return expected.error;
+    }
+
+    const PcmHashResult actual = calculatePcmHash(loader, Track{outputPath}, expected.format, SampleFormat::Unknown);
+    if(!actual.ok) {
+        return actual.error;
+    }
+
+    if(expected.frames != actual.frames || expected.hash != actual.hash) {
+        return u"Lossless PCM verification failed"_s;
+    }
+
+    return {};
+}
+
+std::unique_ptr<ReplayGainProcessor> createReplayGainProcessor(const ConversionProcessing& processing,
+                                                               const Track& track, const AudioFormat& format)
+{
+    if(processing.replayGainMode == ConversionReplayGainMode::None) {
+        return {};
+    }
+
+    auto sharedSettings = ReplayGainProcessor::makeSharedSettings();
+    sharedSettings->update([&processing](ReplayGainProcessor::RuntimeSettings& settings) {
+        settings.mode       = processing.replayGainMode == ConversionReplayGainMode::Track
+                                ? ReplayGainProcessor::SelectionMode::Track
+                                : ReplayGainProcessor::SelectionMode::Album;
+        settings.processing = Engine::RGProcessing{Engine::ApplyGain};
+        if(processing.replayGainPreventClipping) {
+            settings.processing |= Engine::PreventClipping;
+        }
+        settings.rgPreampDb    = processing.replayGainPreampDb;
+        settings.nonRgPreampDb = processing.replayGainWithoutInfoPreampDb;
+    });
+
+    auto processor = std::make_unique<ReplayGainProcessor>(
+        std::shared_ptr<const ReplayGainProcessor::SharedSettings>{std::move(sharedSettings)});
+    processor->init(track, format);
+
+    return processor;
+}
+
+bool populateDspChain(const Engine::DspChain& definitions, const DspRegistry* registry, DspChain& chain, QString& error)
+{
+    if(definitions.empty()) {
+        return true;
+    }
+
+    for(const auto& definition : definitions) {
+        auto node = registry->create(definition.id);
+        if(!node) {
+            if(!definition.enabled) {
+                continue;
+            }
+            error = u"DSP is unavailable: %1"_s.arg(definition.name.isEmpty() ? definition.id : definition.name);
+            return false;
+        }
+
+        node->setEnabled(definition.enabled);
+        node->setInstanceId(definition.instanceId);
+
+        if(!definition.settings.isEmpty() && !node->loadSettings(definition.settings)) {
+            error
+                = u"Failed to load DSP settings: %1"_s.arg(definition.name.isEmpty() ? definition.id : definition.name);
+            return false;
+        }
+
+        chain.addNode(std::move(node));
+    }
+
+    return true;
+}
+
+AudioEncoderSettings encoderSettingsForTrack(const AudioEncoderSettings& settings, const Track& track)
+{
+    AudioEncoderSettings resolved{settings};
+    if(resolved.ditherMode == DitherMode::LossySourceOnly) {
+        resolved.ditherMode
+            = track.encoding().compare(u"Lossy"_s, Qt::CaseInsensitive) == 0 ? DitherMode::Always : DitherMode::Never;
+    }
+    return resolved;
+}
+
+std::expected<uint64_t, QString> previewDurationMs(const ConversionPreset& preset, const Track& track)
+{
+    if(preset.preview.lengthPercentage <= 0 || preset.preview.lengthPercentage > 100) {
+        return std::unexpected{u"Preview length percentage must be between 1 and 100"_s};
+    }
+
+    if(track.duration() == 0) {
+        return std::unexpected{u"Preview generation requires a known track duration"_s};
+    }
+
+    const auto percentage   = static_cast<uint64_t>(preset.preview.lengthPercentage);
+    const uint64_t duration = ((track.duration() / 100) * percentage) + ((track.duration() % 100) * percentage / 100);
+    return std::max<uint64_t>(1, duration);
+}
+
+ProcessingBuffer makeProcessingBuffer(const AudioBuffer& input, ReplayGainProcessor* replayGain,
+                                      const AudioFormat& processingFormat)
+{
+    const AudioBuffer converted = Audio::convert(input, processingFormat);
+    if(!converted.isValid()) {
+        return {};
+    }
+
+    std::vector<double> samples(static_cast<size_t>(converted.sampleCount()));
+    std::memcpy(samples.data(), converted.data(), static_cast<size_t>(converted.byteCount()));
+
+    if(replayGain) {
+        replayGain->process(samples.data(), samples.size());
+    }
+
+    ProcessingBuffer result{samples, processingFormat, converted.startTime() * 1'000'000ULL};
+    if(processingFormat.sampleRate() > 0) {
+        result.setSourceFrameDurationNs(1'000'000'000ULL / static_cast<uint64_t>(processingFormat.sampleRate()));
+    }
+    return result;
+}
+
+AudioEncoder::Result writeProcessingChunks(AudioEncoder& encoder, const ProcessingBufferList& chunks)
+{
+    for(size_t i{0}; i < chunks.count(); ++i) {
+        const auto* chunk = chunks.item(i);
+        if(!chunk || !chunk->isValid()) {
+            continue;
+        }
+        auto result = encoder.write(chunk->toAudioBuffer());
+        if(!result.ok) {
+            return result;
+        }
+    }
+    return AudioEncoder::Result::success();
+}
+
+struct TrackEncodingResult
+{
+    bool ok{false};
+    bool cancelled{false};
+    AudioFormat encoderInputFormat;
+    QString error;
+};
+
+struct SharedProcessingContext
+{
+    std::unique_ptr<DspChain> dspChain;
+    AudioFormat processingInputFormat;
+    AudioFormat encoderInputFormat;
+    bool prepared{false};
+};
+
+TrackEncodingResult trackEncodingFailure(QString error, const AudioFormat& format = {})
+{
+    return {
+        .ok                 = false,
+        .cancelled          = false,
+        .encoderInputFormat = format,
+        .error              = std::move(error),
+    };
+}
+
+TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const Track& track, int index,
+                                const QString& outputPath, const QString& encoderOutputPath, AudioEncoder& encoder,
+                                bool initialiseEncoder, const AudioFormat& requiredFormat,
+                                SharedProcessingContext* sharedProcessing = nullptr, bool flushProcessingAtEnd = true)
+{
+    std::optional<uint64_t> previewDuration;
+    if(request.job.preset.preview.enabled) {
+        const auto duration = previewDurationMs(request.job.preset, track);
+        if(!duration) {
+            return trackEncodingFailure(duration.error());
+        }
+        previewDuration = *duration;
+    }
+
+    auto loaded = request.audioLoader->loadDecoderForTrack(track, AudioDecoder::NoLooping);
+    if(!loaded.decoder || !loaded.format) {
+        return trackEncodingFailure(u"No decoder available"_s);
+    }
+
+    loaded.decoder->start();
+
+    auto finishDecoder = qScopeGuard([&loaded] {
+        if(loaded.decoder) {
+            loaded.decoder->stop();
+        }
+    });
+
+    if(track.offset() > 0) {
+        if(!loaded.decoder->isSeekable()) {
+            return trackEncodingFailure(u"Decoder cannot seek to the track segment"_s);
+        }
+        loaded.decoder->seek(track.offset());
+    }
+
+    reportProgress(request, index, track, outputPath, 0);
+
+    const bool hasReplayGain = request.job.preset.processing.replayGainMode != ConversionReplayGainMode::None;
+    const bool hasDsp        = !request.job.preset.processing.dspChain.empty();
+    const bool hasProcessing = hasReplayGain || hasDsp;
+
+    std::optional<uint64_t> sourceDuration;
+    if(track.isBoundedSegment() && track.duration() > 0) {
+        sourceDuration = track.duration();
+    }
+    if(previewDuration) {
+        sourceDuration = sourceDuration ? std::min(*sourceDuration, *previewDuration) : previewDuration;
+    }
+    if(sourceDuration && *sourceDuration == 0) {
+        return trackEncodingFailure(u"Track contains no audio after CUE pregap removal"_s);
+    }
+
+    uint64_t sourceFramesRemaining
+        = sourceDuration ? framesForDuration(*sourceDuration, loaded.format->sampleRate()) : 0;
+
+    AudioFormat processingInputFormat{*loaded.format};
+    if(hasProcessing) {
+        processingInputFormat.setSampleFormat(SampleFormat::F64);
+    }
+
+    auto replayGain = createReplayGainProcessor(request.job.preset.processing, track, processingInputFormat);
+
+    std::unique_ptr<DspChain> localDspChain;
+    DspChain* dspChain{nullptr};
+    QString dspError;
+    AudioFormat encoderInputFormat;
+
+    if(sharedProcessing && hasDsp) {
+        if(!sharedProcessing->prepared) {
+            sharedProcessing->processingInputFormat = processingInputFormat;
+            sharedProcessing->dspChain              = std::make_unique<DspChain>();
+            if(!populateDspChain(request.job.preset.processing.dspChain, request.dspRegistry,
+                                 *sharedProcessing->dspChain, dspError)) {
+                return trackEncodingFailure(dspError);
+            }
+
+            sharedProcessing->dspChain->prepare(processingInputFormat);
+
+            if(!sharedProcessing->dspChain->outputFormat().isValid()) {
+                return trackEncodingFailure(u"DSP chain produced an invalid format"_s);
+            }
+
+            encoderInputFormat
+                = sharedProcessing->dspChain ? sharedProcessing->dspChain->outputFormat() : processingInputFormat;
+            sharedProcessing->encoderInputFormat = encoderInputFormat;
+            sharedProcessing->prepared           = true;
+        }
+        else {
+            if(processingInputFormat != sharedProcessing->processingInputFormat) {
+                return trackEncodingFailure(u"Continuous DSP requires matching source processing formats"_s,
+                                            sharedProcessing->encoderInputFormat);
+            }
+            encoderInputFormat = sharedProcessing->encoderInputFormat;
+        }
+
+        dspChain = sharedProcessing->dspChain.get();
+    }
+    else {
+        if(hasDsp) {
+            localDspChain = std::make_unique<DspChain>();
+            if(!populateDspChain(request.job.preset.processing.dspChain, request.dspRegistry, *localDspChain,
+                                 dspError)) {
+                return trackEncodingFailure(dspError);
+            }
+
+            localDspChain->prepare(processingInputFormat);
+
+            if(!localDspChain->outputFormat().isValid()) {
+                return trackEncodingFailure(u"DSP chain produced an invalid format"_s);
+            }
+
+            dspChain = localDspChain.get();
+        }
+
+        encoderInputFormat = dspChain ? dspChain->outputFormat() : processingInputFormat;
+    }
+
+    if(requiredFormat.isValid() && encoderInputFormat != requiredFormat) {
+        return trackEncodingFailure(u"Merged tracks must have matching processed audio formats"_s, encoderInputFormat);
+    }
+
+    if(initialiseEncoder) {
+        const AudioEncoderSettings encoderSettings = encoderSettingsForTrack(request.job.preset.encoder, track);
+        const auto result = encoder.init(encoderOutputPath, encoderInputFormat, encoderSettings);
+        if(!result.ok) {
+            return trackEncodingFailure(result.error, encoderInputFormat);
+        }
+    }
+
+    bool failed{false};
+    bool sourceComplete{false};
+    QString error;
+    AudioEncoder::Result encoderResult;
+
+    while(true) {
+        if(shouldCancel(request)) {
+            return {
+                .ok                 = false,
+                .cancelled          = true,
+                .encoderInputFormat = encoderInputFormat,
+                .error              = u"Conversion cancelled"_s,
+            };
+        }
+
+        auto readResult = loaded.decoder->readAudio(TargetReadBytes);
+        switch(readResult.status) {
+            case AudioDecoder::ReadStatus::DecodedAudio: {
+                AudioBuffer inputBuffer{readResult.buffer};
+                if(sourceDuration) {
+                    const int frames = static_cast<int>(
+                        std::min<uint64_t>(sourceFramesRemaining, static_cast<uint64_t>(inputBuffer.frameCount())));
+                    inputBuffer = trimBuffer(inputBuffer, frames);
+                    sourceFramesRemaining -= static_cast<uint64_t>(frames);
+                    sourceComplete = sourceFramesRemaining == 0;
+                }
+
+                if(hasProcessing) {
+                    ProcessingBuffer processed
+                        = makeProcessingBuffer(inputBuffer, replayGain.get(), processingInputFormat);
+                    if(!processed.isValid()) {
+                        failed = true;
+                        error  = u"Failed to prepare audio for conversion processing"_s;
+                        break;
+                    }
+
+                    ProcessingBufferList chunks;
+                    chunks.addChunk(std::move(processed));
+                    if(dspChain) {
+                        dspChain->process(chunks);
+                    }
+                    encoderResult = writeProcessingChunks(encoder, chunks);
+                }
+                else {
+                    encoderResult = encoder.write(inputBuffer);
+                }
+
+                if(!encoderResult.ok) {
+                    failed = true;
+                    error  = encoderResult.error;
+                }
+                else {
+                    reportProgress(request, index, track, outputPath, inputBuffer.endTime());
+                }
+
+                break;
+            }
+            case AudioDecoder::ReadStatus::NeedMoreInput:
+                continue;
+            case AudioDecoder::ReadStatus::EndOfStream:
+                break;
+            case AudioDecoder::ReadStatus::Error:
+                failed = true;
+                error  = !readResult.error.isEmpty() ? readResult.error : u"Decoder error"_s;
+                break;
+        }
+
+        if(failed || sourceComplete || readResult.status == AudioDecoder::ReadStatus::EndOfStream) {
+            break;
+        }
+    }
+
+    if(!failed && dspChain && flushProcessingAtEnd) {
+        ProcessingBufferList tailChunks;
+        dspChain->flush(tailChunks, DspNode::FlushMode::EndOfTrack);
+        encoderResult = writeProcessingChunks(encoder, tailChunks);
+        if(!encoderResult.ok) {
+            failed = true;
+            error  = encoderResult.error;
+        }
+    }
+
+    return {
+        .ok                 = !failed,
+        .cancelled          = false,
+        .encoderInputFormat = encoderInputFormat,
+        .error              = error,
+    };
+}
+
+struct OutputPathDecision
+{
+    bool ready{false};
+    ConversionResultStatus status{ConversionResultStatus::Failed};
+    QString error;
+};
+
+OutputPathDecision prepareOutputPath(const ConversionRunner::Request& request, const ConversionPathResult& pathResult)
+{
+    if(pathResult.status == ConversionPathStatus::Skipped) {
+        return {.ready = false, .status = ConversionResultStatus::Skipped, .error = {}};
+    }
+
+    bool ready = pathResult.status == ConversionPathStatus::Ready;
+
+    if(pathResult.status == ConversionPathStatus::NeedsOverwriteDecision) {
+        const ExistingFileMode decision = request.existingFileCallback
+                                            ? request.existingFileCallback(pathResult.outputPath)
+                                            : ExistingFileMode::Ask;
+        if(decision == ExistingFileMode::Skip) {
+            return {.ready = false, .status = ConversionResultStatus::Skipped, .error = {}};
+        }
+
+        if(decision != ExistingFileMode::Overwrite) {
+            return {
+                .status = ConversionResultStatus::Cancelled,
+                .error  = u"Existing-file decision cancelled"_s,
+            };
+        }
+
+        ready = true;
+    }
+
+    if(!ready) {
+        return {
+            .error = !pathResult.error.isEmpty() ? pathResult.error : u"Output path is not writable"_s,
+        };
+    }
+
+    if(!QFileInfo{pathResult.outputPath}.absoluteDir().mkpath(u"."_s)) {
+        return {.error = u"Failed to create output folder"_s};
+    }
+
+    return {.ready = true, .status = ConversionResultStatus::Failed, .error = {}};
+}
+
+QString transferPictures(const ConversionRunner::Request& request, bool supportsPictures, const Track& source,
+                         const QString& outputPath)
+{
+    if(!request.job.preset.processing.transferPictures || !supportsPictures) {
+        return {};
+    }
+
+    const TrackCovers covers = readCovers(*request.audioLoader, source);
+    if(!covers.empty() && !request.audioLoader->writeTrackCover(Track{outputPath}, covers, AudioReader::None)) {
+        return u"Failed to transfer attached pictures"_s;
+    }
+
+    return {};
+}
+
+QString transferMetadata(const ConversionRunner::Request& request, const Track& source, const QString& outputPath,
+                         bool transferStatistics)
+{
+    AudioReader::WriteOptions options{AudioReader::None};
+    if(request.job.preset.processing.transferMetadata) {
+        options |= AudioReader::Metadata;
+    }
+    if(transferStatistics && request.job.preset.processing.transferRating) {
+        options |= AudioReader::Rating;
+    }
+    if(transferStatistics && request.job.preset.processing.transferPlaycount) {
+        options |= AudioReader::Playcount;
+    }
+    if(options == AudioReader::None) {
+        return {};
+    }
+
+    Track outputTrack{source};
+    outputTrack.setFilePath(outputPath);
+    if(!request.audioLoader->writeTrackMetadata(outputTrack, options)) {
+        return u"Failed to transfer metadata"_s;
+    }
+
+    return {};
+}
+
+void appendGroupedResults(std::vector<ConversionTrackResult>& results, const TrackList& tracks,
+                          const QString& outputPath, ConversionResultStatus status, const QString& error,
+                          const QStringList& firstTrackWarnings = {})
+{
+    for(size_t i{0}; i < tracks.size(); ++i) {
+        results.push_back({
+            .sourceTrack = tracks[i],
+            .outputPath  = outputPath,
+            .status      = status,
+            .error       = error,
+            .warnings    = i == 0 ? firstTrackWarnings : QStringList{},
+        });
+    }
+}
+
+std::vector<ConversionTrackResult> runGroupedOutputs(const ConversionRunner::Request& request,
+                                                     const std::vector<ConversionPathResult>& pathResults,
+                                                     bool supportsPictures, std::set<QString>& handledSidecarCopies)
+{
+    std::vector<ConversionTrackResult> results;
+    results.reserve(request.job.tracks.size());
+
+    for(int progressIndex{0}; const ConversionPathResult& pathResult : pathResults) {
+        const TrackList& groupTracks = pathResult.tracks;
+        const auto addResults        = [&](ConversionResultStatus status, const QString& error,
+                                           const QStringList& firstTrackWarnings = QStringList{}) {
+            appendGroupedResults(results, groupTracks, pathResult.outputPath, status, error, firstTrackWarnings);
+        };
+
+        if(groupTracks.empty()) {
+            results.push_back(failedResult({}, pathResult.outputPath, u"Output group contains no tracks"_s));
+            continue;
+        }
+
+        if(shouldCancel(request)) {
+            addResults(ConversionResultStatus::Cancelled, {});
+            progressIndex += static_cast<int>(groupTracks.size());
+            continue;
+        }
+
+        const OutputPathDecision pathDecision = prepareOutputPath(request, pathResult);
+        if(!pathDecision.ready) {
+            addResults(pathDecision.status, pathDecision.error);
+            progressIndex += static_cast<int>(groupTracks.size());
+            continue;
+        }
+
+        OutputTransaction output{pathResult.outputPath};
+        QString outputError;
+        if(!output.prepare(outputError)) {
+            addResults(ConversionResultStatus::Failed, outputError);
+            progressIndex += static_cast<int>(groupTracks.size());
+            continue;
+        }
+
+        auto encoder = request.encoderRegistry->createEncoder(request.job.preset.encoder.profile.id);
+        if(!encoder) {
+            addResults(ConversionResultStatus::Failed, u"No encoder available"_s);
+            progressIndex += static_cast<int>(groupTracks.size());
+            continue;
+        }
+
+        const bool preserveProcessingState = request.job.preset.processing.preserveDspStateBetweenTracks;
+        SharedProcessingContext sharedProcessing;
+        AudioFormat combinedFormat;
+        TrackEncodingResult encoding;
+
+        for(size_t i{0}; i < groupTracks.size(); ++i) {
+            const Track& track           = groupTracks[i];
+            const bool finalTrackInGroup = i + 1 == groupTracks.size();
+
+            encoding = encodeTrack(request, track, progressIndex++, pathResult.outputPath, output.path(), *encoder,
+                                   i == 0, combinedFormat, preserveProcessingState ? &sharedProcessing : nullptr,
+                                   !preserveProcessingState || finalTrackInGroup);
+            if(!encoding.ok) {
+                progressIndex += static_cast<int>(groupTracks.size() - i - 1);
+                break;
+            }
+
+            if(i == 0) {
+                combinedFormat = encoding.encoderInputFormat;
+            }
+        }
+
+        AudioEncoder::Result finishResult = AudioEncoder::Result::success();
+        if(encoding.ok) {
+            finishResult = encoder->finish();
+        }
+
+        if(!encoding.ok || !finishResult.ok) {
+            const QString error = !encoding.ok ? encoding.error : finishResult.error;
+            encoder.reset();
+            addResults(encoding.cancelled ? ConversionResultStatus::Cancelled : ConversionResultStatus::Failed, error);
+            continue;
+        }
+
+        if(shouldCancel(request)) {
+            addResults(ConversionResultStatus::Cancelled, u"Conversion cancelled"_s);
+            continue;
+        }
+
+        QStringList warnings;
+        const QString metadataError = transferMetadata(request, groupTracks.front(), output.path(), false);
+        if(!metadataError.isEmpty()) {
+            warnings.append(metadataError);
+        }
+        const QString pictureError = transferPictures(request, supportsPictures, groupTracks.front(), output.path());
+        if(!pictureError.isEmpty()) {
+            warnings.append(pictureError);
+        }
+
+        if(request.job.preset.other.verifyOutput) {
+            const QString verificationError = verifyOutput(*request.audioLoader, output.path());
+            if(!verificationError.isEmpty()) {
+                addResults(ConversionResultStatus::Failed, verificationError);
+                continue;
+            }
+        }
+
+        if(!output.commit(outputError)) {
+            addResults(ConversionResultStatus::Failed, outputError, warnings);
+            continue;
+        }
+
+        warnings.append(copySidecarFiles(request.job.preset.other.copyFilesPattern, groupTracks, pathResult.outputPath,
+                                         handledSidecarCopies));
+
+        addResults(ConversionResultStatus::Succeeded, {}, warnings);
+    }
+
+    return results;
+}
+
+std::vector<ConversionTrackResult> runIndividualOutputs(const ConversionRunner::Request& request,
+                                                        const std::vector<ConversionPathResult>& pathResults,
+                                                        bool supportsPictures, std::set<QString>& handledSidecarCopies)
+{
+    std::vector<ConversionTrackResult> results;
+    results.reserve(request.job.tracks.size());
+
+    for(size_t i{0}; i < request.job.tracks.size(); ++i) {
+        const Track& track                     = request.job.tracks[i];
+        const ConversionPathResult& pathResult = pathResults[i];
+
+        if(shouldCancel(request)) {
+            results.push_back({
+                .sourceTrack = track,
+                .outputPath  = pathResult.outputPath,
+                .status      = ConversionResultStatus::Cancelled,
+                .error       = {},
+                .warnings    = {},
+            });
+            continue;
+        }
+
+        const OutputPathDecision pathDecision = prepareOutputPath(request, pathResult);
+        if(!pathDecision.ready) {
+            results.push_back({
+                .sourceTrack = track,
+                .outputPath  = pathResult.outputPath,
+                .status      = pathDecision.status,
+                .error       = pathDecision.error,
+                .warnings    = {},
+            });
+            continue;
+        }
+
+        OutputTransaction output{pathResult.outputPath};
+        QString outputError;
+        if(!output.prepare(outputError)) {
+            results.push_back(failedResult(track, pathResult.outputPath, outputError));
+            continue;
+        }
+
+        auto encoder = request.encoderRegistry->createEncoder(request.job.preset.encoder.profile.id);
+        if(!encoder) {
+            results.push_back(failedResult(track, pathResult.outputPath, u"No encoder available"_s));
+            continue;
+        }
+
+        const TrackEncodingResult encoding = encodeTrack(request, track, static_cast<int>(i), pathResult.outputPath,
+                                                         output.path(), *encoder, true, {});
+
+        AudioEncoder::Result finishResult = AudioEncoder::Result::success();
+        if(encoding.ok) {
+            finishResult = encoder->finish();
+        }
+
+        if(!encoding.ok || !finishResult.ok) {
+            const QString error = !encoding.ok ? encoding.error : finishResult.error;
+            encoder.reset();
+            results.push_back({
+                .sourceTrack = track,
+                .outputPath  = pathResult.outputPath,
+                .status      = encoding.cancelled ? ConversionResultStatus::Cancelled : ConversionResultStatus::Failed,
+                .error       = error,
+                .warnings    = {},
+            });
+            continue;
+        }
+
+        if(shouldCancel(request)) {
+            results.push_back({
+                .sourceTrack = track,
+                .outputPath  = pathResult.outputPath,
+                .status      = ConversionResultStatus::Cancelled,
+                .error       = u"Conversion cancelled"_s,
+                .warnings    = {},
+            });
+            continue;
+        }
+
+        QStringList warnings;
+        const QString metadataError = transferMetadata(request, track, output.path(), true);
+        if(!metadataError.isEmpty()) {
+            warnings.append(metadataError);
+        }
+        const QString pictureError = transferPictures(request, supportsPictures, track, output.path());
+        if(!pictureError.isEmpty()) {
+            warnings.append(pictureError);
+        }
+
+        if(request.job.preset.other.verifyOutput) {
+            QString verificationError = verifyOutput(*request.audioLoader, output.path());
+            if(verificationError.isEmpty() && supportsLosslessPcmVerification(request.job.preset)) {
+                verificationError = verifyLosslessPcm(*request.audioLoader, track, output.path(), request.job.preset);
+            }
+            if(!verificationError.isEmpty()) {
+                results.push_back(failedResult(track, pathResult.outputPath, verificationError));
+                continue;
+            }
+        }
+
+        if(!output.commit(outputError)) {
+            results.push_back(failedResult(track, pathResult.outputPath, outputError));
+            continue;
+        }
+
+        warnings.append(copySidecarFiles(request.job.preset.other.copyFilesPattern, TrackList{track},
+                                         pathResult.outputPath, handledSidecarCopies));
+
+        results.push_back({
+            .sourceTrack = track,
+            .outputPath  = pathResult.outputPath,
+            .status      = ConversionResultStatus::Succeeded,
+            .error       = {},
+            .warnings    = std::move(warnings),
+        });
+    }
+
+    return results;
+}
+
+} // namespace
+
+namespace ConversionRunner {
+std::vector<ConversionTrackResult> run(const Request& request)
+{
+    std::vector<ConversionTrackResult> results;
+    results.reserve(request.job.tracks.size());
+
+    if(!request.audioLoader) {
+        results.push_back(failedResult({}, {}, u"No audio loader supplied"_s));
+        return results;
+    }
+
+    if(!request.encoderRegistry) {
+        results.push_back(failedResult({}, {}, u"No encoder registry supplied"_s));
+        return results;
+    }
+
+    ConversionPathResolver::Request pathRequest;
+    pathRequest.tracks      = request.job.tracks;
+    pathRequest.destination = request.job.preset.destination;
+    pathRequest.extension   = request.job.preset.encoder.profile.extension;
+    pathRequest.askFolder   = request.askFolder;
+
+    const auto pathResults       = ConversionPathResolver::resolve(pathRequest);
+    const bool individualOutputs = request.job.preset.destination.outputStyle == OutputStyle::IndividualFiles;
+    if((individualOutputs && pathResults.size() != request.job.tracks.size())
+       || (!request.job.tracks.empty() && pathResults.empty())) {
+        results.push_back(failedResult({}, {}, u"Failed to resolve output paths"_s));
+        return results;
+    }
+
+    const bool supportsPictures
+        = profileSupportsPictures(*request.encoderRegistry, request.job.preset.encoder.profile.id);
+    std::set<QString> handledSidecarCopies;
+
+    if(individualOutputs) {
+        return runIndividualOutputs(request, pathResults, supportsPictures, handledSidecarCopies);
+    }
+
+    return runGroupedOutputs(request, pathResults, supportsPictures, handledSidecarCopies);
+}
+} // namespace ConversionRunner
+} // namespace Fooyin

--- a/src/core/engine/conversion/outputtransaction.cpp
+++ b/src/core/engine/conversion/outputtransaction.cpp
@@ -1,0 +1,99 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "outputtransaction.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QSaveFile>
+
+using namespace Qt::StringLiterals;
+
+namespace {
+QString tempTemplate(const QString& destination)
+{
+    const QFileInfo info{destination};
+    QString name = u"."_s + info.completeBaseName() + u".fooyin-XXXXXX"_s;
+    if(!info.suffix().isEmpty()) {
+        name += u'.' + info.suffix();
+    }
+    return info.absoluteDir().filePath(name);
+}
+} // namespace
+
+namespace Fooyin {
+OutputTransaction::OutputTransaction(QString destination)
+    : m_destination{std::move(destination)}
+    , m_temporary{tempTemplate(m_destination)}
+{
+    m_temporary.setAutoRemove(true);
+}
+
+QString OutputTransaction::path() const
+{
+    return m_temporary.fileName();
+}
+
+bool OutputTransaction::prepare(QString& error)
+{
+    if(!m_temporary.open()) {
+        error = u"Failed to create temporary output: %1"_s.arg(m_temporary.errorString());
+        return false;
+    }
+    m_temporary.close();
+    return true;
+}
+
+bool OutputTransaction::commit(QString& error)
+{
+    QFile source{path()};
+    if(!source.open(QIODevice::ReadOnly)) {
+        error = u"Failed to open temporary output: %1"_s.arg(source.errorString());
+        return false;
+    }
+
+    QSaveFile destination{m_destination};
+    destination.setDirectWriteFallback(false);
+    if(!destination.open(QIODevice::WriteOnly)) {
+        error = u"Failed to prepare output file: %1"_s.arg(destination.errorString());
+        return false;
+    }
+
+    while(!source.atEnd()) {
+        const QByteArray data = source.read(1024LL * 1024);
+        if(data.isEmpty()) {
+            if(source.error() != QFileDevice::NoError) {
+                error = u"Failed to read temporary output: %1"_s.arg(source.errorString());
+                return false;
+            }
+            break;
+        }
+        if(destination.write(data) != data.size()) {
+            error = u"Failed to write output file: %1"_s.arg(destination.errorString());
+            return false;
+        }
+    }
+
+    if(!destination.commit()) {
+        error = u"Failed to commit output file: %1"_s.arg(destination.errorString());
+        return false;
+    }
+    return true;
+}
+} // namespace Fooyin

--- a/src/core/engine/conversion/outputtransaction.h
+++ b/src/core/engine/conversion/outputtransaction.h
@@ -1,6 +1,6 @@
 /*
  * Fooyin
- * Copyright © 2023, Luke Taylor <luket@pm.me>
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
  *
  * Fooyin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,36 +19,21 @@
 
 #pragma once
 
-#include "ffmpegutils.h"
-
-extern "C"
-{
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-}
+#include <QTemporaryFile>
 
 namespace Fooyin {
-class Codec
+class OutputTransaction
 {
 public:
-    Codec() = default;
-    Codec(CodecContextPtr context, AVStream* stream);
+    explicit OutputTransaction(QString destination);
 
-    Codec(Codec&& other) noexcept;
-    Codec& operator=(Codec&& other) noexcept;
+    [[nodiscard]] QString path() const;
 
-    Codec(const Codec& other)            = delete;
-    Codec& operator=(const Codec& other) = delete;
-
-    [[nodiscard]] bool isValid() const;
-
-    [[nodiscard]] AVCodecContext* context() const;
-    [[nodiscard]] AVStream* stream() const;
-    [[nodiscard]] int streamIndex() const;
-    [[nodiscard]] bool isPlanar() const;
+    bool prepare(QString& error);
+    bool commit(QString& error);
 
 private:
-    CodecContextPtr m_context;
-    AVStream* m_stream;
+    QString m_destination;
+    QTemporaryFile m_temporary;
 };
 } // namespace Fooyin

--- a/src/core/engine/input/ffmpeg/ffmpegencoder.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpegencoder.cpp
@@ -1,0 +1,952 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ffmpegencoder.h"
+
+#include "ffmpegutils.h"
+
+#include <QStringList>
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/audio_fifo.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/mathematics.h>
+#include <libavutil/opt.h>
+#include <libswresample/swresample.h>
+}
+
+#include <array>
+#include <span>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+struct FFmpegProfileDescriptor
+{
+    QString id;
+    QString name;
+    QString extension;
+    QString containerName;
+    QStringList codecNames;
+    EncoderMode mode{EncoderMode::Default};
+    int bitrateKbps{0};
+    double quality{0.0};
+    int compressionLevel{-1};
+    EncoderCapabilities capabilities;
+    QString settingsSummary;
+    std::function<int(const EncoderProfile&)> estimateBitrateKbps;
+    bool supportsPictures{false};
+};
+
+int estimateMp3BitrateKbps(const EncoderProfile& profile)
+{
+    static constexpr std::array Estimates{245, 225, 190, 175, 165, 130, 115, 100, 85, 65};
+
+    const double quality = std::clamp(profile.quality, 0.0, 9.0);
+    const auto lower     = static_cast<size_t>(std::floor(quality));
+    const auto upper     = static_cast<size_t>(std::ceil(quality));
+    if(lower == upper) {
+        return Estimates.at(lower);
+    }
+
+    const double fraction = quality - static_cast<double>(lower);
+    return static_cast<int>(std::lround(std::lerp(Estimates.at(lower), Estimates.at(upper), fraction)));
+}
+
+int estimateVorbisBitrateKbps(const EncoderProfile& profile)
+{
+    static constexpr std::array Estimates{64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 400};
+
+    const double quality = std::clamp(profile.quality, 0.0, 10.0);
+    const auto lower     = static_cast<size_t>(std::floor(quality));
+    const auto upper     = static_cast<size_t>(std::ceil(quality));
+    if(lower == upper) {
+        return Estimates.at(lower);
+    }
+
+    const double fraction = quality - static_cast<double>(lower);
+    return static_cast<int>(std::lround(std::lerp(Estimates.at(lower), Estimates.at(upper), fraction)));
+}
+
+const AVCodec* findEncoder(const QStringList& codecNames, QString* selectedName = nullptr)
+{
+    for(const QString& codecName : codecNames) {
+        if(const AVCodec* codec = avcodec_find_encoder_by_name(codecName.toUtf8().constData())) {
+            if(selectedName) {
+                *selectedName = codecName;
+            }
+            return codec;
+        }
+    }
+
+    return nullptr;
+}
+
+bool encoderSupportsOption(const AVCodecContext* context, const char* name)
+{
+    return context && context->priv_data
+        && av_opt_find(context->priv_data, name, nullptr, AV_OPT_FLAG_ENCODING_PARAM, 0) != nullptr;
+}
+
+bool encoderSupportsOption(const AVCodec* codec, const char* name)
+{
+    AVCodecContext* context = avcodec_alloc_context3(codec);
+    const bool supported    = encoderSupportsOption(context, name);
+    avcodec_free_context(&context);
+    return supported;
+}
+
+QStringList codecNamesForSettings(const AudioEncoderSettings& settings)
+{
+    if(settings.profile.id != u"ffmpeg-wav"_s) {
+        return {settings.profile.codecName};
+    }
+
+    switch(settings.outputSampleFormat) {
+        case SampleFormat::U8:
+            return {u"pcm_u8"_s};
+        case SampleFormat::S24In32:
+            return {u"pcm_s24le"_s};
+        case SampleFormat::S32:
+            return {u"pcm_s32le"_s};
+        case SampleFormat::F32:
+            return {u"pcm_f32le"_s};
+        case SampleFormat::F64:
+            return {u"pcm_f64le"_s};
+        case SampleFormat::S16:
+        case SampleFormat::Unknown:
+        default:
+            return {u"pcm_s16le"_s};
+    }
+}
+
+bool hasMuxer(const QString& containerName, const QString& extension)
+{
+    return av_guess_format(containerName.toUtf8().constData(), nullptr, extension.toUtf8().constData()) != nullptr;
+}
+
+AudioEncoder::Result errorResult(const QString& prefix, int error)
+{
+    return AudioEncoder::Result::failure(prefix + u": "_s + Utils::ffmpegErrorString(error));
+}
+
+std::span<const AVSampleFormat> supportedSampleFormats(const AVCodec* codec)
+{
+    if(!codec) {
+        return {};
+    }
+
+#if !OLD_CODEC_SUPPORTED_CONFIG
+    const void* configs{nullptr};
+    int count{0};
+    if(avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, &configs, &count) < 0 || !configs
+       || count <= 0) {
+        return {};
+    }
+    return {static_cast<const AVSampleFormat*>(configs), static_cast<size_t>(count)};
+#else
+    const AVSampleFormat* formats{codec->sample_fmts};
+    if(!formats) {
+        return {};
+    }
+    const AVSampleFormat* end{formats};
+    while(*end != AV_SAMPLE_FMT_NONE) {
+        ++end;
+    }
+    return {formats, static_cast<size_t>(end - formats)};
+#endif
+}
+
+std::span<const int> supportedSampleRates(const AVCodec* codec)
+{
+    if(!codec) {
+        return {};
+    }
+
+#if !OLD_CODEC_SUPPORTED_CONFIG
+    const void* configs{nullptr};
+    int count{0};
+    if(avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_SAMPLE_RATE, 0, &configs, &count) < 0 || !configs
+       || count <= 0) {
+        return {};
+    }
+    return {static_cast<const int*>(configs), static_cast<size_t>(count)};
+#else
+    const int* rates = codec->supported_samplerates;
+    if(!rates) {
+        return {};
+    }
+    const int* end{rates};
+    while(*end != 0) {
+        ++end;
+    }
+    return {rates, static_cast<size_t>(end - rates)};
+#endif
+}
+
+AVSampleFormat selectSampleFormat(const AVCodec* codec, SampleFormat requested)
+{
+    const auto formats = supportedSampleFormats(codec);
+    if(formats.empty()) {
+        return requested == SampleFormat::Unknown ? AV_SAMPLE_FMT_S16 : Utils::sampleFormat(requested);
+    }
+
+    if(requested != SampleFormat::Unknown) {
+        for(const AVSampleFormat format : formats) {
+            const int bitsPerSample = requested == SampleFormat::S24In32 ? 24 : 0;
+            if(Utils::sampleFormat(format, bitsPerSample) == requested) {
+                return format;
+            }
+        }
+        return AV_SAMPLE_FMT_NONE;
+    }
+
+    constexpr std::array preferredFormats{
+        SampleFormat::S16, SampleFormat::S32, SampleFormat::F32, SampleFormat::U8, SampleFormat::F64,
+    };
+
+    for(const SampleFormat preferred : preferredFormats) {
+        for(const AVSampleFormat format : formats) {
+            if(Utils::sampleFormat(format, 0) == preferred) {
+                return format;
+            }
+        }
+    }
+
+    return formats.front();
+}
+
+int selectSampleRate(const AVCodec* codec, int requestedRate)
+{
+    const int safeRate = std::max(1, requestedRate);
+    const auto rates   = supportedSampleRates(codec);
+    if(rates.empty()) {
+        return safeRate;
+    }
+
+    for(const int rate : rates) {
+        if(rate == safeRate) {
+            return safeRate;
+        }
+    }
+
+    return rates.front() > 0 ? rates.front() : safeRate;
+}
+
+#if OLD_CHANNEL_LAYOUT
+uint64_t defaultChannelLayout(int channels)
+{
+    const auto layout = av_get_default_channel_layout(std::max(1, channels));
+    return layout > 0 ? static_cast<uint64_t>(layout) : 0;
+}
+#else
+AVChannelLayout defaultChannelLayout(int channels)
+{
+    AVChannelLayout layout{};
+    av_channel_layout_default(&layout, std::max(1, channels));
+    return layout;
+}
+#endif
+
+EncoderProfile makeProfile(const FFmpegProfileDescriptor& descriptor, const QString& codecName)
+{
+    EncoderProfile profile;
+    profile.id               = descriptor.id;
+    profile.name             = descriptor.name;
+    profile.extension        = descriptor.extension;
+    profile.containerName    = descriptor.containerName;
+    profile.codecName        = codecName;
+    profile.mode             = descriptor.mode;
+    profile.bitrateKbps      = descriptor.bitrateKbps;
+    profile.quality          = descriptor.quality;
+    profile.compressionLevel = descriptor.compressionLevel;
+    return profile;
+}
+
+QString description(const FFmpegProfileDescriptor& descriptor)
+{
+    if(!descriptor.settingsSummary.isEmpty()) {
+        return descriptor.settingsSummary;
+    }
+    if(descriptor.bitrateKbps > 0) {
+        return QString::number(descriptor.bitrateKbps) + u" kbps"_s;
+    }
+    if(descriptor.compressionLevel >= 0) {
+        return u"level %1"_s.arg(descriptor.compressionLevel);
+    }
+    return {};
+}
+
+std::vector<FFmpegProfileDescriptor> builtInProfiles()
+{
+    return {
+        {
+            .id               = u"ffmpeg-wav"_s,
+            .name             = u"WAV"_s,
+            .extension        = u"wav"_s,
+            .containerName    = u"wav"_s,
+            .codecNames       = {u"pcm_s16le"_s},
+            .mode             = EncoderMode::Default,
+            .capabilities     = {
+                    .modes            = {EncoderMode::Default},
+                    .bitrateKbps      = {},
+                    .quality          = {},
+                    .compressionLevel = {},
+            },
+            .settingsSummary  = u"PCM 16-bit"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = false,
+        },
+        {
+            .id               = u"ffmpeg-flac"_s,
+            .name             = u"FLAC"_s,
+            .extension        = u"flac"_s,
+            .containerName    = u"flac"_s,
+            .codecNames       = {u"flac"_s},
+            .mode             = EncoderMode::LosslessCompression,
+            .compressionLevel = 5,
+            .capabilities     = {
+                    .modes            = {EncoderMode::LosslessCompression},
+                    .bitrateKbps      = {},
+                    .quality          = {},
+                    .compressionLevel = {.minimum = 0, .maximum = 12, .step = 1},
+            },
+            .settingsSummary  = u"level 5"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = true,
+        },
+        {
+            .id               = u"ffmpeg-alac"_s,
+            .name             = u"Apple Lossless"_s,
+            .extension        = u"m4a"_s,
+            .containerName    = u"ipod"_s,
+            .codecNames       = {u"alac"_s},
+            .mode             = EncoderMode::LosslessCompression,
+            .capabilities     = {
+                    .modes            = {EncoderMode::LosslessCompression},
+                    .bitrateKbps      = {},
+                    .quality          = {},
+                    .compressionLevel = {},
+            },
+            .settingsSummary  = u"Lossless"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = true,
+        },
+        {
+            .id               = u"ffmpeg-wavpack"_s,
+            .name             = u"WavPack"_s,
+            .extension        = u"wv"_s,
+            .containerName    = u"wv"_s,
+            .codecNames       = {u"wavpack"_s},
+            .mode             = EncoderMode::LosslessCompression,
+            .compressionLevel = 2,
+            .capabilities     = {
+                    .modes            = {EncoderMode::LosslessCompression},
+                    .bitrateKbps      = {},
+                    .quality          = {},
+                    .compressionLevel = {.minimum = 0, .maximum = 8, .step = 1},
+            },
+            .settingsSummary  = u"level 2"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = true,
+        },
+        {
+            .id               = u"ffmpeg-mp3"_s,
+            .name             = u"MP3"_s,
+            .extension        = u"mp3"_s,
+            .containerName    = u"mp3"_s,
+            .codecNames       = {u"libmp3lame"_s, u"mp3"_s},
+            .mode             = EncoderMode::ConstantBitrate,
+            .bitrateKbps      = 192,
+            .quality          = 2.0,
+            .compressionLevel = 2,
+            .capabilities     = {
+                    .modes            = {EncoderMode::ConstantQuality, EncoderMode::AverageBitrate,
+                                         EncoderMode::ConstantBitrate},
+                    .bitrateKbps      = {.minimum = 32, .maximum = 320, .step = 16},
+                    .quality          = {.minimum = 0, .maximum = 9, .step = 1},
+                    .compressionLevel = {.minimum = 0, .maximum = 9, .step = 1},
+            },
+            .settingsSummary  = u"CBR 192 kbps"_s,
+            .estimateBitrateKbps = estimateMp3BitrateKbps,
+            .supportsPictures = true,
+        },
+        {
+            .id             = u"ffmpeg-aac"_s,
+            .name           = u"AAC"_s,
+            .extension      = u"m4a"_s,
+            .containerName  = u"ipod"_s,
+            .codecNames     = {u"aac"_s},
+            .mode           = EncoderMode::ConstantBitrate,
+            .bitrateKbps    = 256,
+            .quality        = 2.0,
+            .capabilities   = {
+                  .modes            = {EncoderMode::ConstantQuality, EncoderMode::ConstantBitrate},
+                  .bitrateKbps      = {.minimum = 32, .maximum = 512, .step = 16},
+                  .quality          = {.minimum = 0.1, .maximum = 5.0, .step = 0.1},
+                  .compressionLevel = {},
+            },
+            .settingsSummary  = u"CBR 256 kbps"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = true,
+        },
+        {
+            .id             = u"ffmpeg-vorbis"_s,
+            .name           = u"Ogg Vorbis"_s,
+            .extension      = u"ogg"_s,
+            .containerName  = u"ogg"_s,
+            .codecNames     = {u"libvorbis"_s},
+            .mode           = EncoderMode::ConstantQuality,
+            .quality        = 5.0,
+            .capabilities   = {
+                  .modes            = {EncoderMode::ConstantQuality},
+                  .bitrateKbps      = {},
+                  .quality          = {.minimum = 0, .maximum = 10, .step = 1},
+                  .compressionLevel = {},
+            },
+            .settingsSummary      = u"quality 5"_s,
+            .estimateBitrateKbps = estimateVorbisBitrateKbps,
+            .supportsPictures     = true,
+        },
+        {
+            .id               = u"ffmpeg-opus"_s,
+            .name             = u"Opus"_s,
+            .extension        = u"opus"_s,
+            .containerName    = u"ogg"_s,
+            .codecNames       = {u"libopus"_s, u"opus"_s},
+            .mode             = EncoderMode::VariableBitrate,
+            .bitrateKbps      = 128,
+            .compressionLevel = 10,
+            .capabilities     = {
+                    .modes            = {EncoderMode::VariableBitrate, EncoderMode::ConstrainedVariableBitrate,
+                                         EncoderMode::ConstantBitrate},
+                    .bitrateKbps      = {.minimum = 6, .maximum = 510, .step = 8},
+                    .quality          = {},
+                    .compressionLevel = {.minimum = 0, .maximum = 10, .step = 1},
+            },
+            .settingsSummary  = u"VBR 128 kbps"_s,
+            .estimateBitrateKbps = {},
+            .supportsPictures = true,
+        },
+    };
+}
+
+} // namespace
+
+FFmpegEncoder::FFmpegEncoder()
+    : m_stream{nullptr}
+    , m_inputSampleFormat{AV_SAMPLE_FMT_NONE}
+    , m_outputSampleFormat{AV_SAMPLE_FMT_NONE}
+    , m_outputSampleRate{0}
+    , m_nextPts{0}
+    , m_dither{false}
+    , m_finished{false}
+{ }
+
+AudioEncoder::Result FFmpegEncoder::init(const QString& outputPath, const AudioFormat& input,
+                                         const AudioEncoderSettings& settings)
+{
+    cleanup();
+
+    if(outputPath.isEmpty()) {
+        return Result::failure(u"Output path is empty"_s);
+    }
+    if(!input.isValid()) {
+        return Result::failure(u"Input format is invalid"_s);
+    }
+
+    QString codecName;
+    const AVCodec* codec = findEncoder(codecNamesForSettings(settings), &codecName);
+    if(!codec) {
+        return Result::failure(u"Encoder is not available"_s);
+    }
+
+    const QByteArray containerName = settings.profile.containerName.toUtf8();
+    const QByteArray pathBytes     = outputPath.toLocal8Bit();
+
+    AVFormatContext* formatContext{nullptr};
+    int ret = avformat_alloc_output_context2(&formatContext, nullptr, containerName.constData(), pathBytes.constData());
+    m_formatContext.reset(formatContext);
+    if(ret < 0 || !m_formatContext) {
+        return errorResult(u"Failed to allocate output context"_s, ret);
+    }
+
+    m_stream = avformat_new_stream(m_formatContext.get(), nullptr);
+    if(!m_stream) {
+        return Result::failure(u"Failed to create output stream"_s);
+    }
+
+    m_codecContext.reset(avcodec_alloc_context3(codec));
+    if(!m_codecContext) {
+        return Result::failure(u"Failed to allocate encoder context"_s);
+    }
+
+    m_outputSampleFormat = selectSampleFormat(codec, settings.outputSampleFormat);
+    if(m_outputSampleFormat == AV_SAMPLE_FMT_NONE) {
+        return Result::failure(u"Requested output sample format is unsupported by the encoder"_s);
+    }
+
+    m_outputSampleRate          = selectSampleRate(codec, input.sampleRate());
+    m_codecContext->codec_type  = AVMEDIA_TYPE_AUDIO;
+    m_codecContext->codec_id    = codec->id;
+    m_codecContext->sample_fmt  = m_outputSampleFormat;
+    m_codecContext->sample_rate = m_outputSampleRate;
+    m_codecContext->time_base   = AVRational{.num = 1, .den = m_outputSampleRate};
+    m_stream->time_base         = m_codecContext->time_base;
+
+    if(settings.outputSampleFormat == SampleFormat::S24In32) {
+        m_codecContext->bits_per_raw_sample = 24;
+    }
+
+    m_dither = settings.ditherMode == DitherMode::Always;
+
+    const bool constantQuality = settings.profile.mode == EncoderMode::ConstantQuality;
+    if(constantQuality) {
+        m_codecContext->flags |= AV_CODEC_FLAG_QSCALE;
+        m_codecContext->global_quality = static_cast<int>(settings.profile.quality * FF_QP2LAMBDA);
+    }
+    else if(settings.profile.bitrateKbps > 0) {
+        m_codecContext->bit_rate = static_cast<int64_t>(settings.profile.bitrateKbps) * 1000;
+    }
+
+    const int safeChannelCount = std::max(1, input.channelCount());
+
+#if OLD_CHANNEL_LAYOUT
+    m_codecContext->channels       = safeChannelCount;
+    m_codecContext->channel_layout = defaultChannelLayout(safeChannelCount);
+#else
+    m_codecContext->ch_layout = defaultChannelLayout(safeChannelCount);
+#endif
+
+    if((m_formatContext->oformat->flags & AVFMT_GLOBALHEADER) != 0) {
+        m_codecContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    }
+
+    AVDictionary* options{nullptr};
+
+    const bool supportsVbr = encoderSupportsOption(m_codecContext.get(), "vbr");
+    switch(settings.profile.mode) {
+        case EncoderMode::VariableBitrate:
+            if(supportsVbr) {
+                av_dict_set(&options, "vbr", "on", 0);
+            }
+            break;
+        case EncoderMode::ConstrainedVariableBitrate:
+            if(!supportsVbr) {
+                return Result::failure(u"The selected encoder does not support constrained VBR mode"_s);
+            }
+            av_dict_set(&options, "vbr", "constrained", 0);
+            break;
+        case EncoderMode::ConstantBitrate:
+            if(supportsVbr) {
+                av_dict_set(&options, "vbr", "off", 0);
+            }
+            break;
+        case EncoderMode::AverageBitrate:
+            if(!encoderSupportsOption(m_codecContext.get(), "abr")) {
+                return Result::failure(u"The selected encoder does not support ABR mode"_s);
+            }
+            av_dict_set(&options, "abr", "1", 0);
+            break;
+        case EncoderMode::Default:
+        case EncoderMode::ConstantQuality:
+        case EncoderMode::LosslessCompression:
+            break;
+    }
+
+    if(settings.profile.compressionLevel >= 0) {
+        av_dict_set(&options, "compression_level", QByteArray::number(settings.profile.compressionLevel).constData(),
+                    0);
+    }
+
+    ret = avcodec_open2(m_codecContext.get(), codec, &options);
+    av_dict_free(&options);
+    if(ret < 0) {
+        return errorResult(u"Failed to open encoder"_s, ret);
+    }
+
+    ret = avcodec_parameters_from_context(m_stream->codecpar, m_codecContext.get());
+    if(ret < 0) {
+        return errorResult(u"Failed to copy encoder parameters"_s, ret);
+    }
+
+    m_frame.reset(av_frame_alloc());
+    m_convertedFrame.reset(av_frame_alloc());
+    m_packet.reset(av_packet_alloc());
+
+    if(!m_frame || !m_convertedFrame || !m_packet) {
+        return Result::failure(u"Failed to allocate encoder frame or packet"_s);
+    }
+
+    if(m_codecContext->frame_size > 0) {
+#if OLD_CHANNEL_LAYOUT
+        const int channels = m_codecContext->channels;
+#else
+        const int channels = m_codecContext->ch_layout.nb_channels;
+#endif
+        m_fifo.reset(av_audio_fifo_alloc(m_outputSampleFormat, channels, m_codecContext->frame_size));
+        if(!m_fifo) {
+            return Result::failure(u"Failed to allocate encoder audio FIFO"_s);
+        }
+    }
+
+    m_inputFormat       = input;
+    m_inputSampleFormat = Utils::sampleFormat(input.sampleFormat());
+    if(m_inputSampleFormat == AV_SAMPLE_FMT_NONE) {
+        return Result::failure(u"Unsupported input sample format"_s);
+    }
+
+    if(const Result result = configureResampler(); !result.ok) {
+        return result;
+    }
+
+    if((m_formatContext->oformat->flags & AVFMT_NOFILE) == 0) {
+        ret = avio_open(&m_formatContext->pb, pathBytes.constData(), AVIO_FLAG_WRITE);
+        if(ret < 0) {
+            return errorResult(u"Failed to open output file"_s, ret);
+        }
+    }
+
+    ret = avformat_write_header(m_formatContext.get(), nullptr);
+    if(ret < 0) {
+        return errorResult(u"Failed to write output header"_s, ret);
+    }
+
+    m_nextPts  = 0;
+    m_finished = false;
+    return Result::success();
+}
+
+AudioEncoder::Result FFmpegEncoder::configureResampler()
+{
+#if OLD_CHANNEL_LAYOUT
+    const uint64_t inLayout  = defaultChannelLayout(m_inputFormat.channelCount());
+    const uint64_t outLayout = m_codecContext->channel_layout;
+    m_swr.reset(swr_alloc_set_opts(nullptr, static_cast<int64_t>(outLayout), m_outputSampleFormat, m_outputSampleRate,
+                                   static_cast<int64_t>(inLayout), m_inputSampleFormat, m_inputFormat.sampleRate(), 0,
+                                   nullptr));
+#else
+    AVChannelLayout inLayout = defaultChannelLayout(m_inputFormat.channelCount());
+    SwrContext* swr{nullptr};
+    const int ret = swr_alloc_set_opts2(&swr, &m_codecContext->ch_layout, m_outputSampleFormat, m_outputSampleRate,
+                                        &inLayout, m_inputSampleFormat, m_inputFormat.sampleRate(), 0, nullptr);
+    av_channel_layout_uninit(&inLayout);
+    if(ret < 0) {
+        swr_free(&swr);
+        return errorResult(u"Failed to allocate resampler"_s, ret);
+    }
+    m_swr.reset(swr);
+#endif
+
+    if(!m_swr) {
+        return Result::failure(u"Failed to allocate resampler"_s);
+    }
+
+    if(m_dither && av_opt_set_int(m_swr.get(), "dither_method", SWR_DITHER_TRIANGULAR, 0) < 0) {
+        return Result::failure(u"Failed to configure encoder dither"_s);
+    }
+
+    const int initRet = swr_init(m_swr.get());
+    if(initRet < 0) {
+        return errorResult(u"Failed to initialise resampler"_s, initRet);
+    }
+
+    return Result::success();
+}
+
+AudioEncoder::Result FFmpegEncoder::write(const AudioBuffer& buffer)
+{
+    if(m_finished || !m_codecContext || !m_swr || !m_frame) {
+        return Result::failure(u"Encoder is not initialised"_s);
+    }
+    if(!buffer.isValid()) {
+        return Result::failure(u"Audio buffer is invalid"_s);
+    }
+    if(buffer.format() != m_inputFormat) {
+        return Result::failure(u"Audio buffer format changed during encoding"_s);
+    }
+
+    return encodeInput(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.frameCount());
+}
+
+AudioEncoder::Result FFmpegEncoder::encodeInput(const uint8_t* inputData, int inputFrames)
+{
+    if(!inputData || inputFrames <= 0) {
+        return Result::success();
+    }
+
+    const int maxOutFrames = m_inputFormat.sampleRate() == m_outputSampleRate
+                               ? inputFrames
+                               : std::max(1, swr_get_out_samples(m_swr.get(), inputFrames));
+
+    if(const Result result = prepareFrame(m_convertedFrame.get(), maxOutFrames); !result.ok) {
+        return result;
+    }
+
+    const uint8_t* inputPlanes[]{inputData};
+    const int converted = swr_convert(m_swr.get(), m_convertedFrame->data, maxOutFrames, inputPlanes, inputFrames);
+    if(converted < 0) {
+        return errorResult(u"Failed to convert audio for encoder"_s, converted);
+    }
+    if(converted == 0) {
+        return Result::success();
+    }
+
+    return queueConvertedAudio(m_convertedFrame.get(), converted);
+}
+
+AudioEncoder::Result FFmpegEncoder::prepareFrame(AVFrame* frame, int frames) const
+{
+    av_frame_unref(frame);
+
+    frame->format      = m_outputSampleFormat;
+    frame->sample_rate = m_outputSampleRate;
+    frame->nb_samples  = frames;
+#if OLD_CHANNEL_LAYOUT
+    frame->channel_layout = m_codecContext->channel_layout;
+    frame->channels       = m_codecContext->channels;
+#else
+    if(av_channel_layout_copy(&frame->ch_layout, &m_codecContext->ch_layout) < 0) {
+        return Result::failure(u"Failed to copy output channel layout"_s);
+    }
+#endif
+
+    const int ret = av_frame_get_buffer(frame, 0);
+    if(ret < 0) {
+        return errorResult(u"Failed to allocate output frame buffer"_s, ret);
+    }
+
+    return Result::success();
+}
+
+AudioEncoder::Result FFmpegEncoder::queueConvertedAudio(AVFrame* frame, int frames)
+{
+    if(!m_fifo) {
+        frame->nb_samples = frames;
+        frame->pts        = m_nextPts;
+        m_nextPts += frames;
+        return encodeFrame(frame);
+    }
+
+    const int requiredSize = av_audio_fifo_size(m_fifo.get()) + frames;
+    if(av_audio_fifo_realloc(m_fifo.get(), requiredSize) < 0) {
+        return Result::failure(u"Failed to grow encoder audio FIFO"_s);
+    }
+    if(av_audio_fifo_write(m_fifo.get(), reinterpret_cast<void**>(frame->extended_data), frames) != frames) {
+        return Result::failure(u"Failed to queue converted audio"_s);
+    }
+    return encodeQueuedFrames(false);
+}
+
+AudioEncoder::Result FFmpegEncoder::encodeQueuedFrames(bool final)
+{
+    if(!m_fifo || m_codecContext->frame_size <= 0) {
+        return Result::success();
+    }
+
+    const int frameSize = m_codecContext->frame_size;
+    while(av_audio_fifo_size(m_fifo.get()) >= frameSize || (final && av_audio_fifo_size(m_fifo.get()) > 0)) {
+        const int queuedFrames = av_audio_fifo_size(m_fifo.get());
+        const int readFrames   = std::min(frameSize, queuedFrames);
+        const bool smallLastFrame
+            = readFrames < frameSize && (m_codecContext->codec->capabilities & AV_CODEC_CAP_SMALL_LAST_FRAME) != 0;
+        const int outputFrames = smallLastFrame ? readFrames : frameSize;
+
+        if(const Result result = prepareFrame(m_frame.get(), outputFrames); !result.ok) {
+            return result;
+        }
+
+#if OLD_CHANNEL_LAYOUT
+        const int channels = m_codecContext->channels;
+#else
+        const int channels = m_codecContext->ch_layout.nb_channels;
+#endif
+        if(readFrames < outputFrames) {
+            av_samples_set_silence(m_frame->extended_data, 0, outputFrames, channels, m_outputSampleFormat);
+        }
+        if(av_audio_fifo_read(m_fifo.get(), reinterpret_cast<void**>(m_frame->extended_data), readFrames)
+           != readFrames) {
+            return Result::failure(u"Failed to read converted audio from FIFO"_s);
+        }
+
+        m_frame->pts = m_nextPts;
+        m_nextPts += outputFrames;
+        if(const Result result = encodeFrame(m_frame.get()); !result.ok) {
+            return result;
+        }
+    }
+
+    return Result::success();
+}
+
+AudioEncoder::Result FFmpegEncoder::flushResampler()
+{
+    while(true) {
+        const int maxOutFrames = swr_get_out_samples(m_swr.get(), 0);
+        if(maxOutFrames <= 0) {
+            return Result::success();
+        }
+        if(const Result result = prepareFrame(m_convertedFrame.get(), maxOutFrames); !result.ok) {
+            return result;
+        }
+
+        const int converted = swr_convert(m_swr.get(), m_convertedFrame->data, maxOutFrames, nullptr, 0);
+        if(converted < 0) {
+            return errorResult(u"Failed to flush encoder resampler"_s, converted);
+        }
+        if(converted == 0) {
+            return Result::success();
+        }
+        if(const Result result = queueConvertedAudio(m_convertedFrame.get(), converted); !result.ok) {
+            return result;
+        }
+    }
+}
+
+AudioEncoder::Result FFmpegEncoder::encodeFrame(AVFrame* frame)
+{
+    const int ret = avcodec_send_frame(m_codecContext.get(), frame);
+    if(ret < 0) {
+        return errorResult(u"Failed to send audio frame to encoder"_s, ret);
+    }
+
+    return drainPackets();
+}
+
+AudioEncoder::Result FFmpegEncoder::drainPackets()
+{
+    while(true) {
+        int ret = avcodec_receive_packet(m_codecContext.get(), m_packet.get());
+        if(ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+            return Result::success();
+        }
+        if(ret < 0) {
+            return errorResult(u"Failed to receive encoded packet"_s, ret);
+        }
+
+        av_packet_rescale_ts(m_packet.get(), m_codecContext->time_base, m_stream->time_base);
+        m_packet->stream_index = m_stream->index;
+
+        ret = av_interleaved_write_frame(m_formatContext.get(), m_packet.get());
+        av_packet_unref(m_packet.get());
+        if(ret < 0) {
+            return errorResult(u"Failed to write encoded packet"_s, ret);
+        }
+    }
+}
+
+AudioEncoder::Result FFmpegEncoder::finish()
+{
+    if(m_finished || !m_codecContext || !m_formatContext) {
+        return Result::success();
+    }
+
+    if(const Result result = flushResampler(); !result.ok) {
+        cleanup();
+        return result;
+    }
+    if(const Result result = encodeQueuedFrames(true); !result.ok) {
+        cleanup();
+        return result;
+    }
+
+    if(const Result result = encodeFrame(nullptr); !result.ok) {
+        cleanup();
+        return result;
+    }
+
+    const int ret = av_write_trailer(m_formatContext.get());
+    if(ret < 0) {
+        cleanup();
+        return errorResult(u"Failed to write output trailer"_s, ret);
+    }
+
+    m_finished = true;
+    cleanup();
+    return Result::success();
+}
+
+void FFmpegEncoder::cleanup()
+{
+    m_swr.reset();
+    m_fifo.reset();
+    m_frame.reset();
+    m_convertedFrame.reset();
+    m_packet.reset();
+    m_codecContext.reset();
+    m_formatContext.reset();
+
+    m_stream             = nullptr;
+    m_inputFormat        = {};
+    m_inputSampleFormat  = AV_SAMPLE_FMT_NONE;
+    m_outputSampleFormat = AV_SAMPLE_FMT_NONE;
+    m_outputSampleRate   = 0;
+    m_nextPts            = 0;
+    m_dither             = false;
+}
+
+FFmpegEncoder::~FFmpegEncoder()
+{
+    cleanup();
+}
+
+std::vector<AudioEncoderInfo> FFmpegEncoder::availableEncoders() const
+{
+    std::vector<AudioEncoderInfo> encoders;
+
+    const auto profiles = builtInProfiles();
+    for(const FFmpegProfileDescriptor& descriptor : profiles) {
+        QString codecName;
+        const AVCodec* codec = findEncoder(descriptor.codecNames, &codecName);
+        if(!codec || !hasMuxer(descriptor.containerName, descriptor.extension)) {
+            continue;
+        }
+
+        AudioEncoderInfo info;
+        info.id                  = descriptor.id;
+        info.backendId           = u"ffmpeg"_s;
+        info.name                = descriptor.name;
+        info.description         = description(descriptor);
+        info.profile             = makeProfile(descriptor, codecName);
+        info.capabilities        = descriptor.capabilities;
+        info.estimateBitrateKbps = descriptor.estimateBitrateKbps;
+
+        if(!encoderSupportsOption(codec, "vbr")
+           && std::ranges::find(info.capabilities.modes, EncoderMode::ConstrainedVariableBitrate)
+                  != info.capabilities.modes.end()) {
+            std::erase(info.capabilities.modes, EncoderMode::ConstrainedVariableBitrate);
+            std::erase(info.capabilities.modes, EncoderMode::ConstantBitrate);
+        }
+
+        info.supportsMetadata = true;
+        info.supportsPictures = descriptor.supportsPictures;
+        encoders.push_back(std::move(info));
+    }
+
+    std::ranges::sort(encoders, [](const AudioEncoderInfo& lhs, const AudioEncoderInfo& rhs) {
+        return QString::localeAwareCompare(lhs.name, rhs.name) < 0;
+    });
+
+    return encoders;
+}
+} // namespace Fooyin

--- a/src/core/engine/input/ffmpeg/ffmpegencoder.h
+++ b/src/core/engine/input/ffmpeg/ffmpegencoder.h
@@ -1,0 +1,69 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include "ffmpegutils.h"
+
+#include <core/engine/audioencoder.h>
+
+namespace Fooyin {
+class FYCORE_EXPORT FFmpegEncoder : public AudioEncoder
+{
+public:
+    FFmpegEncoder();
+    ~FFmpegEncoder() override;
+
+    [[nodiscard]] std::vector<AudioEncoderInfo> availableEncoders() const override;
+
+    Result init(const QString& outputPath, const AudioFormat& inputFormat,
+                const AudioEncoderSettings& settings) override;
+    Result write(const AudioBuffer& buffer) override;
+    Result finish() override;
+
+private:
+    Result configureResampler();
+    Result encodeInput(const uint8_t* inputData, int inputFrames);
+    Result queueConvertedAudio(AVFrame* frame, int frames);
+    Result encodeQueuedFrames(bool final);
+    Result flushResampler();
+    Result prepareFrame(AVFrame* frame, int frames) const;
+    Result encodeFrame(AVFrame* frame);
+    Result drainPackets();
+    void cleanup();
+
+    OutputFormatContextPtr m_formatContext;
+    CodecContextPtr m_codecContext;
+    AVStream* m_stream;
+    SwrContextPtr m_swr;
+    FramePtr m_frame;
+    FramePtr m_convertedFrame;
+    PacketPtr m_packet;
+    AudioFifoPtr m_fifo;
+    AudioFormat m_inputFormat;
+    AVSampleFormat m_inputSampleFormat;
+    AVSampleFormat m_outputSampleFormat;
+    int m_outputSampleRate;
+    int64_t m_nextPts;
+    bool m_dither;
+    bool m_finished;
+};
+} // namespace Fooyin

--- a/src/core/engine/input/ffmpeg/ffmpeginput.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpeginput.cpp
@@ -48,12 +48,6 @@
 #define strncasecmp _strnicmp
 #endif
 
-#ifdef __GNUG__
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#elifdef __clang__
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#endif
-
 using namespace Qt::StringLiterals;
 
 constexpr AVRational TimeBaseAv           = {.num = 1, .den = AV_TIME_BASE};
@@ -79,13 +73,6 @@ enum class TagType : uint8_t
 bool isRecoverableDecodeError(int error)
 {
     return error == AVERROR_INVALIDDATA;
-}
-
-QString ffmpegErrorString(int error)
-{
-    char errStr[AV_ERROR_MAX_STRING_SIZE]{};
-    av_strerror(error, errStr, AV_ERROR_MAX_STRING_SIZE);
-    return QString::fromLocal8Bit(errStr);
 }
 
 QStringList fileExtensions(bool allSupported)
@@ -941,13 +928,11 @@ FormatContext createAVFormatContext(const AudioSource& source)
     const int ret = avformat_open_input(&avContext, filepath, nullptr, nullptr);
     if(ret < 0) {
         // Format context is freed on failure
-        char err[AV_ERROR_MAX_STRING_SIZE];
-        av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
         if(deadline && deadline->expired()) {
             qCWarning(FFMPEG) << "Timed out opening input:" << source.filepath;
         }
         else {
-            qCWarning(FFMPEG) << "Error opening input:" << err;
+            qCWarning(FFMPEG) << "Error opening input:" << Utils::ffmpegErrorString(ret);
         }
         return {};
     }
@@ -1256,7 +1241,7 @@ int FFmpegInputPrivate::receiveAVFrames()
     }
 
     if(result < 0) {
-        const QString error = ffmpegErrorString(result);
+        const QString error = Utils::ffmpegErrorString(result);
         qCWarning(FFMPEG) << "FFmpeg receive frame failed:"
                           << "error=" << error << "code=" << result << "remote=" << isRemoteStream()
                           << "consecutiveDecodeErrors=" << m_consecutiveDecodeErrors << "currentPosMs=" << m_currentPos
@@ -1433,7 +1418,7 @@ void FFmpegInputPrivate::readNext()
             m_eof = true;
         }
         else {
-            const QString error = ffmpegErrorString(readResult);
+            const QString error = Utils::ffmpegErrorString(readResult);
             if(isRemoteStream()) {
                 qCWarning(FFMPEG) << "Treating remote FFmpeg read error as temporary:"
                                   << "error=" << error << "code=" << readResult << "currentPosMs=" << m_currentPos

--- a/src/core/engine/input/ffmpeg/ffmpegutils.cpp
+++ b/src/core/engine/input/ffmpeg/ffmpegutils.cpp
@@ -19,21 +19,17 @@
 
 #include "ffmpegutils.h"
 
-#if defined(__GNUG__)
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#elif defined(__clang__)
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#endif
+#include <QDebug>
 
 extern "C"
 {
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
+#include <libavutil/audio_fifo.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/frame.h>
+#include <libswresample/swresample.h>
 }
-
-#include <QDebug>
 
 Q_LOGGING_CATEGORY(FFMPEG, "fy.ffmpeg")
 
@@ -211,6 +207,23 @@ void FormatContextDeleter::operator()(AVFormatContext* context) const
     }
 }
 
+void OutputFormatContextDeleter::operator()(AVFormatContext* context) const
+{
+    if(context) {
+        if(context->oformat && (context->oformat->flags & AVFMT_NOFILE) == 0 && context->pb) {
+            avio_closep(&context->pb);
+        }
+        avformat_free_context(context);
+    }
+}
+
+void CodecContextDeleter::operator()(AVCodecContext* context) const
+{
+    if(context) {
+        avcodec_free_context(&context);
+    }
+}
+
 void FrameDeleter::operator()(AVFrame* frame) const
 {
     if(frame != nullptr) {
@@ -225,12 +238,31 @@ void PacketDeleter::operator()(AVPacket* packet) const
     }
 }
 
+void SwrContextDeleter::operator()(SwrContext* context) const
+{
+    if(context) {
+        swr_free(&context);
+    }
+}
+
+void AudioFifoDeleter::operator()(AVAudioFifo* fifo) const
+{
+    if(fifo) {
+        av_audio_fifo_free(fifo);
+    }
+}
+
 namespace Fooyin::Utils {
+QString ffmpegErrorString(int error)
+{
+    char errStr[AV_ERROR_MAX_STRING_SIZE]{};
+    av_strerror(error, errStr, AV_ERROR_MAX_STRING_SIZE);
+    return QString::fromLocal8Bit(errStr);
+}
+
 void printError(int error)
 {
-    char errStr[1024];
-    av_strerror(error, errStr, 1024);
-    qCWarning(FFMPEG) << errStr;
+    qCWarning(FFMPEG) << ffmpegErrorString(error);
 }
 
 void printError(const QString& error)
@@ -255,7 +287,7 @@ AudioFormat audioFormatFromCodec(AVCodecParameters* codec, AVSampleFormat ctxFor
     format.setChannelCount(codec->ch_layout.nb_channels);
     AudioFormat::ChannelLayout layout;
     const auto channelCount = static_cast<unsigned>(codec->ch_layout.nb_channels);
-    layout.reserve(static_cast<size_t>(channelCount));
+    layout.reserve(channelCount);
     for(unsigned i = 0; i < channelCount; ++i) {
         const auto channel = av_channel_layout_channel_from_index(&codec->ch_layout, i);
         layout.push_back(channelPositionFromAvChannel(channel));
@@ -271,21 +303,21 @@ AudioFormat audioFormatFromCodec(AVCodecParameters* codec, AVSampleFormat ctxFor
 SampleFormat sampleFormat(AVSampleFormat format, int bps)
 {
     switch(format) {
-        case(AV_SAMPLE_FMT_NONE):
-        case(AV_SAMPLE_FMT_U8):
-        case(AV_SAMPLE_FMT_U8P):
+        case AV_SAMPLE_FMT_NONE:
+        case AV_SAMPLE_FMT_U8:
+        case AV_SAMPLE_FMT_U8P:
             return SampleFormat::U8;
-        case(AV_SAMPLE_FMT_S16):
-        case(AV_SAMPLE_FMT_S16P):
+        case AV_SAMPLE_FMT_S16:
+        case AV_SAMPLE_FMT_S16P:
             return SampleFormat::S16;
-        case(AV_SAMPLE_FMT_S32):
-        case(AV_SAMPLE_FMT_S32P):
+        case AV_SAMPLE_FMT_S32:
+        case AV_SAMPLE_FMT_S32P:
             return bps == 24 ? SampleFormat::S24In32 : SampleFormat::S32;
-        case(AV_SAMPLE_FMT_FLT):
-        case(AV_SAMPLE_FMT_FLTP):
+        case AV_SAMPLE_FMT_FLT:
+        case AV_SAMPLE_FMT_FLTP:
             return SampleFormat::F32;
-        case(AV_SAMPLE_FMT_DBL):
-        case(AV_SAMPLE_FMT_DBLP):
+        case AV_SAMPLE_FMT_DBL:
+        case AV_SAMPLE_FMT_DBLP:
             return SampleFormat::F64;
         default:
             return SampleFormat::Unknown;
@@ -313,18 +345,18 @@ AVSampleFormat sampleFormat(SampleFormat format, bool planar)
     }
     else {
         switch(format) {
-            case(SampleFormat::U8):
+            case SampleFormat::U8:
                 return AV_SAMPLE_FMT_U8;
-            case(SampleFormat::S16):
+            case SampleFormat::S16:
                 return AV_SAMPLE_FMT_S16;
-            case(SampleFormat::S24In32):
-            case(SampleFormat::S32):
+            case SampleFormat::S24In32:
+            case SampleFormat::S32:
                 return AV_SAMPLE_FMT_S32;
-            case(SampleFormat::F32):
+            case SampleFormat::F32:
                 return AV_SAMPLE_FMT_FLT;
-            case(SampleFormat::F64):
+            case SampleFormat::F64:
                 return AV_SAMPLE_FMT_DBL;
-            case(SampleFormat::Unknown):
+            case SampleFormat::Unknown:
                 break;
         }
     }

--- a/src/core/engine/input/ffmpeg/ffmpegutils.h
+++ b/src/core/engine/input/ffmpeg/ffmpegutils.h
@@ -25,36 +25,26 @@
 
 #include <core/engine/audioformat.h>
 
-#if defined(__GNUG__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#endif
+#include <QLoggingCategory>
 
 extern "C"
 {
 #include <libavcodec/avcodec.h>
 }
 
-#if defined(__GNUG__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
-#include <QLoggingCategory>
-
 #include <memory>
 
 class QString;
 struct AVCodecParameters;
+struct AVCodecContext;
+struct AVAudioFifo;
 struct AVFormatContext;
 struct AVIOContext;
 struct AVPacket;
+struct SwrContext;
 
 #define OLD_CHANNEL_LAYOUT (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100))
+#define OLD_CODEC_SUPPORTED_CONFIG (LIBAVCODEC_VERSION_MAJOR < 61)
 #define OLD_FRAME (LIBAVUTIL_VERSION_MAJOR < 58)
 
 FYCORE_EXPORT Q_DECLARE_LOGGING_CATEGORY(FFMPEG)
@@ -70,6 +60,18 @@ struct FormatContextDeleter
     void operator()(AVFormatContext* context) const;
 };
 using FormatContextPtr = std::unique_ptr<AVFormatContext, FormatContextDeleter>;
+
+struct OutputFormatContextDeleter
+{
+    void operator()(AVFormatContext* context) const;
+};
+using OutputFormatContextPtr = std::unique_ptr<AVFormatContext, OutputFormatContextDeleter>;
+
+struct CodecContextDeleter
+{
+    void operator()(AVCodecContext* context) const;
+};
+using CodecContextPtr = std::unique_ptr<AVCodecContext, CodecContextDeleter>;
 
 struct FrameDeleter
 {
@@ -90,7 +92,20 @@ struct PacketDeleter
 };
 using PacketPtr = std::unique_ptr<AVPacket, PacketDeleter>;
 
+struct SwrContextDeleter
+{
+    void operator()(SwrContext* context) const;
+};
+using SwrContextPtr = std::unique_ptr<SwrContext, SwrContextDeleter>;
+
+struct AudioFifoDeleter
+{
+    void operator()(AVAudioFifo* fifo) const;
+};
+using AudioFifoPtr = std::unique_ptr<AVAudioFifo, AudioFifoDeleter>;
+
 namespace Fooyin::Utils {
+FYCORE_EXPORT QString ffmpegErrorString(int error);
 FYCORE_EXPORT void printError(int error);
 FYCORE_EXPORT void printError(const QString& error);
 

--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -3627,8 +3627,8 @@ bool TagLibReader::writeTrack(const AudioSource& source, const Track& track, Wri
             TagLib::RIFF::WAV::File file(&stream, false);
             if(file.isValid()) {
                 writeProperties(file, false, true);
-                if(file.hasID3v2Tag()) {
-                    writeID3v2Tags(file.ID3v2Tag(), track, options, policy, false);
+                if(auto* tag = file.ID3v2Tag()) {
+                    writeID3v2Tags(tag, track, options, policy, false);
                 }
                 else {
                     logWriteFailure(u"write metadata"_s, source.filepath, mimeType, u"file has no ID3v2 tag block"_s);
@@ -3872,13 +3872,11 @@ bool TagLibReader::writeCover(const AudioSource& source, const Track& track, con
         }
         case AudioFileFormat::Wav: {
             TagLib::RIFF::WAV::File file(&stream, false);
-            if(file.isValid() && file.hasID3v2Tag()) {
-                success = saveModifiedFile(file, writeId3Cover(file.ID3v2Tag(), covers), u"write cover artwork"_s,
-                                           source.filepath, mimeType, failureLogged);
-            }
-            else if(file.isValid()) {
-                logWriteFailure(u"write cover artwork"_s, source.filepath, mimeType, u"file has no ID3v2 tag block"_s);
-                failureLogged = true;
+            if(file.isValid()) {
+                if(auto* tag = file.ID3v2Tag()) {
+                    success = saveModifiedFile(file, writeId3Cover(tag, covers), u"write cover artwork"_s,
+                                               source.filepath, mimeType, failureLogged);
+                }
             }
             break;
         }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -120,6 +120,16 @@ set(SOURCES
     controls/seekbar.h
     controls/volumecontrol.cpp
     controls/volumecontrol.h
+    conversion/conversioncontroller.cpp
+    conversion/conversioncontroller.h
+    conversion/convertersetupdialog.cpp
+    conversion/convertersetupdialog.h
+    conversion/convertersettingsstore.cpp
+    conversion/convertersettingsstore.h
+    conversion/encoderprofiledialog.cpp
+    conversion/encoderprofiledialog.h
+    conversion/encoderprofiletablemodel.cpp
+    conversion/encoderprofiletablemodel.h
     coverprovider.cpp
     coverrepository.cpp
     dialog/aboutdialog.cpp
@@ -550,6 +560,7 @@ create_fooyin_library(
     EXPORT_NAME Gui
     SOURCES ${SOURCES}
 )
+
 target_link_libraries(
     fooyin_gui
     PRIVATE Fooyin::CorePrivate

--- a/src/gui/conversion/conversioncontroller.cpp
+++ b/src/gui/conversion/conversioncontroller.cpp
@@ -1,0 +1,267 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "conversioncontroller.h"
+
+#include "convertersettingsstore.h"
+#include "convertersetupdialog.h"
+
+#include <core/engine/conversion/conversionrunner.h>
+#include <gui/widgets/elapsedprogressdialog.h>
+#include <utils/async.h>
+
+#include <QAbstractButton>
+#include <QFileInfo>
+#include <QFutureWatcher>
+#include <QMessageBox>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+
+using namespace std::chrono_literals;
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+class ConversionSession : public QObject
+{
+    Q_OBJECT
+
+public:
+    ConversionSession(std::shared_ptr<AudioLoader> audioLoader, AudioEncoderRegistry* encoderRegistry,
+                      DspRegistry* dspRegistry, ConversionJob job, QString askFolder, bool showReport,
+                      QWidget* parentWindow, QObject* parent)
+        : QObject{parent}
+        , m_audioLoader{std::move(audioLoader)}
+        , m_encoderRegistry{encoderRegistry}
+        , m_dspRegistry{dspRegistry}
+        , m_job{std::move(job)}
+        , m_askFolder{std::move(askFolder)}
+        , m_showReport{showReport}
+        , m_parentWindow{parentWindow}
+        , m_cancelled{std::make_shared<std::atomic_bool>(false)}
+        , m_progress{new ElapsedProgressDialog(tr("Preparing conversion…"), tr("Cancel"), 0, 100, parentWindow)}
+        , m_watcher{new QFutureWatcher<std::vector<ConversionTrackResult>>(this)}
+    {
+        m_progress->setAttribute(Qt::WA_DeleteOnClose, false);
+        m_progress->setWindowTitle(tr("Audio Conversion"));
+        m_progress->setModal(true);
+        m_progress->setMinimumDuration(250ms);
+        m_progress->startTimer();
+        m_progress->setValue(0);
+
+        QObject::connect(m_progress, &ElapsedProgressDialog::cancelled, m_progress,
+                         [cancelled = m_cancelled]() { cancelled->store(true, std::memory_order_release); });
+        QObject::connect(m_watcher, &QFutureWatcherBase::finished, this, &ConversionSession::finish);
+    }
+
+    void start()
+    {
+        auto future = Utils::asyncExec([audioLoader = m_audioLoader, encoderRegistry = m_encoderRegistry,
+                                        dspRegistry = m_dspRegistry, job = m_job, askFolder = m_askFolder,
+                                        cancelled = m_cancelled, progress = m_progress, parent = m_parentWindow,
+                                        session = this]() {
+            ConversionRunner::Request request;
+            request.audioLoader     = audioLoader.get();
+            request.encoderRegistry = encoderRegistry;
+            request.dspRegistry     = dspRegistry;
+            request.job             = job;
+            request.askFolder       = askFolder;
+            request.cancelCallback  = [cancelled]() {
+                return cancelled->load(std::memory_order_acquire);
+            };
+            request.progressCallback = [progress](const ConversionProgress& current) {
+                const int trackCount       = std::max(1, current.trackCount);
+                const double trackProgress = current.sourceDurationMs > 0
+                                               ? std::clamp(static_cast<double>(current.sourcePositionMs)
+                                                                / static_cast<double>(current.sourceDurationMs),
+                                                            0.0, 1.0)
+                                               : 0.0;
+                const auto percentage      = static_cast<int>(
+                    ((static_cast<double>(current.trackIndex) + trackProgress) / trackCount) * 100.0);
+                const QString text = tr("Current file") + ":\n"_L1 + current.sourcePath;
+                QMetaObject::invokeMethod(progress, [progress, percentage, text]() {
+                    progress->setText(text);
+                    progress->setValue(percentage);
+                });
+            };
+            request.existingFileCallback = [cancelled, parent, session](const QString& path) {
+                if(cancelled->load(std::memory_order_acquire)) {
+                    return ExistingFileMode::Ask;
+                }
+
+                auto promise        = std::make_shared<std::promise<ExistingFileMode>>();
+                auto decisionFuture = promise->get_future();
+                const bool invoked  = QMetaObject::invokeMethod(
+                    session,
+                    [cancelled, parent, path, promise, session]() {
+                        if(cancelled->load(std::memory_order_acquire)) {
+                            promise->set_value(ExistingFileMode::Ask);
+                            return;
+                        }
+
+                        auto* prompt
+                            = new QMessageBox{QMessageBox::Question, tr("File already exists"),
+                                              tr("The file already exists:\n%1").arg(path),
+                                              QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, parent};
+                        prompt->setAttribute(Qt::WA_DeleteOnClose);
+                        prompt->button(QMessageBox::Yes)->setText(tr("Overwrite"));
+                        prompt->button(QMessageBox::No)->setText(tr("Skip"));
+                        QObject::connect(prompt, &QDialog::finished, session, [cancelled, promise](int result) {
+                            if(result == QMessageBox::Yes) {
+                                promise->set_value(ExistingFileMode::Overwrite);
+                            }
+                            else if(result == QMessageBox::No) {
+                                promise->set_value(ExistingFileMode::Skip);
+                            }
+                            else {
+                                cancelled->store(true, std::memory_order_release);
+                                promise->set_value(ExistingFileMode::Ask);
+                            }
+                        });
+                        prompt->open();
+                    },
+                    Qt::QueuedConnection);
+                return invoked ? decisionFuture.get() : ExistingFileMode::Ask;
+            };
+            return ConversionRunner::run(request);
+        });
+
+        m_watcher->setFuture(future);
+    }
+
+private:
+    void finish()
+    {
+        const auto results = m_watcher->result();
+        m_progress->setValue(100);
+
+        int succeeded{0};
+        int skipped{0};
+        int failed{0};
+        int cancelledCount{0};
+        QStringList details;
+        for(const ConversionTrackResult& result : results) {
+            switch(result.status) {
+                case ConversionResultStatus::Succeeded:
+                    ++succeeded;
+                    break;
+                case ConversionResultStatus::Skipped:
+                    ++skipped;
+                    break;
+                case ConversionResultStatus::Failed:
+                    ++failed;
+                    break;
+                case ConversionResultStatus::Cancelled:
+                    ++cancelledCount;
+                    break;
+            }
+            if(!result.error.isEmpty()) {
+                details.push_back(QFileInfo{result.sourceTrack.filepath()}.fileName() + u": "_s + result.error);
+            }
+            for(const QString& warning : result.warnings) {
+                details.push_back(QFileInfo{result.sourceTrack.filepath()}.fileName() + u": "_s + warning);
+            }
+        }
+
+        if(m_showReport || failed > 0 || !details.isEmpty()) {
+            const QString summary = QStringList{tr("Converted: %Ln track(s)", nullptr, succeeded),
+                                                tr("Skipped: %Ln track(s)", nullptr, skipped),
+                                                tr("Failed: %Ln track(s)", nullptr, failed),
+                                                tr("Cancelled: %Ln track(s)", nullptr, cancelledCount)}
+                                        .join(u'\n');
+            QMessageBox report{failed > 0 ? QMessageBox::Warning : QMessageBox::Information, tr("Audio Conversion"),
+                               summary, QMessageBox::Ok, m_parentWindow};
+            if(!details.isEmpty()) {
+                report.setDetailedText(details.join(u'\n'));
+            }
+            report.exec();
+        }
+
+        m_progress->deleteLater();
+        deleteLater();
+    }
+
+    std::shared_ptr<AudioLoader> m_audioLoader;
+    AudioEncoderRegistry* m_encoderRegistry;
+    DspRegistry* m_dspRegistry;
+
+    ConversionJob m_job;
+    QString m_askFolder;
+    bool m_showReport;
+    QWidget* m_parentWindow;
+    std::shared_ptr<std::atomic_bool> m_cancelled;
+    ElapsedProgressDialog* m_progress;
+    QFutureWatcher<std::vector<ConversionTrackResult>>* m_watcher;
+};
+} // namespace
+
+ConversionController::ConversionController(std::shared_ptr<AudioLoader> audioLoader,
+                                           AudioEncoderRegistry* encoderRegistry, DspRegistry* dspRegistry,
+                                           DspChainStore* dspChainStore, DspSettingsRegistry* dspSettingsRegistry,
+                                           SettingsManager* settings, QWidget* parentWindow, QObject* parent)
+    : QObject{parent}
+    , m_audioLoader{std::move(audioLoader)}
+    , m_encoderRegistry{encoderRegistry}
+    , m_dspRegistry{dspRegistry}
+    , m_dspChainStore{dspChainStore}
+    , m_dspSettingsRegistry{dspSettingsRegistry}
+    , m_settings{settings}
+    , m_parentWindow{parentWindow}
+{ }
+
+void ConversionController::showSetup(const TrackList& tracks)
+{
+    if(tracks.empty()) {
+        return;
+    }
+
+    ConverterSetupDialog setup{m_encoderRegistry, m_dspChainStore,      m_settings, tracks,
+                               m_parentWindow,    m_dspSettingsRegistry};
+    const int result = setup.exec();
+    if(result != QDialog::Accepted) {
+        Q_EMIT conversionPresetsChanged();
+        return;
+    }
+
+    ConversionJob job = setup.job();
+    ConverterSettings::setLastUsedConversionPreset({
+        .name       = u"[last used]"_s,
+        .preset     = job.preset,
+        .showReport = setup.showReport(),
+    });
+    Q_EMIT conversionPresetsChanged();
+    start(std::move(job), setup.askFolder(), setup.showReport());
+}
+
+void ConversionController::start(ConversionJob job, QString askFolder, bool showReport)
+{
+    if(job.tracks.empty()) {
+        return;
+    }
+
+    auto* session = new ConversionSession{m_audioLoader,        m_encoderRegistry, m_dspRegistry,  std::move(job),
+                                          std::move(askFolder), showReport,        m_parentWindow, this};
+    session->start();
+}
+} // namespace Fooyin
+
+#include "conversioncontroller.moc"
+#include "moc_conversioncontroller.cpp"

--- a/src/gui/conversion/conversioncontroller.h
+++ b/src/gui/conversion/conversioncontroller.h
@@ -1,0 +1,63 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/conversion/conversiondefs.h>
+
+#include <QObject>
+
+#include <memory>
+
+class QWidget;
+
+namespace Fooyin {
+class AudioEncoderRegistry;
+class AudioLoader;
+class DspChainStore;
+class DspRegistry;
+class DspSettingsRegistry;
+class SettingsManager;
+
+class ConversionController : public QObject
+{
+    Q_OBJECT
+
+public:
+    ConversionController(std::shared_ptr<AudioLoader> audioLoader, AudioEncoderRegistry* encoderRegistry,
+                         DspRegistry* dspRegistry, DspChainStore* dspChainStore,
+                         DspSettingsRegistry* dspSettingsRegistry, SettingsManager* settings, QWidget* parentWindow,
+                         QObject* parent = nullptr);
+
+    void showSetup(const TrackList& tracks);
+    void start(ConversionJob job, QString askFolder, bool showReport);
+
+Q_SIGNALS:
+    void conversionPresetsChanged();
+
+private:
+    std::shared_ptr<AudioLoader> m_audioLoader;
+    AudioEncoderRegistry* m_encoderRegistry;
+    DspRegistry* m_dspRegistry;
+    DspChainStore* m_dspChainStore;
+    DspSettingsRegistry* m_dspSettingsRegistry;
+    SettingsManager* m_settings;
+    QWidget* m_parentWindow;
+};
+} // namespace Fooyin

--- a/src/gui/conversion/convertersettingsstore.cpp
+++ b/src/gui/conversion/convertersettingsstore.cpp
@@ -1,0 +1,306 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "convertersettingsstore.h"
+
+#include <core/coresettings.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto EncoderProfilesKey   = "Converter/EncoderProfiles";
+constexpr auto ConversionPresetsKey = "Converter/Presets";
+constexpr auto LastUsedPresetKey    = "Converter/LastUsedPreset";
+constexpr auto DataVersion          = 1;
+
+namespace Fooyin {
+namespace {
+QJsonObject encoderProfileToJson(const EncoderProfile& profile)
+{
+    return {
+        {u"id"_s, profile.id},
+        {u"name"_s, profile.name},
+        {u"extension"_s, profile.extension},
+        {u"container"_s, profile.containerName},
+        {u"codec"_s, profile.codecName},
+        {u"mode"_s, static_cast<int>(profile.mode)},
+        {u"bitrateKbps"_s, profile.bitrateKbps},
+        {u"quality"_s, profile.quality},
+        {u"compressionLevel"_s, profile.compressionLevel},
+    };
+}
+
+EncoderProfile encoderProfileFromJson(const QJsonObject& object)
+{
+    EncoderProfile profile;
+    profile.id               = object.value(u"id"_s).toString();
+    profile.name             = object.value(u"name"_s).toString();
+    profile.extension        = object.value(u"extension"_s).toString();
+    profile.containerName    = object.value(u"container"_s).toString();
+    profile.codecName        = object.value(u"codec"_s).toString();
+    profile.mode             = static_cast<EncoderMode>(object.value(u"mode"_s).toInt());
+    profile.bitrateKbps      = object.value(u"bitrateKbps"_s).toInt();
+    profile.quality          = object.value(u"quality"_s).toDouble();
+    profile.compressionLevel = object.value(u"compressionLevel"_s).toInt(-1);
+    return profile;
+}
+
+QJsonObject dspDefinitionToJson(const Engine::DspDefinition& dsp)
+{
+    return {
+        {u"id"_s, dsp.id},
+        {u"name"_s, dsp.name},
+        {u"hasSettings"_s, dsp.hasSettings},
+        {u"enabled"_s, dsp.enabled},
+        {u"instanceId"_s, QString::number(dsp.instanceId)},
+        {u"settings"_s, QString::fromUtf8(dsp.settings.toBase64())},
+    };
+}
+
+QJsonArray dspChainToJson(const Engine::DspChain& chain)
+{
+    QJsonArray result;
+    for(const auto& dsp : chain) {
+        result.push_back(dspDefinitionToJson(dsp));
+    }
+    return result;
+}
+
+Engine::DspChain dspChainFromJson(const QJsonArray& array)
+{
+    Engine::DspChain result;
+
+    for(const auto& value : array) {
+        const QJsonObject object = value.toObject();
+
+        Engine::DspDefinition dsp;
+        dsp.id          = object.value(u"id"_s).toString();
+        dsp.name        = object.value(u"name"_s).toString();
+        dsp.hasSettings = object.value(u"hasSettings"_s).toBool();
+        dsp.enabled     = object.value(u"enabled"_s).toBool(true);
+        dsp.instanceId  = object.value(u"instanceId"_s).toString().toULongLong();
+        dsp.settings    = QByteArray::fromBase64(object.value(u"settings"_s).toString().toUtf8());
+
+        if(!dsp.id.isEmpty()) {
+            result.push_back(std::move(dsp));
+        }
+    }
+
+    return result;
+}
+
+QJsonObject conversionPresetToJson(const StoredConversionPreset& stored)
+{
+    const auto& preset = stored.preset;
+    return {
+        {u"name"_s, stored.name},
+        {u"id"_s, preset.id},
+        {u"profile"_s, encoderProfileToJson(preset.encoder.profile)},
+        {u"sampleFormat"_s, static_cast<int>(preset.encoder.outputSampleFormat)},
+        {u"dither"_s, static_cast<int>(preset.encoder.ditherMode)},
+        {u"destinationMode"_s, static_cast<int>(preset.destination.mode)},
+        {u"fixedFolder"_s, preset.destination.fixedFolder},
+        {u"filenamePattern"_s, preset.destination.filenamePattern},
+        {u"existingFileMode"_s, static_cast<int>(preset.destination.existingFileMode)},
+        {u"outputStyle"_s, static_cast<int>(preset.destination.outputStyle)},
+        {u"transferMetadata"_s, preset.processing.transferMetadata},
+        {u"transferRating"_s, preset.processing.transferRating},
+        {u"transferPlaycount"_s, preset.processing.transferPlaycount},
+        {u"transferPictures"_s, preset.processing.transferPictures},
+        {u"replayGainMode"_s, static_cast<int>(preset.processing.replayGainMode)},
+        {u"replayGainPreventClipping"_s, preset.processing.replayGainPreventClipping},
+        {u"replayGainPreampDb"_s, preset.processing.replayGainPreampDb},
+        {u"replayGainWithoutInfoPreampDb"_s, preset.processing.replayGainWithoutInfoPreampDb},
+        {u"dspChain"_s, dspChainToJson(preset.processing.dspChain)},
+        {u"preserveDspStateBetweenTracks"_s, preset.processing.preserveDspStateBetweenTracks},
+        {u"previewEnabled"_s, preset.preview.enabled},
+        {u"previewLengthPercentage"_s, preset.preview.lengthPercentage},
+        {u"copyFilesPattern"_s, preset.other.copyFilesPattern},
+        {u"verifyOutput"_s, preset.other.verifyOutput},
+        {u"showReport"_s, stored.showReport},
+    };
+}
+
+StoredConversionPreset conversionPresetFromJson(const QJsonObject& object)
+{
+    StoredConversionPreset stored;
+
+    stored.name                              = object.value(u"name"_s).toString();
+    stored.preset.id                         = object.value(u"id"_s).toString();
+    stored.preset.name                       = stored.name;
+    stored.preset.encoder.profile            = encoderProfileFromJson(object.value(u"profile"_s).toObject());
+    stored.preset.encoder.outputSampleFormat = static_cast<SampleFormat>(object.value(u"sampleFormat"_s).toInt());
+    stored.preset.encoder.ditherMode         = static_cast<DitherMode>(object.value(u"dither"_s).toInt());
+    stored.preset.destination.mode           = static_cast<DestinationMode>(object.value(u"destinationMode"_s).toInt());
+    stored.preset.destination.fixedFolder    = object.value(u"fixedFolder"_s).toString();
+    stored.preset.destination.filenamePattern = object.value(u"filenamePattern"_s).toString(u"%title%"_s);
+    stored.preset.destination.existingFileMode
+        = static_cast<ExistingFileMode>(object.value(u"existingFileMode"_s).toInt());
+    stored.preset.destination.outputStyle      = static_cast<OutputStyle>(object.value(u"outputStyle"_s).toInt());
+    stored.preset.processing.transferMetadata  = object.value(u"transferMetadata"_s).toBool(true);
+    stored.preset.processing.transferRating    = object.value(u"transferRating"_s).toBool(true);
+    stored.preset.processing.transferPlaycount = object.value(u"transferPlaycount"_s).toBool(false);
+    stored.preset.processing.transferPictures  = object.value(u"transferPictures"_s).toBool(true);
+    stored.preset.processing.replayGainMode    = static_cast<ConversionReplayGainMode>(
+        object.value(u"replayGainMode"_s).toInt(static_cast<int>(ConversionReplayGainMode::None)));
+    stored.preset.processing.replayGainPreventClipping = object.value(u"replayGainPreventClipping"_s).toBool(true);
+    stored.preset.processing.replayGainPreampDb        = object.value(u"replayGainPreampDb"_s).toDouble();
+    stored.preset.processing.replayGainWithoutInfoPreampDb
+        = object.value(u"replayGainWithoutInfoPreampDb"_s).toDouble();
+    stored.preset.processing.dspChain = dspChainFromJson(object.value(u"dspChain"_s).toArray());
+    stored.preset.processing.preserveDspStateBetweenTracks
+        = object.value(u"preserveDspStateBetweenTracks"_s).toBool(false);
+    stored.preset.preview.enabled          = object.value(u"previewEnabled"_s).toBool(false);
+    stored.preset.preview.lengthPercentage = object.value(u"previewLengthPercentage"_s).toInt(20);
+    stored.preset.other.copyFilesPattern   = object.value(u"copyFilesPattern"_s).toString();
+    stored.preset.other.verifyOutput       = object.value(u"verifyOutput"_s).toBool(false);
+    stored.showReport                      = object.value(u"showReport"_s).toBool(true);
+
+    return stored;
+}
+
+QByteArray serialise(const QJsonArray& entries)
+{
+    return QJsonDocument{QJsonObject{{u"version"_s, DataVersion}, {u"entries"_s, entries}}}.toJson(
+        QJsonDocument::Compact);
+}
+
+QJsonArray entriesFromData(const QByteArray& data)
+{
+    QJsonParseError error;
+    const QJsonDocument document = QJsonDocument::fromJson(data, &error);
+    if(error.error != QJsonParseError::NoError || !document.isObject()) {
+        return {};
+    }
+
+    const QJsonObject root = document.object();
+    if(root.value(u"version"_s).toInt() != DataVersion) {
+        return {};
+    }
+
+    return root.value(u"entries"_s).toArray();
+}
+} // namespace
+
+namespace ConverterSettings {
+EncoderProfile applyStoredEncoderProfile(EncoderProfile profile, const StoredEncoderProfile& stored)
+{
+    profile.name             = stored.profile.name;
+    profile.mode             = stored.profile.mode;
+    profile.bitrateKbps      = stored.profile.bitrateKbps;
+    profile.quality          = stored.profile.quality;
+    profile.compressionLevel = stored.profile.compressionLevel;
+    return profile;
+}
+
+std::vector<StoredEncoderProfile> encoderProfiles()
+{
+    const FySettings settings;
+    return deserialiseEncoderProfiles(settings.value(EncoderProfilesKey).toByteArray());
+}
+
+void setEncoderProfiles(const std::vector<StoredEncoderProfile>& profiles)
+{
+    FySettings settings;
+    settings.setValue(EncoderProfilesKey, serialiseEncoderProfiles(profiles));
+}
+
+std::vector<StoredConversionPreset> conversionPresets()
+{
+    const FySettings settings;
+    return deserialiseConversionPresets(settings.value(ConversionPresetsKey).toByteArray());
+}
+
+void setConversionPresets(const std::vector<StoredConversionPreset>& presets)
+{
+    FySettings settings;
+    settings.setValue(ConversionPresetsKey, serialiseConversionPresets(presets));
+}
+
+std::optional<StoredConversionPreset> lastUsedConversionPreset()
+{
+    const FySettings settings;
+    auto presets = deserialiseConversionPresets(settings.value(LastUsedPresetKey).toByteArray());
+    if(presets.empty()) {
+        return {};
+    }
+    return std::move(presets.front());
+}
+
+void setLastUsedConversionPreset(const StoredConversionPreset& preset)
+{
+    FySettings settings;
+    settings.setValue(LastUsedPresetKey, serialiseConversionPresets({preset}));
+}
+
+QByteArray serialiseEncoderProfiles(const std::vector<StoredEncoderProfile>& profiles)
+{
+    QJsonArray entries;
+    for(const auto& stored : profiles) {
+        entries.push_back(QJsonObject{
+            {u"storageId"_s, stored.storageId},
+            {u"baseEncoderId"_s, stored.baseEncoderId},
+            {u"overridesBuiltIn"_s, stored.overridesBuiltIn},
+            {u"profile"_s, encoderProfileToJson(stored.profile)},
+        });
+    }
+    return serialise(entries);
+}
+
+std::vector<StoredEncoderProfile> deserialiseEncoderProfiles(const QByteArray& data)
+{
+    std::vector<StoredEncoderProfile> profiles;
+
+    const auto entries = entriesFromData(data);
+    for(const auto& entry : entries) {
+        const QJsonObject object = entry.toObject();
+
+        StoredEncoderProfile stored;
+        stored.storageId        = object.value(u"storageId"_s).toString();
+        stored.baseEncoderId    = object.value(u"baseEncoderId"_s).toString();
+        stored.overridesBuiltIn = object.value(u"overridesBuiltIn"_s).toBool();
+        stored.profile          = encoderProfileFromJson(object.value(u"profile"_s).toObject());
+
+        if(!stored.storageId.isEmpty() && !stored.baseEncoderId.isEmpty() && !stored.profile.name.isEmpty()) {
+            profiles.push_back(std::move(stored));
+        }
+    }
+    return profiles;
+}
+
+QByteArray serialiseConversionPresets(const std::vector<StoredConversionPreset>& presets)
+{
+    QJsonArray entries;
+    for(const auto& stored : presets) {
+        entries.push_back(conversionPresetToJson(stored));
+    }
+    return serialise(entries);
+}
+
+std::vector<StoredConversionPreset> deserialiseConversionPresets(const QByteArray& data)
+{
+    std::vector<StoredConversionPreset> presets;
+
+    const auto entries = entriesFromData(data);
+    for(const auto& entry : entries) {
+        StoredConversionPreset stored = conversionPresetFromJson(entry.toObject());
+
+        if(!stored.name.isEmpty() && !stored.preset.encoder.profile.id.isEmpty()) {
+            presets.push_back(std::move(stored));
+        }
+    }
+    return presets;
+}
+} // namespace ConverterSettings
+} // namespace Fooyin

--- a/src/gui/conversion/convertersettingsstore.h
+++ b/src/gui/conversion/convertersettingsstore.h
@@ -1,0 +1,58 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <core/engine/conversion/conversiondefs.h>
+
+#include <QByteArray>
+#include <QString>
+
+#include <optional>
+#include <vector>
+
+namespace Fooyin {
+class SettingsManager;
+
+struct StoredEncoderProfile
+{
+    QString storageId;
+    QString baseEncoderId;
+    EncoderProfile profile;
+    bool overridesBuiltIn{false};
+};
+
+struct StoredConversionPreset
+{
+    QString name;
+    ConversionPreset preset;
+    bool showReport{true};
+};
+
+namespace ConverterSettings {
+constexpr auto DefaultEncoderProfileId = "ffmpeg-wav";
+
+EncoderProfile applyStoredEncoderProfile(EncoderProfile profile, const StoredEncoderProfile& stored);
+
+std::vector<StoredEncoderProfile> encoderProfiles();
+void setEncoderProfiles(const std::vector<StoredEncoderProfile>& profiles);
+
+std::vector<StoredConversionPreset> conversionPresets();
+void setConversionPresets(const std::vector<StoredConversionPreset>& presets);
+
+std::optional<StoredConversionPreset> lastUsedConversionPreset();
+void setLastUsedConversionPreset(const StoredConversionPreset& preset);
+
+QByteArray serialiseEncoderProfiles(const std::vector<StoredEncoderProfile>& profiles);
+std::vector<StoredEncoderProfile> deserialiseEncoderProfiles(const QByteArray& data);
+QByteArray serialiseConversionPresets(const std::vector<StoredConversionPreset>& presets);
+std::vector<StoredConversionPreset> deserialiseConversionPresets(const QByteArray& data);
+} // namespace ConverterSettings
+} // namespace Fooyin

--- a/src/gui/conversion/convertersetupdialog.cpp
+++ b/src/gui/conversion/convertersetupdialog.cpp
@@ -1,0 +1,1241 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "convertersetupdialog.h"
+
+#include "convertersettingsstore.h"
+#include "dsp/dspsettingsregistry.h"
+#include "encoderprofiledialog.h"
+#include "encoderprofiletablemodel.h"
+#include "settings/playback/dspdelegate.h"
+#include "settings/playback/dspmodel.h"
+
+#include <core/engine/audioencoderregistry.h>
+#include <core/engine/conversion/conversionpathresolver.h>
+#include <core/engine/dsp/dspchainstore.h>
+#include <gui/guiconstants.h>
+#include <gui/iconloader.h>
+#include <gui/widgets/extendabletableview.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QAction>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QDoubleSpinBox>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QInputDialog>
+#include <QItemSelectionModel>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListView>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSaveFile>
+#include <QSpinBox>
+#include <QTabBar>
+#include <QTabWidget>
+#include <QTableView>
+#include <QUuid>
+#include <QVBoxLayout>
+
+#include <set>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+ConverterSetupDialog::ConverterSetupDialog(AudioEncoderRegistry* registry, DspChainStore* dspChainStore,
+                                           SettingsManager* settings, TrackList tracks, QWidget* parent,
+                                           DspSettingsRegistry* dspSettingsRegistry)
+    : QDialog{parent}
+    , m_registry{registry}
+    , m_dspChainStore{dspChainStore}
+    , m_dspSettingsRegistry{dspSettingsRegistry}
+    , m_settings{settings}
+    , m_tracks{std::move(tracks)}
+    , m_pages{new QTabWidget(this)}
+    , m_presetList{new QListWidget(this)}
+    , m_loadPreset{new QPushButton(tr("Load"), this)}
+    , m_savePreset{new QPushButton(tr("Save"), this)}
+    , m_removePreset{new QPushButton(tr("Remove"), this)}
+    , m_importPresets{new QPushButton(tr("Import"), this)}
+    , m_exportPreset{new QPushButton(tr("Export"), this)}
+    , m_profileTable{new ExtendableTableView(this)}
+    , m_profileModel{new EncoderProfileTableModel(&m_profiles, &m_runtimeEncoders, this)}
+    , m_editProfile{new QPushButton(tr("Edit"), this)}
+    , m_sampleFormat{new QComboBox(this)}
+    , m_dither{new QComboBox(this)}
+    , m_destinationMode{new QComboBox(this)}
+    , m_folder{new QLineEdit(this)}
+    , m_browse{new QPushButton(tr("Browse…"), this)}
+    , m_filenamePattern{new QLineEdit(u"%title%"_s, this)}
+    , m_existingFileMode{new QComboBox(this)}
+    , m_outputStyle{new QComboBox(this)}
+    , m_preview{new QListWidget(this)}
+    , m_transferMetadata{new QCheckBox(tr("Transfer metadata (tags)"), this)}
+    , m_transferRating{new QCheckBox(tr("Transfer rating"), this)}
+    , m_transferPlaycount{new QCheckBox(tr("Transfer play count"), this)}
+    , m_transferPictures{new QCheckBox(tr("Transfer attached pictures"), this)}
+    , m_replayGainMode{new QComboBox(this)}
+    , m_replayGainPreventClipping{new QCheckBox(tr("Prevent clipping"), this)}
+    , m_replayGainPreamp{new QDoubleSpinBox(this)}
+    , m_replayGainWithoutInfoPreamp{new QDoubleSpinBox(this)}
+    , m_preserveDspState{new QCheckBox(tr("Don't reset DSP between tracks"), this)}
+    , m_activeDsps{new QTableView(this)}
+    , m_availableDspList{new QListView(this)}
+    , m_activeDspModel{new DspModel(this)}
+    , m_availableDspModel{new DspModel(this)}
+    , m_activeDspDelegate{new DspDelegate(m_activeDsps, this)}
+    , m_availableDspDelegate{new DspDelegate(m_availableDspList, this, DspDelegate::Mode::Available)}
+    , m_generatePreview{new QCheckBox(tr("Generate short previews instead of converting entire tracks"), this)}
+    , m_previewPercentage{new QSpinBox(this)}
+    , m_showReport{new QCheckBox(tr("Show full status report"), this)}
+    , m_copyFilesPattern{new QLineEdit(this)}
+    , m_verifyOutput{new QCheckBox(tr("Verify converted output"), this)}
+    , m_outputSummary{new QLabel(this)}
+    , m_destinationSummary{new QLabel(this)}
+    , m_processingSummary{new QLabel(this)}
+    , m_otherSummary{new QLabel(this)}
+    , m_convert{nullptr}
+{
+    setWindowTitle(tr("Converter Setup"));
+    resize(900, 600);
+
+    auto* presetsSidebar = createPresetsSidebar();
+    m_pages->addTab(createOutputPage(), tr("Output"));
+    m_pages->addTab(createDestinationPage(), tr("Destination"));
+    m_pages->addTab(createProcessingPage(), tr("Processing"));
+    m_pages->addTab(createOtherPage(), tr("Other"));
+    m_pages->tabBar()->setExpanding(false);
+    m_pages->setCurrentIndex(0);
+
+    auto* contentLayout = new QHBoxLayout();
+    contentLayout->addWidget(m_pages, 1);
+    contentLayout->addWidget(presetsSidebar);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Cancel, this);
+    m_convert       = buttonBox->addButton(tr("Convert"), QDialogButtonBox::AcceptRole);
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &ConverterSetupDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addLayout(contentLayout, 1);
+    layout->addWidget(createSummaryBar());
+    layout->addWidget(buttonBox);
+
+    populateProfiles();
+    populatePresets();
+    applyDefaultPreset();
+}
+
+ConversionJob ConverterSetupDialog::job() const
+{
+    ConversionJob result;
+    result.tracks = m_tracks;
+
+    if(const AudioEncoderInfo* encoder = selectedEncoder()) {
+        result.preset.encoder.profile = encoder->profile;
+    }
+
+    result.preset.encoder.outputSampleFormat  = static_cast<SampleFormat>(m_sampleFormat->currentData().toInt());
+    result.preset.encoder.ditherMode          = static_cast<DitherMode>(m_dither->currentData().toInt());
+    result.preset.destination.mode            = destinationMode();
+    result.preset.destination.fixedFolder     = m_folder->text().trimmed();
+    result.preset.destination.filenamePattern = m_filenamePattern->text().trimmed();
+    result.preset.destination.existingFileMode
+        = static_cast<ExistingFileMode>(m_existingFileMode->currentData().toInt());
+    result.preset.destination.outputStyle      = static_cast<OutputStyle>(m_outputStyle->currentData().toInt());
+    result.preset.processing.transferMetadata  = m_transferMetadata->isChecked();
+    result.preset.processing.transferRating    = m_transferRating->isChecked();
+    result.preset.processing.transferPlaycount = m_transferPlaycount->isChecked();
+    result.preset.processing.transferPictures  = m_transferPictures->isChecked() && m_transferPictures->isEnabled();
+    result.preset.processing.replayGainMode
+        = static_cast<ConversionReplayGainMode>(m_replayGainMode->currentData().toInt());
+    result.preset.processing.replayGainPreventClipping     = m_replayGainPreventClipping->isChecked();
+    result.preset.processing.replayGainPreampDb            = m_replayGainPreamp->value();
+    result.preset.processing.replayGainWithoutInfoPreampDb = m_replayGainWithoutInfoPreamp->value();
+    result.preset.processing.dspChain                      = m_dspChain;
+    result.preset.processing.preserveDspStateBetweenTracks = m_preserveDspState->isChecked();
+    result.preset.preview.enabled                          = m_generatePreview->isChecked();
+    result.preset.preview.lengthPercentage                 = m_previewPercentage->value();
+    result.preset.other.copyFilesPattern                   = m_copyFilesPattern->text().trimmed();
+    result.preset.other.verifyOutput                       = m_verifyOutput->isChecked();
+
+    return result;
+}
+
+QString ConverterSetupDialog::askFolder() const
+{
+    return m_askFolder;
+}
+
+bool ConverterSetupDialog::showReport() const
+{
+    return m_showReport->isChecked();
+}
+
+void ConverterSetupDialog::accept()
+{
+    if(!selectedEncoder()) {
+        QMessageBox::warning(this, tr("Converter Setup"), tr("No output encoder is available."));
+        return;
+    }
+
+    if(destinationMode() == DestinationMode::Ask) {
+        m_askFolder = QFileDialog::getExistingDirectory(this, tr("Choose destination"), QDir::homePath(),
+                                                        QFileDialog::DontResolveSymlinks);
+        if(m_askFolder.isEmpty()) {
+            return;
+        }
+    }
+
+    QDialog::accept();
+}
+
+QWidget* ConverterSetupDialog::createPresetsSidebar()
+{
+    auto* page = new QWidget(this);
+    page->setFixedWidth(210);
+
+    auto* presetButtons = new QGridLayout();
+
+    int row{0};
+    presetButtons->addWidget(m_loadPreset, row, 0);
+    presetButtons->addWidget(m_savePreset, row++, 1);
+    presetButtons->addWidget(m_removePreset, row++, 0, 1, 2);
+    presetButtons->addWidget(m_importPresets, row, 0);
+    presetButtons->addWidget(m_exportPreset, row++, 1);
+
+    auto* presetsLayout = new QVBoxLayout(page);
+    presetsLayout->addWidget(new QLabel(tr("Saved presets"), page));
+    presetsLayout->addWidget(m_presetList, 1);
+    presetsLayout->addLayout(presetButtons);
+
+    QObject::connect(m_loadPreset, &QAbstractButton::clicked, this, &ConverterSetupDialog::loadPreset);
+    QObject::connect(m_savePreset, &QAbstractButton::clicked, this, &ConverterSetupDialog::savePreset);
+    QObject::connect(m_removePreset, &QAbstractButton::clicked, this, &ConverterSetupDialog::removePreset);
+    QObject::connect(m_importPresets, &QAbstractButton::clicked, this, &ConverterSetupDialog::importPresets);
+    QObject::connect(m_exportPreset, &QAbstractButton::clicked, this, &ConverterSetupDialog::exportPreset);
+    QObject::connect(m_presetList, &QListWidget::itemDoubleClicked, this, &ConverterSetupDialog::loadPreset);
+    QObject::connect(m_presetList, &QListWidget::currentRowChanged, this, [this](int currentRow) {
+        m_loadPreset->setEnabled(currentRow >= 0);
+        m_removePreset->setEnabled(currentRow > 0);
+        m_exportPreset->setEnabled(currentRow > 0);
+    });
+
+    return page;
+}
+
+QWidget* ConverterSetupDialog::createSummaryBar()
+{
+    auto* summaryBox = new QGroupBox(tr("Current settings"), this);
+    auto* grid       = new QGridLayout(summaryBox);
+
+    const auto addSummary = [grid, summaryBox](int row, int column, const QString& title, QLabel* value) {
+        auto* label = new QLabel(title + ":"_L1, summaryBox);
+        QFont font  = label->font();
+        font.setBold(true);
+        label->setFont(font);
+        value->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        grid->addWidget(label, row, column);
+        grid->addWidget(value, row, column + 1);
+    };
+
+    addSummary(0, 0, tr("Output"), m_outputSummary);
+    addSummary(0, 2, tr("Destination"), m_destinationSummary);
+    addSummary(1, 0, tr("Processing"), m_processingSummary);
+    addSummary(1, 2, tr("Other"), m_otherSummary);
+    grid->setColumnStretch(1, 1);
+    grid->setColumnStretch(3, 1);
+
+    return summaryBox;
+}
+
+QWidget* ConverterSetupDialog::createOutputPage()
+{
+    m_profileTable->setExtendableModel(m_profileModel);
+    m_profileTable->setExtendableColumn(0);
+    m_profileTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_profileTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_profileTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_profileTable->verticalHeader()->hide();
+    m_profileTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_profileTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_profileTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+
+    m_profileTable->addCustomTool(m_editProfile);
+
+    m_sampleFormat->addItem(tr("Auto"), static_cast<int>(SampleFormat::Unknown));
+    m_sampleFormat->addItem(tr("8-bit integer"), static_cast<int>(SampleFormat::U8));
+    m_sampleFormat->addItem(tr("16-bit integer"), static_cast<int>(SampleFormat::S16));
+    m_sampleFormat->addItem(tr("24-bit integer"), static_cast<int>(SampleFormat::S24In32));
+    m_sampleFormat->addItem(tr("32-bit integer"), static_cast<int>(SampleFormat::S32));
+    m_sampleFormat->addItem(tr("32-bit floating point"), static_cast<int>(SampleFormat::F32));
+
+    m_dither->addItem(tr("Never"), static_cast<int>(DitherMode::Never));
+    m_dither->addItem(tr("Lossy sources only"), static_cast<int>(DitherMode::LossySourceOnly));
+    m_dither->addItem(tr("Always"), static_cast<int>(DitherMode::Always));
+
+    auto* page    = new QWidget(this);
+    auto* options = new QGridLayout();
+
+    int row{0};
+    options->addWidget(new QLabel(tr("Output sample format") + ":"_L1, page), row, 0);
+    options->addWidget(m_sampleFormat, row++, 1);
+    options->addWidget(new QLabel(tr("Dither") + ":"_L1, page), row, 0);
+    options->addWidget(m_dither, row++, 1);
+    options->setColumnStretch(1, 1);
+
+    auto* layout = new QVBoxLayout(page);
+    layout->addWidget(m_profileTable, 1);
+    layout->addLayout(options);
+
+    QObject::connect(m_profileTable->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+                     &ConverterSetupDialog::updateState);
+    QObject::connect(m_profileTable, &QAbstractItemView::doubleClicked, this, &ConverterSetupDialog::editProfile);
+    QObject::connect(m_profileModel, &EncoderProfileTableModel::addProfileRequested, this,
+                     &ConverterSetupDialog::addProfile);
+    QObject::connect(m_profileModel, &EncoderProfileTableModel::profilesChanged, this,
+                     &ConverterSetupDialog::saveProfiles);
+    QObject::connect(m_profileModel, &EncoderProfileTableModel::profilesChanged, this,
+                     &ConverterSetupDialog::updateState);
+    QObject::connect(m_editProfile, &QAbstractButton::clicked, this, &ConverterSetupDialog::editProfile);
+    QObject::connect(m_sampleFormat, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_dither, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateOverview);
+
+    return page;
+}
+
+QWidget* ConverterSetupDialog::createDestinationPage()
+{
+    m_destinationMode->addItem(tr("Ask when conversion starts"), static_cast<int>(DestinationMode::Ask));
+    m_destinationMode->addItem(tr("Source track folder"), static_cast<int>(DestinationMode::SourceFolder));
+    m_destinationMode->addItem(tr("Specified folder"), static_cast<int>(DestinationMode::FixedFolder));
+    m_existingFileMode->addItem(tr("Ask"), static_cast<int>(ExistingFileMode::Ask));
+    m_existingFileMode->addItem(tr("Skip"), static_cast<int>(ExistingFileMode::Skip));
+    m_existingFileMode->addItem(tr("Overwrite"), static_cast<int>(ExistingFileMode::Overwrite));
+    m_outputStyle->addItem(tr("Convert each track to an individual file"),
+                           static_cast<int>(OutputStyle::IndividualFiles));
+    m_outputStyle->addItem(tr("Generate one multi-track file per name group"),
+                           static_cast<int>(OutputStyle::MultiTrackFiles));
+    m_outputStyle->addItem(tr("Merge all tracks into one output file"), static_cast<int>(OutputStyle::MergeTracks));
+
+    auto* folderLayout = new QHBoxLayout();
+    folderLayout->addWidget(m_folder, 1);
+    folderLayout->addWidget(m_browse);
+
+    auto* page = new QWidget(this);
+    auto* form = new QGridLayout();
+
+    int row{0};
+    form->addWidget(new QLabel(tr("Output path") + ":"_L1, page), row, 0);
+    form->addWidget(m_destinationMode, row++, 1);
+    form->addWidget(new QLabel(tr("Folder") + ":"_L1, page), row, 0);
+    form->addLayout(folderLayout, row++, 1);
+    form->addWidget(new QLabel(tr("Output style") + ":"_L1, page), row, 0);
+    form->addWidget(m_outputStyle, row++, 1);
+    form->addWidget(new QLabel(tr("Name format") + ":"_L1, page), row, 0);
+    form->addWidget(m_filenamePattern, row++, 1);
+    form->addWidget(new QLabel(tr("If file already exists") + ":"_L1, page), row, 0);
+    form->addWidget(m_existingFileMode, row++, 1);
+    form->setColumnStretch(1, 1);
+
+    auto* layout = new QVBoxLayout(page);
+    layout->addLayout(form);
+    layout->addWidget(new QLabel(tr("Preview") + ":"_L1, page));
+    layout->addWidget(m_preview, 1);
+
+    QObject::connect(m_browse, &QAbstractButton::clicked, this, &ConverterSetupDialog::browseForFolder);
+    QObject::connect(m_destinationMode, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_existingFileMode, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_outputStyle, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_folder, &QLineEdit::textChanged, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_filenamePattern, &QLineEdit::textChanged, this, &ConverterSetupDialog::updateState);
+    return page;
+}
+
+QWidget* ConverterSetupDialog::createProcessingPage()
+{
+    m_transferMetadata->setChecked(true);
+    m_transferRating->setChecked(true);
+    m_transferPlaycount->setChecked(false);
+    m_transferPictures->setChecked(true);
+    m_replayGainMode->addItem(tr("None"), static_cast<int>(ConversionReplayGainMode::None));
+    m_replayGainMode->addItem(tr("Track gain"), static_cast<int>(ConversionReplayGainMode::Track));
+    m_replayGainMode->addItem(tr("Album gain"), static_cast<int>(ConversionReplayGainMode::Album));
+    m_replayGainPreventClipping->setChecked(true);
+
+    for(QDoubleSpinBox* preamp : {m_replayGainPreamp, m_replayGainWithoutInfoPreamp}) {
+        preamp->setRange(-20.0, 20.0);
+        preamp->setDecimals(1);
+        preamp->setSingleStep(0.5);
+        preamp->setSuffix(tr(" dB"));
+    }
+
+    auto* replayGainBox  = new QGroupBox(tr("ReplayGain processing"), this);
+    auto* replayGainForm = new QGridLayout(replayGainBox);
+    int row{0};
+    replayGainForm->addWidget(new QLabel(tr("Mode") + ":"_L1, replayGainBox), row, 0);
+    replayGainForm->addWidget(m_replayGainMode, row++, 1);
+    replayGainForm->addWidget(m_replayGainPreventClipping, row++, 1);
+    replayGainForm->addWidget(new QLabel(tr("Preamp") + ":"_L1, replayGainBox), row, 0);
+    replayGainForm->addWidget(m_replayGainPreamp, row++, 1);
+    replayGainForm->addWidget(new QLabel(tr("Without ReplayGain info") + ":"_L1, replayGainBox), row, 0);
+    replayGainForm->addWidget(m_replayGainWithoutInfoPreamp, row++, 1);
+    auto* replayGainWarning
+        = new QLabel(tr("ReplayGain is applied permanently to the converted audio."), replayGainBox);
+    replayGainWarning->setWordWrap(true);
+    replayGainForm->addWidget(replayGainWarning, row++, 0, 1, 2);
+    replayGainForm->setColumnStretch(1, 1);
+
+    m_availableDspModel->setAllowInternalMoves(false);
+    m_availableDspModel->setCheckable(false);
+
+    m_activeDsps->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_activeDsps->setDragDropOverwriteMode(false);
+    m_activeDsps->horizontalHeader()->hide();
+    m_activeDsps->horizontalHeader()->setStretchLastSection(true);
+    m_activeDsps->setMouseTracking(true);
+    m_activeDsps->setModel(m_activeDspModel);
+    m_activeDsps->setItemDelegate(m_activeDspDelegate);
+
+    m_availableDspList->setMouseTracking(true);
+    m_availableDspList->setModel(m_availableDspModel);
+    m_availableDspList->setItemDelegate(m_availableDspDelegate);
+
+    const auto setupList = [](QAbstractItemView* list, bool acceptDrops) {
+        list->setSelectionMode(QAbstractItemView::SingleSelection);
+        list->setDragEnabled(true);
+        list->setAcceptDrops(acceptDrops);
+        list->setDropIndicatorShown(acceptDrops);
+        list->setDragDropMode(acceptDrops ? QAbstractItemView::DragDrop : QAbstractItemView::DragOnly);
+        list->setDefaultDropAction(acceptDrops ? Qt::MoveAction : Qt::CopyAction);
+    };
+    setupList(m_activeDsps, true);
+    setupList(m_availableDspList, false);
+
+    auto* dspBox       = new QGroupBox(tr("DSP chain"), this);
+    auto* activeLayout = new QVBoxLayout();
+    activeLayout->addWidget(new QLabel(tr("Active DSPs"), this));
+    activeLayout->addWidget(m_activeDsps);
+    auto* availableLayout = new QVBoxLayout();
+    availableLayout->addWidget(new QLabel(tr("Available DSPs"), this));
+    availableLayout->addWidget(m_availableDspList);
+    auto* dspListLayout = new QHBoxLayout();
+    dspListLayout->addLayout(activeLayout, 1);
+    dspListLayout->addLayout(availableLayout, 1);
+    auto* dspLayout = new QVBoxLayout(dspBox);
+    dspLayout->addLayout(dspListLayout, 1);
+    dspLayout->addWidget(m_preserveDspState);
+
+    auto* metadataBox    = new QGroupBox(tr("Metadata"), this);
+    auto* metadataLayout = new QVBoxLayout(metadataBox);
+    metadataLayout->addWidget(m_transferMetadata);
+    metadataLayout->addWidget(m_transferRating);
+    metadataLayout->addWidget(m_transferPlaycount);
+    metadataLayout->addWidget(m_transferPictures);
+
+    auto* page   = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+    layout->addWidget(replayGainBox);
+    layout->addWidget(dspBox, 1);
+    layout->addWidget(metadataBox);
+
+    QObject::connect(m_transferMetadata, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_transferRating, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_transferPlaycount, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_transferPictures, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_replayGainMode, &QComboBox::currentIndexChanged, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_replayGainPreventClipping, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_replayGainPreamp, &QDoubleSpinBox::valueChanged, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_replayGainWithoutInfoPreamp, &QDoubleSpinBox::valueChanged, this,
+                     &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_preserveDspState, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+
+    m_availableDsps = m_dspChainStore ? m_dspChainStore->availableDsps() : Engine::DspChain{};
+    for(auto& dsp : m_availableDsps) {
+        dsp.enabled    = true;
+        dsp.instanceId = 0;
+    }
+    std::ranges::sort(m_availableDsps,
+                      [](const auto& lhs, const auto& rhs) { return lhs.name.localeAwareCompare(rhs.name) < 0; });
+    refreshDspModels();
+
+    QObject::connect(m_activeDspDelegate, &DspDelegate::removeClicked, this, &ConverterSetupDialog::removeDsp);
+    QObject::connect(m_activeDspDelegate, &DspDelegate::configureClicked, this, &ConverterSetupDialog::configureDsp);
+    QObject::connect(m_availableDspDelegate, &DspDelegate::addClicked, this, &ConverterSetupDialog::addDsp);
+    QObject::connect(m_availableDspList, &QListView::doubleClicked, this, &ConverterSetupDialog::addDsp);
+    QObject::connect(m_activeDsps, &QTableView::doubleClicked, this, &ConverterSetupDialog::configureDsp);
+    QObject::connect(m_activeDspModel, &QAbstractItemModel::dataChanged, this, [this] { syncDspChainFromModel(); });
+    QObject::connect(m_activeDspModel, &QAbstractItemModel::rowsInserted, this, [this] { syncDspChainFromModel(); });
+    QObject::connect(m_activeDspModel, &QAbstractItemModel::rowsRemoved, this, [this] { syncDspChainFromModel(); });
+    QObject::connect(m_activeDspModel, &QAbstractItemModel::modelReset, this, [this] { syncDspChainFromModel(); });
+    return page;
+}
+
+QWidget* ConverterSetupDialog::createOtherPage()
+{
+    m_copyFilesPattern->setPlaceholderText(u"*.jpg; *.png"_s);
+    m_previewPercentage->setRange(1, 100);
+    m_previewPercentage->setValue(20);
+    m_previewPercentage->setSuffix(u" %"_s);
+    m_showReport->setChecked(true);
+
+    auto* previewBox    = new QGroupBox(tr("Preview generation"), this);
+    auto* previewLayout = new QGridLayout(previewBox);
+
+    int row{0};
+    previewLayout->addWidget(m_generatePreview, row++, 0, 1, 2);
+    previewLayout->addWidget(new QLabel(tr("Length") + ":"_L1, previewBox), row, 0);
+    previewLayout->addWidget(m_previewPercentage, row++, 1);
+    previewLayout->setColumnStretch(1, 1);
+
+    auto* whenDoneBox    = new QGroupBox(tr("When done"), this);
+    auto* whenDoneLayout = new QVBoxLayout(whenDoneBox);
+    whenDoneLayout->addWidget(m_showReport);
+    whenDoneLayout->addWidget(m_verifyOutput);
+
+    auto* copyFilesBox    = new QGroupBox(tr("Copy other files to the destination folder"), this);
+    auto* copyFilesLayout = new QVBoxLayout(copyFilesBox);
+    copyFilesLayout->addWidget(m_copyFilesPattern);
+
+    auto* page   = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+    layout->addWidget(previewBox);
+    layout->addWidget(whenDoneBox);
+    layout->addWidget(copyFilesBox);
+    layout->addStretch();
+
+    QObject::connect(m_generatePreview, &QCheckBox::toggled, this, &ConverterSetupDialog::updateState);
+    QObject::connect(m_previewPercentage, &QSpinBox::valueChanged, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_showReport, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_copyFilesPattern, &QLineEdit::textChanged, this, &ConverterSetupDialog::updateOverview);
+    QObject::connect(m_verifyOutput, &QCheckBox::toggled, this, &ConverterSetupDialog::updateOverview);
+
+    return page;
+}
+
+void ConverterSetupDialog::populateProfiles()
+{
+    m_runtimeEncoders = m_registry ? m_registry->availableEncoders() : std::vector<AudioEncoderInfo>{};
+    m_profiles.clear();
+
+    for(const AudioEncoderInfo& info : std::as_const(m_runtimeEncoders)) {
+        m_profiles.push_back({.info = info, .storageId = u"builtin:%1"_s.arg(info.id), .builtIn = true});
+    }
+
+    for(const StoredEncoderProfile& stored : ConverterSettings::encoderProfiles()) {
+        const auto runtime = std::ranges::find_if(
+            m_runtimeEncoders, [&stored](const AudioEncoderInfo& info) { return info.id == stored.baseEncoderId; });
+        if(runtime == m_runtimeEncoders.cend()) {
+            continue;
+        }
+
+        AudioEncoderInfo info{*runtime};
+        info.profile = ConverterSettings::applyStoredEncoderProfile(std::move(info.profile), stored);
+        info.name    = info.profile.name;
+        if(const QString description = EncoderProfileTableModel::profileDescription(info.profile);
+           !description.isEmpty()) {
+            info.description = description;
+        }
+
+        if(stored.overridesBuiltIn) {
+            const auto builtIn = std::ranges::find_if(m_profiles, [&stored](const EncoderProfileEntry& entry) {
+                return entry.info.id == stored.baseEncoderId;
+            });
+            if(builtIn != m_profiles.end()) {
+                builtIn->info      = std::move(info);
+                builtIn->storageId = stored.storageId;
+                builtIn->persisted = true;
+            }
+        }
+        else {
+            m_profiles.push_back(
+                {.info = std::move(info), .storageId = stored.storageId, .builtIn = false, .persisted = true});
+        }
+    }
+
+    refreshProfileTable(0);
+}
+
+void ConverterSetupDialog::refreshProfileTable(int selectedRow)
+{
+    if(selectedRow < 0) {
+        selectedRow = m_profileTable->currentIndex().row();
+    }
+
+    m_profileModel->resetProfiles();
+
+    if(!m_profiles.empty()) {
+        m_profileTable->selectRow(std::clamp(selectedRow, 0, static_cast<int>(m_profiles.size()) - 1));
+    }
+}
+
+void ConverterSetupDialog::addProfile()
+{
+    if(m_runtimeEncoders.empty()) {
+        return;
+    }
+
+    const AudioEncoderInfo initial = selectedEncoder() ? *selectedEncoder() : m_runtimeEncoders.front();
+    m_profileModel->insertPendingProfile(initial);
+
+    auto* dialog = new EncoderProfileDialog(m_runtimeEncoders, initial, true, this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+    QObject::connect(dialog, &QDialog::finished, this, [this, dialog](int result) {
+        if(result == QDialog::Accepted) {
+            m_profileModel->commitPendingProfile(dialog->encoderInfo());
+        }
+        else {
+            m_profileModel->removePendingRow();
+        }
+    });
+
+    dialog->open();
+}
+
+void ConverterSetupDialog::editProfile()
+{
+    const int row = m_profileTable->currentIndex().row();
+    if(row < 0 || std::cmp_greater_equal(row, m_profiles.size())) {
+        return;
+    }
+
+    auto* dialog = new EncoderProfileDialog(m_runtimeEncoders, m_profiles.at(row).info, false, this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+    QObject::connect(dialog, &QDialog::accepted, this, [this, dialog, row]() {
+        if(row < 0 || std::cmp_greater_equal(row, m_profiles.size())) {
+            return;
+        }
+
+        EncoderProfileEntry& entry = m_profiles[row];
+        entry.info                 = dialog->encoderInfo();
+
+        if(const QString description = EncoderProfileTableModel::profileDescription(entry.info.profile);
+           !description.isEmpty()) {
+            entry.info.description = description;
+        }
+
+        entry.persisted = true;
+        saveProfiles();
+        m_profileModel->refreshRow(row);
+        updateState();
+    });
+
+    dialog->open();
+}
+
+void ConverterSetupDialog::saveProfiles() const
+{
+    std::vector<StoredEncoderProfile> storedProfiles;
+    for(const EncoderProfileEntry& entry : m_profiles) {
+        if(entry.persisted) {
+            storedProfiles.emplace_back(entry.storageId, entry.info.id, entry.info.profile, entry.builtIn);
+        }
+    }
+    ConverterSettings::setEncoderProfiles(storedProfiles);
+}
+
+void ConverterSetupDialog::refreshDspModels()
+{
+    const auto resolveSettingsSupport = [this](Engine::DspChain& dsps) {
+        for(auto& dsp : dsps) {
+            dsp.hasSettings = m_dspSettingsRegistry && m_dspSettingsRegistry->hasProvider(dsp.id);
+        }
+    };
+
+    resolveSettingsSupport(m_dspChain);
+    resolveSettingsSupport(m_availableDsps);
+
+    m_activeDspModel->setup(m_dspChain);
+    m_availableDspModel->setup(m_availableDsps);
+}
+
+void ConverterSetupDialog::addDsp(const QModelIndex& index)
+{
+    if(!index.isValid()) {
+        return;
+    }
+
+    auto dsp = index.data(DspModel::Dsp).value<Engine::DspDefinition>();
+    if(dsp.id.isEmpty()) {
+        return;
+    }
+
+    dsp.enabled = true;
+    auto dsps   = m_activeDspModel->dsps();
+    dsps.push_back(std::move(dsp));
+    m_activeDspModel->setup(dsps);
+}
+
+void ConverterSetupDialog::configureDsp(const QModelIndex& index)
+{
+    if(!index.isValid()) {
+        return;
+    }
+
+    auto dsps = m_activeDspModel->dsps();
+    if(index.row() < 0 || std::cmp_greater_equal(index.row(), dsps.size())) {
+        return;
+    }
+
+    auto& dsp      = dsps[static_cast<size_t>(index.row())];
+    auto* provider = m_dspSettingsRegistry->providerFor(dsp.id);
+    if(!provider) {
+        QMessageBox::information(this, tr("DSP Settings"), tr("This DSP has no configurable settings."));
+        return;
+    }
+
+    auto settingsDialog = std::unique_ptr<DspSettingsDialog>{provider->createSettingsWidget(this)};
+    if(!settingsDialog) {
+        QMessageBox::warning(this, tr("DSP Settings"),
+                             tr("Unable to open settings for DSP \"%1\".").arg(dsp.name.isEmpty() ? dsp.id : dsp.name));
+        return;
+    }
+
+    settingsDialog->setWindowTitle(dsp.name.isEmpty() ? dsp.id : dsp.name);
+    settingsDialog->loadSettings(dsp.settings);
+    if(settingsDialog->exec() != QDialog::Accepted) {
+        return;
+    }
+
+    dsp.settings = settingsDialog->saveSettings();
+    m_activeDspModel->setup(dsps);
+}
+
+void ConverterSetupDialog::removeDsp(const QModelIndex& index)
+{
+    if(!index.isValid()) {
+        return;
+    }
+    m_activeDspModel->removeRow(index.row());
+}
+
+void ConverterSetupDialog::syncDspChainFromModel()
+{
+    auto dsps = m_activeDspModel->dsps();
+    uint64_t nextInstanceId{1};
+    for(const auto& dsp : dsps) {
+        nextInstanceId = std::max(nextInstanceId, dsp.instanceId + 1);
+    }
+
+    std::set<uint64_t> instanceIds;
+    bool normalised{false};
+    for(auto& dsp : dsps) {
+        if(dsp.instanceId == 0 || instanceIds.contains(dsp.instanceId)) {
+            dsp.instanceId = nextInstanceId++;
+            normalised     = true;
+        }
+        instanceIds.emplace(dsp.instanceId);
+    }
+
+    m_dspChain = dsps;
+    if(normalised) {
+        m_activeDspModel->setup(dsps);
+        return;
+    }
+
+    updateOverview();
+}
+
+void ConverterSetupDialog::populatePresets()
+{
+    m_presets = ConverterSettings::conversionPresets();
+    m_presetList->clear();
+    m_presetList->addItem(tr("Default settings"));
+    for(const StoredConversionPreset& stored : m_presets) {
+        m_presetList->addItem(stored.name);
+    }
+    m_presetList->setCurrentRow(0);
+}
+
+void ConverterSetupDialog::loadPreset()
+{
+    const int row = m_presetList->currentRow();
+    if(row < 0) {
+        return;
+    }
+    if(row == 0) {
+        applyDefaultPreset();
+    }
+    else if(static_cast<size_t>(row - 1) < m_presets.size()) {
+        applyPreset(m_presets.at(static_cast<size_t>(row - 1)));
+    }
+}
+
+void ConverterSetupDialog::savePreset()
+{
+    QString initialName;
+    if(m_presetList->currentRow() > 0) {
+        initialName = m_presetList->currentItem()->text();
+    }
+
+    bool accepted{false};
+    const QString name = QInputDialog::getText(this, tr("Save Converter Preset"), tr("Name") + ":"_L1,
+                                               QLineEdit::Normal, initialName, &accepted)
+                             .trimmed();
+    if(!accepted || name.isEmpty()) {
+        return;
+    }
+
+    StoredConversionPreset stored;
+    QString presetId;
+
+    auto existing = std::ranges::find(m_presets, name, &StoredConversionPreset::name);
+    if(existing != m_presets.end()) {
+        stored   = *existing;
+        presetId = existing->preset.id;
+    }
+    else {
+        presetId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    }
+
+    stored.name        = name;
+    stored.preset      = job().preset;
+    stored.preset.id   = presetId;
+    stored.preset.name = name;
+    stored.showReport  = m_showReport->isChecked();
+
+    if(existing != m_presets.end()) {
+        *existing = std::move(stored);
+    }
+    else {
+        m_presets.push_back(std::move(stored));
+    }
+
+    savePresets();
+    populatePresets();
+
+    for(int row{1}; row < m_presetList->count(); ++row) {
+        if(m_presetList->item(row)->text() == name) {
+            m_presetList->setCurrentRow(row);
+            break;
+        }
+    }
+}
+
+void ConverterSetupDialog::removePreset()
+{
+    const int row = m_presetList->currentRow();
+    if(row <= 0 || static_cast<size_t>(row - 1) >= m_presets.size()) {
+        return;
+    }
+
+    m_presets.erase(m_presets.begin() + (row - 1));
+    savePresets();
+    populatePresets();
+}
+
+void ConverterSetupDialog::importPresets()
+{
+    const QString path = QFileDialog::getOpenFileName(this, tr("Import Converter Presets"), {},
+                                                      tr("fooyin Converter Presets (*.fycp)"), nullptr,
+                                                      QFileDialog::DontResolveSymlinks);
+    if(path.isEmpty()) {
+        return;
+    }
+
+    QFile file{path};
+    if(!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this, tr("Import Converter Presets"), tr("The preset file could not be opened."));
+        return;
+    }
+
+    auto imported = ConverterSettings::deserialiseConversionPresets(file.readAll());
+    if(imported.empty()) {
+        QMessageBox::warning(this, tr("Import Converter Presets"), tr("The preset file is invalid or empty."));
+        return;
+    }
+
+    for(const StoredConversionPreset& stored : imported) {
+        const bool encoderAvailable = std::ranges::any_of(m_runtimeEncoders, [&stored](const AudioEncoderInfo& info) {
+            return info.id == stored.preset.encoder.profile.id;
+        });
+        if(!encoderAvailable) {
+            QMessageBox::warning(this, tr("Import Converter Presets"),
+                                 tr("Encoder is unavailable for preset: %1").arg(stored.name));
+            return;
+        }
+    }
+
+    QString selectedId;
+
+    for(StoredConversionPreset& stored : imported) {
+        if(stored.preset.id.isEmpty()) {
+            stored.preset.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        }
+
+        stored.preset.name = stored.name;
+        selectedId         = stored.preset.id;
+
+        auto existing = std::ranges::find_if(m_presets, [&stored](const StoredConversionPreset& candidate) {
+            return candidate.preset.id == stored.preset.id || candidate.name == stored.name;
+        });
+        if(existing != m_presets.end()) {
+            *existing = std::move(stored);
+        }
+        else {
+            m_presets.push_back(std::move(stored));
+        }
+    }
+
+    savePresets();
+    populatePresets();
+
+    for(int row{1}; row < m_presetList->count(); ++row) {
+        if(m_presets.at(row - 1).preset.id == selectedId) {
+            m_presetList->setCurrentRow(row);
+            break;
+        }
+    }
+}
+
+void ConverterSetupDialog::exportPreset()
+{
+    const int row = m_presetList->currentRow();
+    if(row <= 0 || std::cmp_greater_equal(row - 1, m_presets.size())) {
+        return;
+    }
+
+    const StoredConversionPreset& preset = m_presets.at(static_cast<size_t>(row - 1));
+    const QString suggested              = QDir::home().filePath(preset.name + u".fycp"_s);
+    const QString path = QFileDialog::getSaveFileName(this, tr("Export Converter Preset"), suggested,
+                                                      tr("fooyin Converter Presets (*.fycp)"), nullptr,
+                                                      QFileDialog::DontResolveSymlinks);
+    if(path.isEmpty()) {
+        return;
+    }
+
+    QSaveFile file{path};
+    const QByteArray presetData = ConverterSettings::serialiseConversionPresets({preset});
+    if(!file.open(QIODevice::WriteOnly) || file.write(presetData) != presetData.size() || !file.commit()) {
+        QMessageBox::warning(this, tr("Export Converter Preset"), tr("The preset file could not be written."));
+    }
+}
+
+void ConverterSetupDialog::applyPreset(const StoredConversionPreset& stored)
+{
+    const EncoderProfile& profile = stored.preset.encoder.profile;
+
+    int profileRow{-1};
+    for(int row{0}; row < m_profiles.size(); ++row) {
+        const EncoderProfile& candidate = m_profiles.at(row).info.profile;
+        if(candidate.id == profile.id && candidate.name == profile.name && candidate.mode == profile.mode
+           && candidate.bitrateKbps == profile.bitrateKbps && candidate.quality == profile.quality
+           && candidate.compressionLevel == profile.compressionLevel) {
+            profileRow = row;
+            break;
+        }
+    }
+
+    if(profileRow < 0) {
+        const auto runtime = std::ranges::find_if(
+            m_runtimeEncoders, [&profile](const AudioEncoderInfo& info) { return info.id == profile.id; });
+        if(runtime != m_runtimeEncoders.end()) {
+            AudioEncoderInfo info         = *runtime;
+            info.name                     = profile.name;
+            info.profile.name             = profile.name;
+            info.profile.mode             = profile.mode;
+            info.profile.bitrateKbps      = profile.bitrateKbps;
+            info.profile.quality          = profile.quality;
+            info.profile.compressionLevel = profile.compressionLevel;
+
+            if(const QString description = EncoderProfileTableModel::profileDescription(info.profile);
+               !description.isEmpty()) {
+                info.description = description;
+            }
+
+            m_profiles.emplace_back(std::move(info), QString{}, false, false);
+            profileRow = static_cast<int>(m_profiles.size()) - 1;
+            refreshProfileTable(profileRow);
+        }
+    }
+    else {
+        m_profileTable->selectRow(profileRow);
+    }
+
+    const auto setComboValue = [](QComboBox* combo, int value) {
+        const int index = combo->findData(value);
+        if(index >= 0) {
+            combo->setCurrentIndex(index);
+        }
+    };
+
+    setComboValue(m_sampleFormat, static_cast<int>(stored.preset.encoder.outputSampleFormat));
+    setComboValue(m_dither, static_cast<int>(stored.preset.encoder.ditherMode));
+    setComboValue(m_destinationMode, static_cast<int>(stored.preset.destination.mode));
+    setComboValue(m_existingFileMode, static_cast<int>(stored.preset.destination.existingFileMode));
+    setComboValue(m_outputStyle, static_cast<int>(stored.preset.destination.outputStyle));
+    setComboValue(m_replayGainMode, static_cast<int>(stored.preset.processing.replayGainMode));
+
+    m_folder->setText(stored.preset.destination.fixedFolder);
+    m_filenamePattern->setText(stored.preset.destination.filenamePattern);
+    m_transferMetadata->setChecked(stored.preset.processing.transferMetadata);
+    m_transferRating->setChecked(stored.preset.processing.transferRating);
+    m_transferPlaycount->setChecked(stored.preset.processing.transferPlaycount);
+    m_transferPictures->setChecked(stored.preset.processing.transferPictures);
+    m_replayGainPreventClipping->setChecked(stored.preset.processing.replayGainPreventClipping);
+    m_replayGainPreamp->setValue(stored.preset.processing.replayGainPreampDb);
+    m_replayGainWithoutInfoPreamp->setValue(stored.preset.processing.replayGainWithoutInfoPreampDb);
+    m_dspChain = stored.preset.processing.dspChain;
+    m_preserveDspState->setChecked(stored.preset.processing.preserveDspStateBetweenTracks);
+    refreshDspModels();
+    m_generatePreview->setChecked(stored.preset.preview.enabled);
+    m_previewPercentage->setValue(stored.preset.preview.lengthPercentage);
+    m_copyFilesPattern->setText(stored.preset.other.copyFilesPattern);
+    m_verifyOutput->setChecked(stored.preset.other.verifyOutput);
+    m_showReport->setChecked(stored.showReport);
+
+    updateState();
+}
+
+void ConverterSetupDialog::applyDefaultPreset()
+{
+    const auto defaultProfile = std::ranges::find_if(m_profiles, [](const EncoderProfileEntry& entry) {
+        return entry.info.id == QLatin1StringView{ConverterSettings::DefaultEncoderProfileId};
+    });
+    if(defaultProfile != m_profiles.cend()) {
+        m_profileTable->selectRow(static_cast<int>(std::ranges::distance(m_profiles.cbegin(), defaultProfile)));
+    }
+    else {
+        m_profileTable->setCurrentIndex({});
+    }
+
+    m_sampleFormat->setCurrentIndex(m_sampleFormat->findData(static_cast<int>(SampleFormat::Unknown)));
+    m_dither->setCurrentIndex(m_dither->findData(static_cast<int>(DitherMode::Never)));
+    m_destinationMode->setCurrentIndex(m_destinationMode->findData(static_cast<int>(DestinationMode::Ask)));
+    m_existingFileMode->setCurrentIndex(m_existingFileMode->findData(static_cast<int>(ExistingFileMode::Ask)));
+    m_outputStyle->setCurrentIndex(m_outputStyle->findData(static_cast<int>(OutputStyle::IndividualFiles)));
+    m_folder->clear();
+    m_filenamePattern->setText(u"%title%"_s);
+    m_transferMetadata->setChecked(true);
+    m_transferRating->setChecked(true);
+    m_transferPlaycount->setChecked(false);
+    m_transferPictures->setChecked(true);
+    m_replayGainMode->setCurrentIndex(m_replayGainMode->findData(static_cast<int>(ConversionReplayGainMode::None)));
+    m_replayGainPreventClipping->setChecked(true);
+    m_replayGainPreamp->setValue(0.0);
+    m_replayGainWithoutInfoPreamp->setValue(0.0);
+    m_preserveDspState->setChecked(false);
+    m_dspChain.clear();
+    refreshDspModels();
+    m_generatePreview->setChecked(false);
+    m_previewPercentage->setValue(20);
+    m_copyFilesPattern->clear();
+    m_verifyOutput->setChecked(false);
+    m_showReport->setChecked(true);
+    updateState();
+}
+
+void ConverterSetupDialog::savePresets() const
+{
+    ConverterSettings::setConversionPresets(m_presets);
+}
+
+void ConverterSetupDialog::browseForFolder()
+{
+    const QString start  = m_folder->text().isEmpty() ? QDir::homePath() : m_folder->text();
+    const QString folder = QFileDialog::getExistingDirectory(this, tr("Choose destination"), start);
+    if(!folder.isEmpty()) {
+        m_folder->setText(folder);
+    }
+}
+
+void ConverterSetupDialog::updateState()
+{
+    const bool fixedFolder = destinationMode() == DestinationMode::FixedFolder;
+    m_folder->setEnabled(fixedFolder);
+    m_browse->setEnabled(fixedFolder);
+
+    const AudioEncoderInfo* encoder = selectedEncoder();
+
+    const bool individualOutput
+        = static_cast<OutputStyle>(m_outputStyle->currentData().toInt()) == OutputStyle::IndividualFiles;
+    m_transferRating->setEnabled(individualOutput);
+    m_transferPlaycount->setEnabled(individualOutput);
+
+    const bool supportsPictures = encoder && encoder->supportsPictures;
+    m_transferPictures->setEnabled(supportsPictures);
+
+    const bool applyReplayGain = static_cast<ConversionReplayGainMode>(m_replayGainMode->currentData().toInt())
+                              != ConversionReplayGainMode::None;
+    m_replayGainPreventClipping->setEnabled(applyReplayGain);
+    m_replayGainPreamp->setEnabled(applyReplayGain);
+    m_replayGainWithoutInfoPreamp->setEnabled(applyReplayGain);
+
+    m_previewPercentage->setEnabled(m_generatePreview->isChecked());
+    m_editProfile->setEnabled(encoder);
+    m_profileTable->addRowAction()->setEnabled(!m_runtimeEncoders.empty());
+
+    const int profileRow       = m_profileTable->currentIndex().row();
+    const bool validProfileRow = profileRow >= 0 && std::cmp_less(profileRow, m_profiles.size());
+    const bool selectedBuiltIn = validProfileRow && m_profiles.at(profileRow).builtIn;
+    const bool canResetBuiltIn = selectedBuiltIn && m_profiles.at(profileRow).persisted;
+    m_profileTable->removeRowAction()->setText(selectedBuiltIn ? tr("Reset") : tr("Remove"));
+    m_profileTable->removeRowAction()->setEnabled(validProfileRow && (!selectedBuiltIn || canResetBuiltIn));
+
+    const bool validDestination = !fixedFolder || !m_folder->text().trimmed().isEmpty();
+    m_convert->setEnabled(encoder && validDestination && !m_filenamePattern->text().trimmed().isEmpty()
+                          && !m_tracks.empty());
+
+    updatePreview();
+    updateOverview();
+}
+
+void ConverterSetupDialog::updatePreview()
+{
+    m_preview->clear();
+
+    const AudioEncoderInfo* encoder = selectedEncoder();
+    if(!encoder) {
+        return;
+    }
+
+    ConversionPathResolver::Request request;
+    request.tracks                       = m_tracks;
+    request.extension                    = encoder->profile.extension;
+    request.destination.mode             = destinationMode();
+    request.destination.fixedFolder      = m_folder->text().trimmed();
+    request.destination.filenamePattern  = m_filenamePattern->text().trimmed();
+    request.destination.existingFileMode = ExistingFileMode::Overwrite;
+    request.destination.outputStyle      = static_cast<OutputStyle>(m_outputStyle->currentData().toInt());
+    request.askFolder                    = QDir::homePath();
+
+    const auto paths   = Fooyin::ConversionPathResolver::resolve(request);
+    const size_t count = std::min<size_t>(paths.size(), 20);
+    for(size_t i{0}; i < count; ++i) {
+        const QString filename = QFileInfo{paths.at(i).outputPath}.fileName();
+        m_preview->addItem(filename.isEmpty() ? paths.at(i).error : filename);
+    }
+}
+
+void ConverterSetupDialog::updateOverview()
+{
+    const AudioEncoderInfo* encoder = selectedEncoder();
+
+    m_outputSummary->setText(
+        encoder ? encoder->name + (encoder->description.isEmpty() ? QString{} : u", "_s + encoder->description)
+                : tr("No encoder available"));
+
+    QStringList destinationParts;
+
+    switch(destinationMode()) {
+        case DestinationMode::Ask:
+            destinationParts.push_back(tr("Ask when conversion starts"));
+            break;
+        case DestinationMode::SourceFolder:
+            destinationParts.push_back(tr("Source track folder"));
+            break;
+        case DestinationMode::FixedFolder: {
+            const QString folder = m_folder->text().trimmed();
+            destinationParts.push_back(folder.isEmpty() ? tr("No folder specified") : folder);
+            break;
+        }
+    }
+    switch(static_cast<OutputStyle>(m_outputStyle->currentData().toInt())) {
+        case OutputStyle::IndividualFiles:
+            break;
+        case OutputStyle::MultiTrackFiles:
+            destinationParts.push_back(tr("group tracks by output name"));
+            break;
+        case OutputStyle::MergeTracks:
+            destinationParts.push_back(tr("merge tracks"));
+            break;
+    }
+    const QString filenamePattern = m_filenamePattern->text().trimmed();
+    destinationParts.push_back(filenamePattern.isEmpty() ? tr("No name format") : filenamePattern);
+
+    m_destinationSummary->setText(destinationParts.join(u", "_s));
+
+    QStringList processing;
+
+    if(m_transferMetadata->isChecked()) {
+        processing.push_back(tr("metadata"));
+    }
+    if(m_transferRating->isChecked() && m_transferRating->isEnabled()) {
+        processing.push_back(tr("rating"));
+    }
+    if(m_transferPlaycount->isChecked() && m_transferPlaycount->isEnabled()) {
+        processing.push_back(tr("play count"));
+    }
+    if(m_transferPictures->isChecked() && m_transferPictures->isEnabled()) {
+        processing.push_back(tr("attached pictures"));
+    }
+
+    switch(static_cast<ConversionReplayGainMode>(m_replayGainMode->currentData().toInt())) {
+        case ConversionReplayGainMode::Track:
+            processing.push_back(tr("ReplayGain (track)"));
+            break;
+        case ConversionReplayGainMode::Album:
+            processing.push_back(tr("ReplayGain (album)"));
+            break;
+        case ConversionReplayGainMode::None:
+            break;
+    }
+
+    if(!m_dspChain.empty()) {
+        processing.push_back(tr("%Ln DSP(s)", nullptr, static_cast<int>(m_dspChain.size())));
+        if(m_preserveDspState->isChecked()) {
+            processing.push_back(tr("continuous DSP"));
+        }
+    }
+
+    m_processingSummary->setText(processing.isEmpty() ? tr("None") : processing.join(u", "_s));
+
+    QStringList other;
+
+    if(m_generatePreview->isChecked()) {
+        other.push_back(tr("%1% previews").arg(m_previewPercentage->value()));
+    }
+    if(m_showReport->isChecked()) {
+        other.push_back(tr("Show status report"));
+    }
+    if(!m_copyFilesPattern->text().trimmed().isEmpty()) {
+        other.push_back(tr("Copy matching files"));
+    }
+    if(m_verifyOutput->isChecked()) {
+        other.push_back(tr("Verify output"));
+    }
+
+    m_otherSummary->setText(other.isEmpty() ? tr("None") : other.join(u", "_s));
+}
+
+const AudioEncoderInfo* ConverterSetupDialog::selectedEncoder() const
+{
+    const int row = m_profileTable->currentIndex().row();
+    return row >= 0 && std::cmp_less(row, m_profiles.size()) ? &m_profiles.at(row).info : nullptr;
+}
+
+DestinationMode ConverterSetupDialog::destinationMode() const
+{
+    return static_cast<DestinationMode>(m_destinationMode->currentData().toInt());
+}
+} // namespace Fooyin
+
+#include "moc_convertersetupdialog.cpp"

--- a/src/gui/conversion/convertersetupdialog.h
+++ b/src/gui/conversion/convertersetupdialog.h
@@ -1,0 +1,160 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "convertersettingsstore.h"
+#include "encoderprofiletablemodel.h"
+
+#include <core/engine/audioencoder.h>
+#include <core/engine/conversion/conversiondefs.h>
+
+#include <QDialog>
+
+class QCheckBox;
+class QComboBox;
+class QDoubleSpinBox;
+class QLabel;
+class QLineEdit;
+class QListView;
+class QListWidget;
+class QModelIndex;
+class QPushButton;
+class QSpinBox;
+class QTabWidget;
+class QTableView;
+
+namespace Fooyin {
+class AudioEncoderRegistry;
+class DspChainStore;
+class DspSettingsRegistry;
+class DspDelegate;
+class DspModel;
+class ExtendableTableView;
+class SettingsManager;
+
+class ConverterSetupDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    ConverterSetupDialog(AudioEncoderRegistry* registry, DspChainStore* dspChainStore, SettingsManager* settings,
+                         TrackList tracks, QWidget* parent = nullptr,
+                         DspSettingsRegistry* dspSettingsRegistry = nullptr);
+
+    [[nodiscard]] ConversionJob job() const;
+    [[nodiscard]] QString askFolder() const;
+    [[nodiscard]] bool showReport() const;
+
+    void accept() override;
+
+private:
+    QWidget* createPresetsSidebar();
+    QWidget* createSummaryBar();
+    QWidget* createOutputPage();
+    QWidget* createDestinationPage();
+    QWidget* createProcessingPage();
+    QWidget* createOtherPage();
+
+    void populateProfiles();
+    void refreshProfileTable(int selectedRow = -1);
+    void addProfile();
+    void editProfile();
+    void saveProfiles() const;
+    void refreshDspModels();
+    void addDsp(const QModelIndex& index);
+    void configureDsp(const QModelIndex& index);
+    void removeDsp(const QModelIndex& index);
+    void syncDspChainFromModel();
+    void populatePresets();
+    void loadPreset();
+    void savePreset();
+    void removePreset();
+    void importPresets();
+    void exportPreset();
+    void applyPreset(const StoredConversionPreset& stored);
+    void applyDefaultPreset();
+    void savePresets() const;
+    void browseForFolder();
+    void updateState();
+    void updatePreview();
+    void updateOverview();
+
+    [[nodiscard]] const AudioEncoderInfo* selectedEncoder() const;
+    [[nodiscard]] DestinationMode destinationMode() const;
+
+    AudioEncoderRegistry* m_registry;
+    DspChainStore* m_dspChainStore;
+    DspSettingsRegistry* m_dspSettingsRegistry;
+    SettingsManager* m_settings;
+    TrackList m_tracks;
+    std::vector<AudioEncoderInfo> m_runtimeEncoders;
+
+    QList<EncoderProfileEntry> m_profiles;
+    Engine::DspChain m_availableDsps;
+    Engine::DspChain m_dspChain;
+    std::vector<StoredConversionPreset> m_presets;
+    QString m_askFolder;
+
+    QTabWidget* m_pages;
+    QListWidget* m_presetList;
+    QPushButton* m_loadPreset;
+    QPushButton* m_savePreset;
+    QPushButton* m_removePreset;
+    QPushButton* m_importPresets;
+    QPushButton* m_exportPreset;
+    ExtendableTableView* m_profileTable;
+    EncoderProfileTableModel* m_profileModel;
+    QPushButton* m_editProfile;
+    QComboBox* m_sampleFormat;
+    QComboBox* m_dither;
+    QComboBox* m_destinationMode;
+    QLineEdit* m_folder;
+    QPushButton* m_browse;
+    QLineEdit* m_filenamePattern;
+    QComboBox* m_existingFileMode;
+    QComboBox* m_outputStyle;
+    QListWidget* m_preview;
+    QCheckBox* m_transferMetadata;
+    QCheckBox* m_transferRating;
+    QCheckBox* m_transferPlaycount;
+    QCheckBox* m_transferPictures;
+    QComboBox* m_replayGainMode;
+    QCheckBox* m_replayGainPreventClipping;
+    QDoubleSpinBox* m_replayGainPreamp;
+    QDoubleSpinBox* m_replayGainWithoutInfoPreamp;
+    QCheckBox* m_preserveDspState;
+    QTableView* m_activeDsps;
+    QListView* m_availableDspList;
+    DspModel* m_activeDspModel;
+    DspModel* m_availableDspModel;
+    DspDelegate* m_activeDspDelegate;
+    DspDelegate* m_availableDspDelegate;
+    QCheckBox* m_generatePreview;
+    QSpinBox* m_previewPercentage;
+    QCheckBox* m_showReport;
+    QLineEdit* m_copyFilesPattern;
+    QCheckBox* m_verifyOutput;
+    QLabel* m_outputSummary;
+    QLabel* m_destinationSummary;
+    QLabel* m_processingSummary;
+    QLabel* m_otherSummary;
+    QPushButton* m_convert;
+};
+} // namespace Fooyin

--- a/src/gui/conversion/encoderprofiledialog.cpp
+++ b/src/gui/conversion/encoderprofiledialog.cpp
@@ -1,0 +1,276 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "encoderprofiledialog.h"
+
+#include <gui/widgets/doubleslidereditor.h>
+#include <gui/widgets/slidereditor.h>
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+QString modeName(EncoderMode mode)
+{
+    switch(mode) {
+        case EncoderMode::Default:
+            return EncoderProfileDialog::tr("Default");
+        case EncoderMode::VariableBitrate:
+            return EncoderProfileDialog::tr("Variable bitrate (VBR)");
+        case EncoderMode::ConstrainedVariableBitrate:
+            return EncoderProfileDialog::tr("Constrained variable bitrate");
+        case EncoderMode::ConstantQuality:
+            return EncoderProfileDialog::tr("Constant quality (VBR)");
+        case EncoderMode::AverageBitrate:
+            return EncoderProfileDialog::tr("Average bitrate (ABR)");
+        case EncoderMode::ConstantBitrate:
+            return EncoderProfileDialog::tr("Constant bitrate (CBR)");
+        case EncoderMode::LosslessCompression:
+            return EncoderProfileDialog::tr("Lossless compression");
+    }
+    return {};
+}
+} // namespace
+
+EncoderProfileDialog::EncoderProfileDialog(std::vector<AudioEncoderInfo> availableEncoders,
+                                           const AudioEncoderInfo& initial, bool allowEncoderChange, QWidget* parent)
+    : QDialog{parent}
+    , m_availableEncoders{std::move(availableEncoders)}
+    , m_encoder{new QComboBox(this)}
+    , m_name{new QLineEdit(this)}
+    , m_options{new QGroupBox(tr("Options"), this)}
+    , m_optionsLayout{new QGridLayout(m_options)}
+    , m_modeLabel{new QLabel(tr("Mode") + ":"_L1, m_options)}
+    , m_qualityLabel{new QLabel(tr("Quality") + ":"_L1, m_options)}
+    , m_bitrateEstimateLabel{new QLabel(tr("Estimated bitrate") + ":"_L1, m_options)}
+    , m_bitrateEstimate{new QLabel(m_options)}
+    , m_bitrateLabel{new QLabel(tr("Bitrate") + ":"_L1, m_options)}
+    , m_levelLabel{new QLabel(tr("Level") + ":"_L1, m_options)}
+    , m_mode{new QComboBox(this)}
+    , m_quality{new DoubleSliderEditor(this)}
+    , m_bitrate{new SliderEditor(this)}
+    , m_level{new SliderEditor(this)}
+    , m_okButton{nullptr}
+{
+    setWindowTitle(tr("Encoder Profile"));
+    setModal(true);
+    resize(520, 300);
+
+    for(const AudioEncoderInfo& encoder : std::as_const(m_availableEncoders)) {
+        m_encoder->addItem(encoder.name);
+    }
+    m_encoder->setEnabled(allowEncoderChange);
+
+    m_bitrate->setSuffix(u" kbps"_s);
+    m_quality->setTicksVisible(true);
+    m_bitrate->setTicksVisible(true);
+    m_level->setTicksVisible(true);
+
+    int row{0};
+    m_optionsLayout->addWidget(m_modeLabel, row, 0);
+    m_optionsLayout->addWidget(m_mode, row++, 1);
+    m_optionsLayout->addWidget(m_qualityLabel, row, 0);
+    m_optionsLayout->addWidget(m_quality, row++, 1);
+    m_optionsLayout->addWidget(m_bitrateEstimateLabel, row, 0);
+    m_optionsLayout->addWidget(m_bitrateEstimate, row++, 1);
+    m_optionsLayout->addWidget(m_bitrateLabel, row, 0);
+    m_optionsLayout->addWidget(m_bitrate, row++, 1);
+    m_optionsLayout->addWidget(m_levelLabel, row, 0);
+    m_optionsLayout->addWidget(m_level, row++, 1);
+    m_optionsLayout->setColumnStretch(1, 1);
+
+    auto* encoderGroup  = new QGroupBox(tr("Encoder"), this);
+    auto* encoderLayout = new QGridLayout(encoderGroup);
+
+    row = 0;
+    encoderLayout->addWidget(new QLabel(tr("Format") + ":"_L1, encoderGroup), row, 0);
+    encoderLayout->addWidget(m_encoder, row++, 1);
+    encoderLayout->addWidget(new QLabel(tr("Name") + ":"_L1, encoderGroup), row, 0);
+    encoderLayout->addWidget(m_name, row++, 1);
+    encoderLayout->setColumnStretch(1, 1);
+
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    m_okButton      = buttonBox->button(QDialogButtonBox::Ok);
+
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    QObject::connect(m_encoder, &QComboBox::currentIndexChanged, this, &EncoderProfileDialog::encoderChanged);
+    QObject::connect(m_name, &QLineEdit::textChanged, this, &EncoderProfileDialog::updateAcceptState);
+    QObject::connect(m_mode, &QComboBox::currentIndexChanged, this, &EncoderProfileDialog::updateMode);
+    QObject::connect(m_quality, &DoubleSliderEditor::valueChanged, this, &EncoderProfileDialog::updateBitrateEstimate);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(encoderGroup);
+    layout->addWidget(m_options);
+    layout->addStretch();
+    layout->addWidget(buttonBox);
+
+    int initialIndex{0};
+    for(int i{0}; std::cmp_less(i, m_availableEncoders.size()); ++i) {
+        if(m_availableEncoders.at(i).id == initial.id) {
+            initialIndex = i;
+            break;
+        }
+    }
+    m_encoder->setCurrentIndex(initialIndex);
+    encoderChanged(initialIndex);
+
+    m_name->setText(initial.profile.name.isEmpty() ? initial.name : initial.profile.name);
+    const int modeIndex = m_mode->findData(static_cast<int>(initial.profile.mode));
+    if(modeIndex >= 0) {
+        m_mode->setCurrentIndex(modeIndex);
+    }
+
+    m_quality->setValue(initial.profile.quality);
+    m_bitrate->setValue(initial.profile.bitrateKbps);
+    m_level->setValue(std::max(0, initial.profile.compressionLevel));
+
+    updateMode();
+    updateAcceptState();
+}
+
+void EncoderProfileDialog::encoderChanged(int index)
+{
+    if(index < 0 || std::cmp_greater_equal(index, m_availableEncoders.size())) {
+        m_options->hide();
+        updateAcceptState();
+        return;
+    }
+
+    const AudioEncoderInfo& encoder = m_availableEncoders.at(index);
+    m_mode->clear();
+    for(const EncoderMode mode : encoder.capabilities.modes) {
+        m_mode->addItem(modeName(mode), static_cast<int>(mode));
+    }
+    const int modeIndex = m_mode->findData(static_cast<int>(encoder.profile.mode));
+    m_mode->setCurrentIndex(modeIndex >= 0 ? modeIndex : 0);
+
+    const auto configureRange = [](auto* editor, const EncoderParameterRange& range) {
+        editor->setRange(range.minimum, range.maximum);
+        editor->setSingleStep(range.step);
+    };
+    if(encoder.capabilities.quality.isValid()) {
+        configureRange(m_quality, encoder.capabilities.quality);
+    }
+    else {
+        m_quality->setRange(0.0, 1.0);
+    }
+    if(encoder.capabilities.bitrateKbps.isValid()) {
+        configureRange(m_bitrate, encoder.capabilities.bitrateKbps);
+    }
+    else {
+        m_bitrate->setRange(0, 0);
+    }
+    if(encoder.capabilities.compressionLevel.isValid()) {
+        configureRange(m_level, encoder.capabilities.compressionLevel);
+    }
+    else {
+        m_level->setRange(0, 0);
+    }
+
+    m_quality->setValue(encoder.profile.quality);
+    m_bitrate->setValue(encoder.profile.bitrateKbps);
+    m_level->setValue(std::max(0, encoder.profile.compressionLevel));
+    updateMode();
+
+    m_name->setText(encoder.profile.name.isEmpty() ? encoder.name : encoder.profile.name);
+    updateAcceptState();
+}
+
+void EncoderProfileDialog::updateMode()
+{
+    const auto mode        = static_cast<EncoderMode>(m_mode->currentData().toInt());
+    const bool bitrate     = mode == EncoderMode::VariableBitrate || mode == EncoderMode::ConstrainedVariableBitrate
+                          || mode == EncoderMode::AverageBitrate || mode == EncoderMode::ConstantBitrate;
+    const bool showMode    = m_mode->count() > 1;
+    const bool showQuality = mode == EncoderMode::ConstantQuality && m_quality->maximum() > m_quality->minimum();
+    const bool showBitrate = bitrate && m_bitrate->maximum() > m_bitrate->minimum();
+    const bool showLevel   = m_level->maximum() > m_level->minimum();
+
+    const auto setRowVisible = [](QWidget* label, QWidget* field, bool visible) {
+        label->setVisible(visible);
+        field->setVisible(visible);
+    };
+
+    setRowVisible(m_modeLabel, m_mode, showMode);
+    setRowVisible(m_qualityLabel, m_quality, showQuality);
+    setRowVisible(m_bitrateLabel, m_bitrate, showBitrate);
+    setRowVisible(m_levelLabel, m_level, showLevel);
+    m_options->setVisible(showMode || showQuality || showBitrate || showLevel);
+
+    m_levelLabel->setText(mode == EncoderMode::LosslessCompression ? tr("Compression level") + ":"_L1
+                                                                   : tr("Encoding effort") + ":"_L1);
+    updateBitrateEstimate();
+}
+
+void EncoderProfileDialog::updateBitrateEstimate()
+{
+    const int index = m_encoder->currentIndex();
+    if(index < 0 || std::cmp_greater_equal(index, m_availableEncoders.size())) {
+        m_bitrateEstimateLabel->hide();
+        m_bitrateEstimate->hide();
+        return;
+    }
+
+    const AudioEncoderInfo& encoder = m_availableEncoders.at(index);
+    EncoderProfile profile{encoder.profile};
+    profile.mode    = static_cast<EncoderMode>(m_mode->currentData().toInt());
+    profile.quality = m_quality->value();
+
+    const int estimate = encoder.estimateBitrateKbps && profile.mode == EncoderMode::ConstantQuality
+                           ? encoder.estimateBitrateKbps(profile)
+                           : 0;
+    m_bitrateEstimate->setText(estimate > 0 ? u"~%1 kbps"_s.arg(estimate) : QString{});
+    m_bitrateEstimateLabel->setVisible(estimate > 0);
+    m_bitrateEstimate->setVisible(estimate > 0);
+}
+
+void EncoderProfileDialog::updateAcceptState() const
+{
+    m_okButton->setEnabled(m_encoder->currentIndex() >= 0 && !m_name->text().trimmed().isEmpty());
+}
+
+AudioEncoderInfo EncoderProfileDialog::encoderInfo() const
+{
+    const int index = m_encoder->currentIndex();
+    if(index < 0 || std::cmp_greater_equal(index, m_availableEncoders.size())) {
+        return {};
+    }
+
+    AudioEncoderInfo result         = m_availableEncoders.at(index);
+    result.name                     = m_name->text().trimmed();
+    result.profile.name             = result.name;
+    result.profile.mode             = static_cast<EncoderMode>(m_mode->currentData().toInt());
+    result.profile.quality          = m_quality->value();
+    result.profile.bitrateKbps      = m_bitrate->value();
+    result.profile.compressionLevel = result.capabilities.compressionLevel.isValid() ? m_level->value() : -1;
+    return result;
+}
+} // namespace Fooyin
+
+#include "moc_encoderprofiledialog.cpp"

--- a/src/gui/conversion/encoderprofiledialog.h
+++ b/src/gui/conversion/encoderprofiledialog.h
@@ -1,0 +1,71 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/audioencoder.h>
+
+#include <QDialog>
+
+#include <vector>
+
+class QComboBox;
+class QGridLayout;
+class QGroupBox;
+class QLabel;
+class QLineEdit;
+
+namespace Fooyin {
+class DoubleSliderEditor;
+class SliderEditor;
+
+class EncoderProfileDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    EncoderProfileDialog(std::vector<AudioEncoderInfo> availableEncoders, const AudioEncoderInfo& initial,
+                         bool allowEncoderChange, QWidget* parent = nullptr);
+
+    [[nodiscard]] AudioEncoderInfo encoderInfo() const;
+
+private:
+    void encoderChanged(int index);
+    void updateMode();
+    void updateBitrateEstimate();
+    void updateAcceptState() const;
+
+    std::vector<AudioEncoderInfo> m_availableEncoders;
+    QComboBox* m_encoder;
+    QLineEdit* m_name;
+    QGroupBox* m_options;
+    QGridLayout* m_optionsLayout;
+    QLabel* m_modeLabel;
+    QLabel* m_qualityLabel;
+    QLabel* m_bitrateEstimateLabel;
+    QLabel* m_bitrateEstimate;
+    QLabel* m_bitrateLabel;
+    QLabel* m_levelLabel;
+    QComboBox* m_mode;
+    DoubleSliderEditor* m_quality;
+    SliderEditor* m_bitrate;
+    SliderEditor* m_level;
+    QPushButton* m_okButton;
+};
+} // namespace Fooyin

--- a/src/gui/conversion/encoderprofiletablemodel.cpp
+++ b/src/gui/conversion/encoderprofiletablemodel.cpp
@@ -1,0 +1,218 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "encoderprofiletablemodel.h"
+
+#include <QUuid>
+
+#include <algorithm>
+#include <utility>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+EncoderProfileTableModel::EncoderProfileTableModel(QList<EncoderProfileEntry>* profiles,
+                                                   std::vector<AudioEncoderInfo>* encoders, QObject* parent)
+    : ExtendableTableModel{parent}
+    , m_profiles{profiles}
+    , m_encoders{encoders}
+    , m_pendingRow{-1}
+{ }
+
+QString EncoderProfileTableModel::profileDescription(const EncoderProfile& profile)
+{
+    switch(profile.mode) {
+        case EncoderMode::VariableBitrate:
+            return tr("VBR");
+        case EncoderMode::ConstrainedVariableBitrate:
+            return tr("CVBR");
+        case EncoderMode::ConstantQuality:
+            return tr("VBR quality %1").arg(profile.quality, 0, 'f', 1);
+        case EncoderMode::AverageBitrate:
+            return tr("ABR");
+        case EncoderMode::ConstantBitrate:
+            return tr("CBR");
+        case EncoderMode::LosslessCompression:
+            return profile.compressionLevel >= 0 ? tr("level %1").arg(profile.compressionLevel) : QString{};
+        case EncoderMode::Default:
+            return {};
+    }
+    return {};
+}
+
+int EncoderProfileTableModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_profiles->size());
+}
+
+int EncoderProfileTableModel::columnCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : 3;
+}
+
+QVariant EncoderProfileTableModel::data(const QModelIndex& index, int role) const
+{
+    if(!index.isValid() || index.row() >= static_cast<int>(m_profiles->size()) || role != Qt::DisplayRole) {
+        return {};
+    }
+
+    const AudioEncoderInfo& info = m_profiles->at(index.row()).info;
+
+    switch(index.column()) {
+        case 0:
+            return info.name;
+        case 1: {
+            switch(info.profile.mode) {
+                case EncoderMode::VariableBitrate:
+                case EncoderMode::ConstrainedVariableBitrate:
+                case EncoderMode::AverageBitrate:
+                case EncoderMode::ConstantBitrate:
+                case EncoderMode::Default:
+                    return info.profile.bitrateKbps > 0 ? tr("%1 kbps").arg(info.profile.bitrateKbps) : QString{};
+                case EncoderMode::ConstantQuality: {
+                    const int estimate = info.estimateBitrateKbps ? info.estimateBitrateKbps(info.profile) : 0;
+                    return estimate > 0 ? tr("~%1 kbps").arg(estimate) : QString{};
+                }
+                case EncoderMode::LosslessCompression:
+                    return {};
+            }
+            return {};
+        }
+        case 2: {
+            const QString description = profileDescription(info.profile);
+            return description.isEmpty() ? info.description : description;
+        }
+        default:
+            return {};
+    }
+}
+
+QVariant EncoderProfileTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation != Qt::Horizontal || role != Qt::DisplayRole) {
+        return {};
+    }
+    switch(section) {
+        case 0:
+            return tr("Name");
+        case 1:
+            return tr("Bitrate");
+        case 2:
+            return tr("Settings");
+        default:
+            return {};
+    }
+}
+
+Qt::ItemFlags EncoderProfileTableModel::flags(const QModelIndex& index) const
+{
+    return index.isValid() ? Qt::ItemIsEnabled | Qt::ItemIsSelectable : Qt::NoItemFlags;
+}
+
+void EncoderProfileTableModel::addPendingRow()
+{
+    Q_EMIT addProfileRequested();
+}
+
+void EncoderProfileTableModel::removePendingRow()
+{
+    if(m_pendingRow < 0 || m_pendingRow >= static_cast<int>(m_profiles->size())) {
+        return;
+    }
+
+    beginRemoveRows({}, m_pendingRow, m_pendingRow);
+    m_profiles->erase(m_profiles->begin() + m_pendingRow);
+    m_pendingRow = -1;
+    endRemoveRows();
+    Q_EMIT profilesChanged();
+}
+
+bool EncoderProfileTableModel::removeRows(int row, int count, const QModelIndex& parent)
+{
+    if(parent.isValid() || count != 1 || row < 0 || row >= static_cast<int>(m_profiles->size())) {
+        return false;
+    }
+
+    auto& entry = (*m_profiles)[row];
+    if(entry.builtIn) {
+        if(!entry.persisted) {
+            return false;
+        }
+
+        const auto runtime = std::ranges::find(*m_encoders, entry.info.id, &AudioEncoderInfo::id);
+        if(runtime == m_encoders->end()) {
+            return false;
+        }
+
+        entry.info      = *runtime;
+        entry.storageId = u"builtin:%1"_s.arg(entry.info.id);
+        entry.persisted = false;
+        Q_EMIT dataChanged(index(row, 0), index(row, columnCount() - 1));
+    }
+    else {
+        beginRemoveRows({}, row, row);
+        m_profiles->erase(m_profiles->begin() + row);
+        endRemoveRows();
+    }
+
+    Q_EMIT profilesChanged();
+    return true;
+}
+
+void EncoderProfileTableModel::insertPendingProfile(const AudioEncoderInfo& initial)
+{
+    if(m_pendingRow >= 0) {
+        return;
+    }
+
+    m_pendingRow = static_cast<int>(m_profiles->size());
+    beginInsertRows({}, m_pendingRow, m_pendingRow);
+    m_profiles->emplace_back(initial, QUuid::createUuid().toString(QUuid::WithoutBraces), false, false);
+    endInsertRows();
+}
+
+void EncoderProfileTableModel::commitPendingProfile(AudioEncoderInfo info)
+{
+    if(m_pendingRow < 0 || m_pendingRow >= static_cast<int>(m_profiles->size())) {
+        return;
+    }
+
+    auto& entry = (*m_profiles)[m_pendingRow];
+    entry.info  = std::move(info);
+    if(const QString description = profileDescription(entry.info.profile); !description.isEmpty()) {
+        entry.info.description = description;
+    }
+
+    entry.persisted = true;
+    const int row   = std::exchange(m_pendingRow, -1);
+    Q_EMIT dataChanged(index(row, 0), index(row, columnCount() - 1));
+    Q_EMIT profilesChanged();
+}
+
+void EncoderProfileTableModel::resetProfiles()
+{
+    beginResetModel();
+    endResetModel();
+}
+
+void EncoderProfileTableModel::refreshRow(int row)
+{
+    Q_EMIT dataChanged(index(row, 0), index(row, columnCount() - 1));
+}
+} // namespace Fooyin

--- a/src/gui/conversion/encoderprofiletablemodel.h
+++ b/src/gui/conversion/encoderprofiletablemodel.h
@@ -1,0 +1,69 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/audioencoder.h>
+#include <gui/widgets/extendabletableview.h>
+
+namespace Fooyin {
+struct EncoderProfileEntry
+{
+    AudioEncoderInfo info;
+    QString storageId;
+    bool builtIn{true};
+    bool persisted{false};
+};
+
+class EncoderProfileTableModel : public ExtendableTableModel
+{
+    Q_OBJECT
+
+public:
+    EncoderProfileTableModel(QList<EncoderProfileEntry>* profiles, std::vector<AudioEncoderInfo>* encoders,
+                             QObject* parent = nullptr);
+
+    [[nodiscard]] static QString profileDescription(const EncoderProfile& profile);
+
+    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+    void addPendingRow() override;
+    void removePendingRow() override;
+    bool removeRows(int row, int count, const QModelIndex& parent = {}) override;
+
+    void insertPendingProfile(const AudioEncoderInfo& initial);
+    void commitPendingProfile(AudioEncoderInfo info);
+    void resetProfiles();
+    void refreshRow(int row);
+
+Q_SIGNALS:
+    void addProfileRequested();
+    void profilesChanged();
+
+private:
+    QList<EncoderProfileEntry>* m_profiles;
+    std::vector<AudioEncoderInfo>* m_encoders;
+    int m_pendingRow;
+};
+
+} // namespace Fooyin

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -22,6 +22,8 @@
 #include "artwork/artworkdialog.h"
 #include "artwork/artworkfinder.h"
 #include "artwork/artworksaveutils.h"
+#include "conversion/conversioncontroller.h"
+#include "conversion/convertersettingsstore.h"
 #include "dialog/autoplaylistdialog.h"
 #include "dialog/saveplaylistsdialog.h"
 #include "dialog/searchdialog.h"
@@ -54,6 +56,7 @@
 #include <core/corepaths.h>
 #include <core/coresettings.h>
 #include <core/database/database.h>
+#include <core/engine/audioencoderregistry.h>
 #include <core/engine/enginehandler.h>
 #include <core/engine/enginehelpers.h>
 #include <core/internalcoresettings.h>
@@ -118,6 +121,7 @@
 #include <QStyle>
 #include <QStyleFactory>
 #include <QTimer>
+#include <QUrl>
 
 Q_LOGGING_CATEGORY(GUI_APP, "fy.gui")
 
@@ -186,6 +190,11 @@ Application* prepareCoreForGuiApplication(Application* core)
     applyInitialIconThemes(core ? core->settingsManager() : nullptr);
     return core;
 }
+
+Id conversionPresetActionId(const QString& presetId)
+{
+    return Id{u"Tracks.Convert.Preset.%1"_s.arg(presetId)};
+}
 } // namespace
 
 GuiApplication::GuiApplication(Application* core)
@@ -239,6 +248,13 @@ GuiApplication::GuiApplication(Application* core)
                          m_coverRepository}
     , m_logWidget{std::make_unique<LogWidget>(m_settings)}
     , m_widgets{new Widgets(m_core, this, m_guiPluginContext, m_mainWindow.get(), &m_playlistInteractor, this)}
+    , m_conversionController{new ConversionController(
+          m_core->audioLoader(), m_core->audioEncoderRegistry(), m_core->dspRegistry(), m_core->dspChainStore(),
+          m_widgets->dspSettingsRegistry(), m_settings, m_mainWindow.get(), this)}
+    , m_defaultConversionAction{nullptr}
+    , m_defaultConversionCommand{nullptr}
+    , m_lastUsedConversionAction{nullptr}
+    , m_lastUsedConversionCommand{nullptr}
     , m_coverProvider{m_coverRepository}
     , m_themeUpdatePending{false}
     , m_refreshSystemBaseline{false}
@@ -563,6 +579,7 @@ void GuiApplication::initialise()
     registerActions();
     setupScanMenu();
     setupRatingMenu();
+    setupConvertMenu();
     setupUtilitiesMenu();
     setStyle();
     setIconTheme();
@@ -1087,6 +1104,184 @@ void GuiApplication::setupRatingMenu()
     m_selectionController->registerTrackContextSubmenu(
         this, TrackContextMenuArea::Track, Constants::Menus::Context::TrackSelection,
         Constants::Menus::Context::Tagging, tr("Tagging"), Constants::Menus::Context::TrackFinalSeparator);
+}
+
+void GuiApplication::startConversionPreset(const StoredConversionPreset& stored, const TrackList& tracks)
+{
+    if(tracks.empty()) {
+        return;
+    }
+
+    QString askFolder;
+    if(stored.preset.destination.mode == DestinationMode::Ask) {
+        askFolder = QFileDialog::getExistingDirectory(m_mainWindow.get(), tr("Choose destination"), QDir::homePath());
+        if(askFolder.isEmpty()) {
+            return;
+        }
+    }
+
+    StoredConversionPreset lastUsed{stored};
+    lastUsed.name        = u"[last used]"_s;
+    lastUsed.preset.name = lastUsed.name;
+    ConverterSettings::setLastUsedConversionPreset(lastUsed);
+    if(m_lastUsedConversionAction) {
+        m_lastUsedConversionAction->setEnabled(true);
+    }
+
+    ConversionJob job{.tracks = tracks, .preset = stored.preset};
+    m_conversionController->start(std::move(job), std::move(askFolder), stored.showReport);
+}
+
+void GuiApplication::startDefaultConversion(const TrackList& tracks)
+{
+    const auto encoders = m_core->audioEncoderRegistry()->availableEncoders();
+    const auto encoder  = std::ranges::find_if(encoders, [](const AudioEncoderInfo& info) {
+        return info.id == QLatin1StringView{ConverterSettings::DefaultEncoderProfileId};
+    });
+    if(encoder == encoders.cend()) {
+        return;
+    }
+
+    StoredConversionPreset preset;
+    preset.name                   = u"[default]"_s;
+    preset.preset.name            = preset.name;
+    preset.preset.encoder.profile = encoder->profile;
+
+    const auto storedProfiles  = ConverterSettings::encoderProfiles();
+    const auto profileOverride = std::ranges::find_if(storedProfiles, [&encoder](const StoredEncoderProfile& stored) {
+        return stored.overridesBuiltIn && stored.baseEncoderId == encoder->id;
+    });
+    if(profileOverride != storedProfiles.cend()) {
+        preset.preset.encoder.profile
+            = ConverterSettings::applyStoredEncoderProfile(std::move(preset.preset.encoder.profile), *profileOverride);
+    }
+
+    startConversionPreset(preset, tracks);
+}
+
+void GuiApplication::startLastUsedConversion(const TrackList& tracks)
+{
+    if(const auto preset = ConverterSettings::lastUsedConversionPreset()) {
+        startConversionPreset(*preset, tracks);
+    }
+}
+
+void GuiApplication::refreshConversionPresetActions()
+{
+    const auto presets = ConverterSettings::conversionPresets();
+
+    std::erase_if(m_conversionPresetActions, [this, &presets](const ConversionPresetAction& presetAction) {
+        const bool removed = std::ranges::none_of(presets, [&presetAction](const StoredConversionPreset& preset) {
+            return preset.preset.id == presetAction.presetId;
+        });
+        if(removed && presetAction.action) {
+            m_actionManager->unregisterAction(presetAction.action, conversionPresetActionId(presetAction.presetId));
+            presetAction.action->deleteLater();
+        }
+        return removed;
+    });
+
+    for(const StoredConversionPreset& preset : presets) {
+        if(preset.preset.id.isEmpty()) {
+            continue;
+        }
+
+        const auto existing
+            = std::ranges::find(m_conversionPresetActions, preset.preset.id, &ConversionPresetAction::presetId);
+        if(existing != m_conversionPresetActions.end()) {
+            existing->action->setText(preset.name);
+            existing->command->setDescription(tr("Convert using preset %1").arg(preset.name));
+            continue;
+        }
+
+        auto* action  = new QAction(preset.name, m_mainWindow.get());
+        const Id id   = conversionPresetActionId(preset.preset.id);
+        auto* command = m_actionManager->registerAction(action, id);
+        command->setCategories({tr("Tracks"), tr("Convert")});
+        command->setDescription(tr("Convert using preset %1").arg(preset.name));
+        command->setAttribute(ProxyAction::UpdateText);
+        command->action()->setShortcutVisibleInContextMenu(true);
+
+        QObject::connect(action, &QAction::triggered, this, [this, presetId = preset.preset.id]() {
+            const auto currentPresets = ConverterSettings::conversionPresets();
+            const auto current        = std::ranges::find(
+                currentPresets, presetId, [](const StoredConversionPreset& stored) { return stored.preset.id; });
+            if(current != currentPresets.cend()) {
+                startConversionPreset(*current, m_selectionController->selectedTracks());
+            }
+        });
+
+        m_conversionPresetActions.push_back({preset.preset.id, action, command});
+    }
+
+    if(m_defaultConversionAction) {
+        const auto encoders = m_core->audioEncoderRegistry()->availableEncoders();
+        m_defaultConversionAction->setEnabled(std::ranges::any_of(encoders, [](const AudioEncoderInfo& encoder) {
+            return encoder.id == QLatin1StringView{ConverterSettings::DefaultEncoderProfileId};
+        }));
+    }
+    if(m_lastUsedConversionAction) {
+        m_lastUsedConversionAction->setEnabled(ConverterSettings::lastUsedConversionPreset().has_value());
+    }
+}
+
+void GuiApplication::setupConvertMenu()
+{
+    auto* convertAction  = new QAction(tr("Converter setup…"), m_mainWindow.get());
+    auto* convertCommand = m_actionManager->registerAction(convertAction, Constants::Actions::Convert);
+    convertCommand->setCategories({tr("Tracks"), tr("Convert")});
+    QObject::connect(convertAction, &QAction::triggered, m_mainWindow.get(), [this]() {
+        if(m_selectionController->hasTracks()) {
+            m_conversionController->showSetup(m_selectionController->selectedTracks());
+        }
+    });
+
+    m_defaultConversionAction = new QAction(tr("Using default settings"), m_mainWindow.get());
+    m_defaultConversionCommand
+        = m_actionManager->registerAction(m_defaultConversionAction, Constants::Actions::ConvertDefault);
+    m_defaultConversionCommand->setCategories({tr("Tracks"), tr("Convert")});
+    m_defaultConversionCommand->setDescription(tr("Convert using default settings"));
+    m_defaultConversionCommand->action()->setShortcutVisibleInContextMenu(true);
+    QObject::connect(m_defaultConversionAction, &QAction::triggered, this,
+                     [this]() { startDefaultConversion(m_selectionController->selectedTracks()); });
+
+    m_lastUsedConversionAction = new QAction(tr("Repeat last conversion"), m_mainWindow.get());
+    m_lastUsedConversionCommand
+        = m_actionManager->registerAction(m_lastUsedConversionAction, Constants::Actions::ConvertLastUsed);
+    m_lastUsedConversionCommand->setCategories({tr("Tracks"), tr("Convert")});
+    m_lastUsedConversionCommand->action()->setShortcutVisibleInContextMenu(true);
+    QObject::connect(m_lastUsedConversionAction, &QAction::triggered, this,
+                     [this]() { startLastUsedConversion(m_selectionController->selectedTracks()); });
+
+    refreshConversionPresetActions();
+    QObject::connect(m_conversionController, &ConversionController::conversionPresetsChanged, this,
+                     &GuiApplication::refreshConversionPresetActions);
+
+    m_selectionController->registerTrackContextDynamicSubmenu(
+        this, TrackContextMenuArea::Track, Constants::Menus::Context::TrackSelection,
+        Constants::Menus::Context::Convert, tr("Convert"),
+        [this](QMenu* menu, const TrackSelection& selection) {
+            const TrackList tracks = selection.tracks;
+            refreshConversionPresetActions();
+
+            menu->addAction(m_defaultConversionCommand->action());
+            menu->addAction(m_lastUsedConversionCommand->action());
+
+            if(!m_conversionPresetActions.empty()) {
+                menu->addSeparator();
+            }
+
+            for(const ConversionPresetAction& presetAction : m_conversionPresetActions) {
+                menu->addAction(presetAction.command->action());
+            }
+
+            menu->addSeparator();
+            QAction* setupAction = menu->addAction(tr("Custom conversion…"));
+            setupAction->setEnabled(!tracks.empty());
+            QObject::connect(setupAction, &QAction::triggered, this,
+                             [this, tracks] { m_conversionController->showSetup(tracks); });
+        },
+        Constants::Menus::Context::TrackFinalSeparator);
 }
 
 void GuiApplication::setupUtilitiesMenu()

--- a/src/gui/guiapplication.h
+++ b/src/gui/guiapplication.h
@@ -40,14 +40,18 @@
 
 #include <memory>
 #include <set>
+#include <vector>
 
 class QTimerEvent;
+class QAction;
 
 namespace Fooyin {
 class ActionManager;
 class AdvancedSettingsRegistry;
 class Application;
 class CoverRepository;
+class ConversionController;
+class Command;
 class EditableLayout;
 class GuiStyleProvider;
 class EditMenu;
@@ -76,6 +80,7 @@ class SettingsManager;
 class MusicLibrary;
 class PlayerController;
 class PlaylistHandler;
+struct StoredConversionPreset;
 
 class FYGUI_EXPORT GuiApplication : public QObject
 {
@@ -138,7 +143,13 @@ private:
 
     void setupScanMenu();
     void setupRatingMenu();
+    void setupConvertMenu();
+    void refreshConversionPresetActions();
     void setupUtilitiesMenu();
+
+    void startConversionPreset(const StoredConversionPreset& preset, const TrackList& tracks);
+    void startDefaultConversion(const TrackList& tracks);
+    void startLastUsedConversion(const TrackList& tracks);
 
     void close();
     void changeVolume(double delta) const;
@@ -225,6 +236,20 @@ private:
     QPointer<QueueViewer> m_playbackQueueWidget;
     QPointer<PlaylistManagerWidget> m_playlistManagerWidget;
     Widgets* m_widgets;
+    ConversionController* m_conversionController;
+
+    struct ConversionPresetAction
+    {
+        QString presetId;
+        QAction* action;
+        Command* command;
+    };
+    QAction* m_defaultConversionAction;
+    Command* m_defaultConversionCommand;
+    QAction* m_lastUsedConversionAction;
+    Command* m_lastUsedConversionCommand;
+    std::vector<ConversionPresetAction> m_conversionPresetActions;
+
     ScriptParser m_scriptParser;
     CoverProvider m_coverProvider;
 

--- a/src/gui/widgets/doubleslidereditor.cpp
+++ b/src/gui/widgets/doubleslidereditor.cpp
@@ -48,9 +48,7 @@ DoubleSliderEditor::DoubleSliderEditor(const QString& name, QWidget* parent)
     QObject::connect(m_slider, &QSlider::valueChanged, this, &DoubleSliderEditor::sliderValueChanged);
     QObject::connect(m_spinBox, &QDoubleSpinBox::valueChanged, this, &DoubleSliderEditor::spinBoxValueChanged);
 
-    m_slider->setMinimum(0);
-    m_slider->setMaximum(1000000);
-    m_slider->setSingleStep(0);
+    m_slider->setSingleStep(1);
 }
 
 DoubleSliderEditor::DoubleSliderEditor(QWidget* parent)
@@ -145,9 +143,7 @@ void DoubleSliderEditor::sliderValueChanged(int value)
     const double max  = m_spinBox->maximum();
     const double step = m_spinBox->singleStep();
 
-    const double ratio = static_cast<double>(value) / m_slider->maximum();
-    double spinVal     = min + (max - min) * ratio;
-    spinVal            = std::round(spinVal / step) * step;
+    const double spinVal = std::min(max, min + (static_cast<double>(value) * step));
 
     if(spinVal != m_spinBox->value()) {
         m_spinBox->setValue(spinVal);
@@ -164,22 +160,24 @@ void DoubleSliderEditor::spinBoxValueChanged(double value)
 
 void DoubleSliderEditor::updateSlider()
 {
+    const QSignalBlocker blocker{m_slider};
+
     const double min  = m_spinBox->minimum();
     const double max  = m_spinBox->maximum();
     const double step = m_spinBox->singleStep();
 
     const double range = max - min;
-    if(range > 0.0 && step > 0.0) {
-        const int tickInterval
-            = std::max(1, static_cast<int>(std::round(m_slider->maximum() * std::min(step, range) / range)));
-        m_slider->setTickInterval(tickInterval);
+    if(range <= 0.0 || step <= 0.0) {
+        m_slider->setRange(0, 0);
+        return;
     }
 
-    double value = m_spinBox->value();
-    value        = std::round(value / step) * step;
+    const int stepCount = std::max(1, static_cast<int>(std::round(range / step)));
+    m_slider->setRange(0, stepCount);
+    m_slider->setPageStep(std::max(1, stepCount / 10));
+    m_slider->setTickInterval(1);
 
-    const double ratio  = (value - min) / (max - min);
-    const int sliderVal = static_cast<int>(std::round(m_slider->maximum() * ratio));
+    const int sliderVal = std::clamp(static_cast<int>(std::round((m_spinBox->value() - min) / step)), 0, stepCount);
 
     if(sliderVal != m_slider->value()) {
         m_slider->setValue(sliderVal);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ function(fooyin_add_test name)
     add_executable(${name} ${ARGN} testutils.cpp)
     fooyin_set_rpath(${name} ${LIB_INSTALL_DIR})
     target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_include_directories(${name} SYSTEM PRIVATE ${FFMPEG_INCLUDE_DIRS})
     target_compile_definitions(${name} PRIVATE FOOYIN_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     target_link_libraries(
         ${name}
@@ -15,6 +16,7 @@ function(fooyin_add_test name)
                 Fooyin::GuiPrivate
                 Fooyin::Utils
                 Qt6::Test
+                ${FFMPEG_LIBRARIES}
                 GTest::gtest_main
     )
     gtest_discover_tests(${name})
@@ -22,6 +24,9 @@ endfunction()
 
 fooyin_add_test(test_audioconverter core/engine/audioconvertertest.cpp)
 fooyin_add_test(test_audioclock core/engine/audioclocktest.cpp)
+fooyin_add_test(test_conversionpathresolver core/engine/conversion/conversionpathresolvertest.cpp)
+fooyin_add_test(test_conversionrunner core/engine/conversion/conversionrunnertest.cpp)
+fooyin_add_test(test_ffmpegencoder core/engine/ffmpegencodertest.cpp)
 fooyin_add_test(test_audioloader core/engine/audioloadertest.cpp)
 fooyin_add_test(test_audioengine core/engine/audioenginetest.cpp)
 fooyin_add_test(test_visualisationbackend core/engine/visualisationbackendtest.cpp)

--- a/tests/core/engine/audioloadertest.cpp
+++ b/tests/core/engine/audioloadertest.cpp
@@ -1053,6 +1053,31 @@ TEST_F(AudioLoaderTest, ReadsWritesMetadataAndCoversForRegularTracks)
     EXPECT_TRUE(secondReader->lastWriteOptions.testFlag(AudioReader::PreserveTimestamps));
 }
 
+TEST_F(AudioLoaderTest, DisabledReadersRemainAvailableForMetadataWrites)
+{
+    AudioLoader loader;
+    const QString filePath = createFile(u"metadata.mp3"_s, "metadata-track");
+
+    const auto reader        = addReader(loader, u"metadata-writer"_s, {u"mp3"_s});
+    reader->canWriteMetadata = true;
+    reader->canWriteCover    = true;
+
+    loader.setReaderEnabled(u"metadata-writer"_s, false);
+
+    Track track{filePath};
+    EXPECT_TRUE(loader.readersForTrack(track).empty());
+    EXPECT_FALSE(loader.readTrackMetadata(track));
+    EXPECT_EQ(0, reader->readCalls);
+    EXPECT_TRUE(loader.canWriteMetadata(track));
+    EXPECT_TRUE(loader.writeTrackMetadata(track, AudioReader::Metadata));
+    EXPECT_EQ(1, reader->writeTrackCalls);
+
+    TrackCovers covers;
+    covers.emplace(Track::Cover::Front, CoverImage{u"image/png"_s, QByteArray{"cover"}});
+    EXPECT_TRUE(loader.writeTrackCover(track, covers, AudioReader::None));
+    EXPECT_EQ(1, reader->writeCoverCalls);
+}
+
 TEST_F(AudioLoaderTest, LoadsDecoderAndReaderForArchiveTracks)
 {
     AudioLoader loader;

--- a/tests/core/engine/conversion/conversionpathresolvertest.cpp
+++ b/tests/core/engine/conversion/conversionpathresolvertest.cpp
@@ -1,0 +1,288 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/conversion/conversionpathresolver.h>
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Testing {
+namespace {
+Track makeTrack(const QString& path, const QString& title = {})
+{
+    Track track{path};
+    if(!title.isEmpty()) {
+        track.setTitle(title);
+    }
+    return track;
+}
+
+ConversionDestination destination(DestinationMode mode, QString pattern = u"%title%"_s)
+{
+    ConversionDestination dest;
+    dest.mode            = mode;
+    dest.filenamePattern = std::move(pattern);
+    return dest;
+}
+
+} // namespace
+
+TEST(ConversionPathResolverTest, ResolvesSourceFolderDestination)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"Song One"_s);
+
+    ConversionPathResolver resolver;
+    const QString path = resolver.previewPath(track, destination(DestinationMode::SourceFolder), u"flac"_s);
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{dir.path()}.filePath(u"Song One.flac"_s)));
+}
+
+TEST(ConversionPathResolverTest, ResolvesFixedFolderDestination)
+{
+    QTemporaryDir sourceDir;
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(sourceDir.isValid());
+    ASSERT_TRUE(outputDir.isValid());
+
+    const Track track = makeTrack(QDir{sourceDir.path()}.filePath(u"source.wav"_s), u"Song Two"_s);
+
+    auto dest        = destination(DestinationMode::FixedFolder);
+    dest.fixedFolder = outputDir.path();
+
+    ConversionPathResolver resolver;
+    const QString path = resolver.previewPath(track, dest, u".wav"_s);
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{outputDir.path()}.filePath(u"Song Two.wav"_s)));
+}
+
+TEST(ConversionPathResolverTest, ResolvesAskFolderDestination)
+{
+    QTemporaryDir sourceDir;
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(sourceDir.isValid());
+    ASSERT_TRUE(outputDir.isValid());
+
+    const Track track = makeTrack(QDir{sourceDir.path()}.filePath(u"source.wav"_s), u"Song Three"_s);
+
+    ConversionPathResolver resolver;
+    const QString path = resolver.previewPath(track, destination(DestinationMode::Ask), u"opus"_s, outputDir.path());
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{outputDir.path()}.filePath(u"Song Three.opus"_s)));
+}
+
+TEST(ConversionPathResolverTest, FormatsFilenamePattern)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"Track Title"_s);
+    track.setArtists({u"Artist Name"_s});
+
+    ConversionPathResolver resolver;
+    const QString path
+        = resolver.previewPath(track, destination(DestinationMode::SourceFolder, u"%artist% - %title%"_s), u"flac"_s);
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{dir.path()}.filePath(u"Artist Name - Track Title.flac"_s)));
+}
+
+TEST(ConversionPathResolverTest, SanitisesInvalidFilenameCharacters)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"A:B*C?D\"E<F>G|H"_s);
+
+    ConversionPathResolver resolver;
+    const QString path = resolver.previewPath(track, destination(DestinationMode::SourceFolder), u"wav"_s);
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{dir.path()}.filePath(u"A_B_C_D_E_F_G_H.wav"_s)));
+}
+
+TEST(ConversionPathResolverTest, FallsBackWhenPatternIsEmpty)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"fallback-name.wav"_s));
+
+    ConversionPathResolver resolver;
+    const QString path = resolver.previewPath(track, destination(DestinationMode::SourceFolder, u"[]"_s), u"flac"_s);
+
+    EXPECT_EQ(path, QDir::cleanPath(QDir{dir.path()}.filePath(u"fallback-name.flac"_s)));
+}
+
+TEST(ConversionPathResolverTest, DetectsDuplicateOutputPaths)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const Track first  = makeTrack(QDir{dir.path()}.filePath(u"first.wav"_s), u"Same"_s);
+    const Track second = makeTrack(QDir{dir.path()}.filePath(u"second.wav"_s), u"Same"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks      = {first, second};
+    request.destination = destination(DestinationMode::SourceFolder);
+    request.extension   = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0].status, ConversionPathStatus::Ready);
+    EXPECT_EQ(results[1].status, ConversionPathStatus::Error);
+    EXPECT_FALSE(results[1].error.isEmpty());
+}
+
+TEST(ConversionPathResolverTest, ResolvesSinglePathForMergedTracks)
+{
+    QTemporaryDir sourceDir;
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(sourceDir.isValid());
+    ASSERT_TRUE(outputDir.isValid());
+
+    const Track first  = makeTrack(QDir{sourceDir.path()}.filePath(u"first.wav"_s), u"Merged Album"_s);
+    const Track second = makeTrack(QDir{sourceDir.path()}.filePath(u"second.wav"_s), u"Second Track"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks                  = {first, second};
+    request.destination             = destination(DestinationMode::FixedFolder);
+    request.destination.fixedFolder = outputDir.path();
+    request.destination.outputStyle = OutputStyle::MergeTracks;
+    request.extension               = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results.front().status, ConversionPathStatus::Ready);
+    EXPECT_EQ(results.front().outputPath, QDir{outputDir.path()}.filePath(u"Merged Album.flac"_s));
+    EXPECT_EQ(results.front().tracks.size(), 2);
+}
+
+TEST(ConversionPathResolverTest, GroupsMultiTrackFilesByResolvedOutputPath)
+{
+    QTemporaryDir sourceDir;
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(sourceDir.isValid());
+    ASSERT_TRUE(outputDir.isValid());
+
+    Track first = makeTrack(QDir{sourceDir.path()}.filePath(u"first.wav"_s), u"First Track"_s);
+    first.setAlbum(u"Album A"_s);
+    Track second = makeTrack(QDir{sourceDir.path()}.filePath(u"second.wav"_s), u"Second Track"_s);
+    second.setAlbum(u"Album A"_s);
+    Track third = makeTrack(QDir{sourceDir.path()}.filePath(u"third.wav"_s), u"Third Track"_s);
+    third.setAlbum(u"Album B"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks                  = {first, second, third};
+    request.destination             = destination(DestinationMode::FixedFolder, u"%album%"_s);
+    request.destination.fixedFolder = outputDir.path();
+    request.destination.outputStyle = OutputStyle::MultiTrackFiles;
+    request.extension               = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0].status, ConversionPathStatus::Ready);
+    EXPECT_EQ(results[0].outputPath, QDir{outputDir.path()}.filePath(u"Album A.flac"_s));
+    EXPECT_EQ(results[0].tracks.size(), 2);
+    EXPECT_EQ(results[1].status, ConversionPathStatus::Ready);
+    EXPECT_EQ(results[1].outputPath, QDir{outputDir.path()}.filePath(u"Album B.flac"_s));
+    EXPECT_EQ(results[1].tracks.size(), 1);
+}
+
+TEST(ConversionPathResolverTest, AppliesSkipExistingFilePolicy)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString output = QDir{dir.path()}.filePath(u"Existing.flac"_s);
+    QFile file{output};
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"Existing"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks                       = {track};
+    request.destination                  = destination(DestinationMode::SourceFolder);
+    request.destination.existingFileMode = ExistingFileMode::Skip;
+    request.extension                    = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].status, ConversionPathStatus::Skipped);
+    EXPECT_EQ(results[0].outputPath, QDir::cleanPath(output));
+}
+
+TEST(ConversionPathResolverTest, AppliesAskExistingFilePolicy)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString output = QDir{dir.path()}.filePath(u"Existing.flac"_s);
+    QFile file{output};
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"Existing"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks                       = {track};
+    request.destination                  = destination(DestinationMode::SourceFolder);
+    request.destination.existingFileMode = ExistingFileMode::Ask;
+    request.extension                    = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].status, ConversionPathStatus::NeedsOverwriteDecision);
+}
+
+TEST(ConversionPathResolverTest, AppliesOverwriteExistingFilePolicy)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString output = QDir{dir.path()}.filePath(u"Existing.flac"_s);
+    QFile file{output};
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const Track track = makeTrack(QDir{dir.path()}.filePath(u"source.wav"_s), u"Existing"_s);
+
+    ConversionPathResolver::Request request;
+    request.tracks                       = {track};
+    request.destination                  = destination(DestinationMode::SourceFolder);
+    request.destination.existingFileMode = ExistingFileMode::Overwrite;
+    request.extension                    = u"flac"_s;
+
+    const auto results = ConversionPathResolver{}.resolve(request);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0].status, ConversionPathStatus::Ready);
+}
+} // namespace Fooyin::Testing

--- a/tests/core/engine/conversion/conversionrunnertest.cpp
+++ b/tests/core/engine/conversion/conversionrunnertest.cpp
@@ -1,0 +1,807 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/audioconverter.h>
+#include <core/engine/conversion/conversionrunner.h>
+#include <core/engine/dsp/dspregistry.h>
+#include <core/engine/input/ffmpeg/ffmpegencoder.h>
+#include <core/engine/input/ffmpeg/ffmpeginput.h>
+#include <core/engine/input/taglibparser.h>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QScopeGuard>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+}
+
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Testing {
+namespace {
+std::optional<AudioEncoderInfo> profileById(const std::vector<AudioEncoderInfo>& profiles, const QString& id)
+{
+    const auto it = std::ranges::find_if(profiles, [&id](const AudioEncoderInfo& info) { return info.id == id; });
+    if(it == profiles.end()) {
+        return {};
+    }
+    return *it;
+}
+
+bool hasCodec(const QString& path, AVCodecID codecId)
+{
+    AVFormatContext* context{nullptr};
+    if(avformat_open_input(&context, path.toLocal8Bit().constData(), nullptr, nullptr) < 0) {
+        return false;
+    }
+
+    const auto close = qScopeGuard([&context] { avformat_close_input(&context); });
+    if(avformat_find_stream_info(context, nullptr) < 0) {
+        return false;
+    }
+
+    for(unsigned i{0}; i < context->nb_streams; ++i) {
+        const AVCodecParameters* params = context->streams[i]->codecpar;
+        if(params->codec_type == AVMEDIA_TYPE_AUDIO && params->codec_id == codecId) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+int audioChannelCount(const QString& path)
+{
+    AVFormatContext* context{nullptr};
+    if(avformat_open_input(&context, path.toLocal8Bit().constData(), nullptr, nullptr) < 0) {
+        return 0;
+    }
+
+    const auto close = qScopeGuard([&context] { avformat_close_input(&context); });
+    if(avformat_find_stream_info(context, nullptr) < 0) {
+        return 0;
+    }
+    for(unsigned i{0}; i < context->nb_streams; ++i) {
+        const AVCodecParameters* params = context->streams[i]->codecpar;
+        if(params->codec_type == AVMEDIA_TYPE_AUDIO) {
+#if OLD_CHANNEL_LAYOUT
+            return params->channels;
+#else
+            return params->ch_layout.nb_channels;
+#endif
+        }
+    }
+    return 0;
+}
+
+uint64_t audioDurationMs(const QString& path)
+{
+    AVFormatContext* context{nullptr};
+    if(avformat_open_input(&context, path.toLocal8Bit().constData(), nullptr, nullptr) < 0) {
+        return 0;
+    }
+
+    const auto close = qScopeGuard([&context] { avformat_close_input(&context); });
+    if(avformat_find_stream_info(context, nullptr) < 0 || context->duration <= 0) {
+        return 0;
+    }
+    return static_cast<uint64_t>(context->duration) * 1000 / AV_TIME_BASE;
+}
+
+QString outputTitle(const QString& path)
+{
+    AVFormatContext* context{nullptr};
+    if(avformat_open_input(&context, path.toLocal8Bit().constData(), nullptr, nullptr) < 0) {
+        return {};
+    }
+
+    const auto close = qScopeGuard([&context] { avformat_close_input(&context); });
+    if(avformat_find_stream_info(context, nullptr) < 0) {
+        return {};
+    }
+
+    const AVDictionaryEntry* title = av_dict_get(context->metadata, "title", nullptr, 0);
+    return title ? QString::fromUtf8(title->value) : QString{};
+}
+
+double decodedPeak(AudioLoader& loader, const QString& path)
+{
+    auto loaded = loader.loadDecoderForTrack(Track{path}, AudioDecoder::NoLooping);
+    if(!loaded.decoder || !loaded.format) {
+        return 0.0;
+    }
+
+    loaded.decoder->start();
+    const auto stop = qScopeGuard([&loaded] { loaded.decoder->stop(); });
+    double peak{0.0};
+
+    while(true) {
+        auto result = loaded.decoder->readAudio(256 * 1024);
+        if(result.status == AudioDecoder::ReadStatus::EndOfStream) {
+            break;
+        }
+        if(result.status == AudioDecoder::ReadStatus::NeedMoreInput) {
+            continue;
+        }
+        if(result.status != AudioDecoder::ReadStatus::DecodedAudio) {
+            return 0.0;
+        }
+
+        AudioFormat format = result.buffer.format();
+        format.setSampleFormat(SampleFormat::F64);
+
+        const AudioBuffer converted = Audio::convert(result.buffer, format);
+        if(!converted.isValid()) {
+            return 0.0;
+        }
+
+        std::vector<double> samples(static_cast<size_t>(converted.sampleCount()));
+        std::memcpy(samples.data(), converted.data(), static_cast<size_t>(converted.byteCount()));
+
+        for(const double sample : samples) {
+            peak = std::max(peak, std::abs(sample));
+        }
+    }
+    return peak;
+}
+
+class CapturingAudioEncoder : public AudioEncoder
+{
+public:
+    explicit CapturingAudioEncoder(std::shared_ptr<std::vector<DitherMode>> ditherModes)
+        : m_ditherModes{std::move(ditherModes)}
+    { }
+
+    [[nodiscard]] std::vector<AudioEncoderInfo> availableEncoders() const override
+    {
+        EncoderProfile profile;
+        profile.id            = u"capture-wav"_s;
+        profile.name          = u"Capture WAV"_s;
+        profile.extension     = u"wav"_s;
+        profile.containerName = u"wav"_s;
+        profile.codecName     = u"capture"_s;
+        return {{.id               = profile.id,
+                 .backendId        = u"capture"_s,
+                 .name             = profile.name,
+                 .description      = {},
+                 .profile          = profile,
+                 .supportsMetadata = false,
+                 .supportsPictures = false}};
+    }
+
+    Result init(const QString&, const AudioFormat&, const AudioEncoderSettings& settings) override
+    {
+        m_ditherModes->push_back(settings.ditherMode);
+        return Result::success();
+    }
+
+    Result write(const AudioBuffer&) override
+    {
+        return Result::success();
+    }
+
+    Result finish() override
+    {
+        return Result::success();
+    }
+
+private:
+    std::shared_ptr<std::vector<DitherMode>> m_ditherModes;
+};
+
+class CountingDsp : public DspNode
+{
+public:
+    [[nodiscard]] QString name() const override
+    {
+        return u"Counting DSP"_s;
+    }
+
+    [[nodiscard]] QString id() const override
+    {
+        return u"test.dsp.counting"_s;
+    }
+
+    void prepare(const AudioFormat&) override { }
+    void process(ProcessingBufferList&) override { }
+};
+} // namespace
+
+TEST(ConversionRunnerTest, ConvertsTrackToFlac)
+{
+    const auto flacProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-flac"_s);
+    if(!flacProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg FLAC encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+    loader.addReader(u"TagLib"_s, [] { return std::make_unique<TagLibReader>(); });
+
+    AudioEncoderRegistry registry;
+    registry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    Track track{QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s)};
+    track.setTitle(u"Converted Track"_s);
+    track.setRating(0.8F);
+    track.setPlayCount(12);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = flacProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.destination.outputStyle      = OutputStyle::IndividualFiles;
+    preset.processing.transferPlaycount = true;
+    preset.other.verifyOutput           = true;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &registry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results.front().status, ConversionResultStatus::Succeeded) << results.front().error.toStdString();
+    EXPECT_TRUE(QFileInfo::exists(results.front().outputPath));
+    EXPECT_GT(QFileInfo{results.front().outputPath}.size(), 0);
+    EXPECT_TRUE(hasCodec(results.front().outputPath, AV_CODEC_ID_FLAC));
+    EXPECT_EQ(outputTitle(results.front().outputPath), u"Converted Track"_s);
+
+    Track convertedTrack{results.front().outputPath};
+    ASSERT_TRUE(loader.readTrackMetadata(convertedTrack));
+    EXPECT_FLOAT_EQ(convertedTrack.rating(), 0.8F);
+    EXPECT_EQ(convertedTrack.playCount(), 12);
+
+    bool existingFileCallbackCalled{false};
+    request.job.preset.destination.existingFileMode = ExistingFileMode::Ask;
+    request.existingFileCallback                    = [&existingFileCallbackCalled](const QString&) {
+        existingFileCallbackCalled = true;
+        return ExistingFileMode::Skip;
+    };
+
+    const auto skippedResults = ConversionRunner::run(request);
+
+    ASSERT_EQ(skippedResults.size(), 1);
+    EXPECT_TRUE(existingFileCallbackCalled);
+    EXPECT_EQ(skippedResults.front().status, ConversionResultStatus::Skipped);
+    EXPECT_EQ(outputTitle(skippedResults.front().outputPath), u"Converted Track"_s);
+
+    request.job.preset.processing.transferMetadata = false;
+    request.existingFileCallback                   = [](const QString&) {
+        return ExistingFileMode::Overwrite;
+    };
+
+    const auto resultsWithoutMetadata = ConversionRunner::run(request);
+
+    ASSERT_EQ(resultsWithoutMetadata.size(), 1);
+    EXPECT_EQ(resultsWithoutMetadata.front().status, ConversionResultStatus::Succeeded)
+        << resultsWithoutMetadata.front().error.toStdString();
+    EXPECT_TRUE(outputTitle(resultsWithoutMetadata.front().outputPath).isEmpty());
+
+    Track convertedWithoutMetadata{resultsWithoutMetadata.front().outputPath};
+    ASSERT_TRUE(loader.readTrackMetadata(convertedWithoutMetadata));
+    EXPECT_FLOAT_EQ(convertedWithoutMetadata.rating(), 0.8F);
+    EXPECT_EQ(convertedWithoutMetadata.playCount(), 12);
+}
+
+TEST(ConversionRunnerTest, ReportsFailedDecode)
+{
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+    auto ditherModes = std::make_shared<std::vector<DitherMode>>();
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"capture"_s, u"Capture"_s,
+                                      [ditherModes] { return std::make_unique<CapturingAudioEncoder>(ditherModes); });
+
+    Track track{outputDir.filePath(u"missing.wav"_s)};
+    track.setTitle(u"Missing"_s);
+    ConversionPreset preset;
+    preset.encoder.profile.id            = u"capture-wav"_s;
+    preset.encoder.profile.extension     = u"wav"_s;
+    preset.encoder.profile.containerName = u"wav"_s;
+    preset.encoder.profile.codecName     = u"capture"_s;
+    preset.destination.mode              = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder       = outputDir.path();
+    preset.destination.filenamePattern   = u"%title%"_s;
+    preset.destination.existingFileMode  = ExistingFileMode::Overwrite;
+
+    const QByteArray originalContents{"existing output"};
+    QFile existingOutput{outputDir.filePath(u"Missing.wav"_s)};
+    ASSERT_TRUE(existingOutput.open(QIODevice::WriteOnly));
+    ASSERT_EQ(existingOutput.write(originalContents), originalContents.size());
+    existingOutput.close();
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results.front().status, ConversionResultStatus::Failed);
+    EXPECT_FALSE(results.front().error.isEmpty());
+    EXPECT_TRUE(ditherModes->empty());
+    ASSERT_TRUE(existingOutput.open(QIODevice::ReadOnly));
+    EXPECT_EQ(existingOutput.readAll(), originalContents);
+}
+
+TEST(ConversionRunnerTest, CancelsAtTrackBoundary)
+{
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+    QFile existing{outputDir.filePath(u"First.wav"_s)};
+    ASSERT_TRUE(existing.open(QIODevice::WriteOnly));
+    existing.close();
+
+    AudioLoader loader;
+    auto ditherModes = std::make_shared<std::vector<DitherMode>>();
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"capture"_s, u"Capture"_s,
+                                      [ditherModes] { return std::make_unique<CapturingAudioEncoder>(ditherModes); });
+
+    Track first{outputDir.filePath(u"first-source.wav"_s)};
+    first.setTitle(u"First"_s);
+    Track second{outputDir.filePath(u"second-source.wav"_s)};
+    second.setTitle(u"Second"_s);
+    ConversionPreset preset;
+    preset.encoder.profile.id            = u"capture-wav"_s;
+    preset.encoder.profile.extension     = u"wav"_s;
+    preset.encoder.profile.containerName = u"wav"_s;
+    preset.encoder.profile.codecName     = u"capture"_s;
+    preset.destination.mode              = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder       = outputDir.path();
+    preset.destination.filenamePattern   = u"%title%"_s;
+    preset.destination.existingFileMode  = ExistingFileMode::Skip;
+
+    int cancellationChecks{0};
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {first, second};
+    request.job.preset      = preset;
+    request.cancelCallback  = [&cancellationChecks] {
+        return cancellationChecks++ > 0;
+    };
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0].status, ConversionResultStatus::Skipped);
+    EXPECT_EQ(results[1].status, ConversionResultStatus::Cancelled);
+    EXPECT_TRUE(ditherModes->empty());
+}
+
+TEST(ConversionRunnerTest, AppliesTrackReplayGainBeforeEncoding)
+{
+    const auto wavProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-wav"_s);
+    if(!wavProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+
+    AudioEncoderRegistry registry;
+    registry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    Track track{QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s)};
+    track.setTitle(u"ReplayGain Off"_s);
+    track.setRGTrackGain(-6.0F);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = wavProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &registry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto unprocessedResults = ConversionRunner::run(request);
+    ASSERT_EQ(unprocessedResults.size(), 1);
+    ASSERT_EQ(unprocessedResults.front().status, ConversionResultStatus::Succeeded)
+        << unprocessedResults.front().error.toStdString();
+    const double unprocessedPeak = decodedPeak(loader, unprocessedResults.front().outputPath);
+    ASSERT_GT(unprocessedPeak, 0.0);
+
+    track.setTitle(u"ReplayGain Track"_s);
+    request.job.tracks                                      = {track};
+    request.job.preset.processing.replayGainMode            = ConversionReplayGainMode::Track;
+    request.job.preset.processing.replayGainPreventClipping = false;
+
+    const auto processedResults = ConversionRunner::run(request);
+    ASSERT_EQ(processedResults.size(), 1);
+    ASSERT_EQ(processedResults.front().status, ConversionResultStatus::Succeeded)
+        << processedResults.front().error.toStdString();
+    const double processedPeak = decodedPeak(loader, processedResults.front().outputPath);
+    ASSERT_GT(processedPeak, 0.0);
+
+    EXPECT_NEAR(processedPeak / unprocessedPeak, std::pow(10.0, -6.0 / 20.0), 0.02);
+}
+
+TEST(ConversionRunnerTest, AppliesIndependentDspChainBeforeEncoding)
+{
+    const auto wavProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-wav"_s);
+    if(!wavProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+    DspRegistry dspRegistry;
+
+    Track track{QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s)};
+    track.setTitle(u"DSP Mono"_s);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = wavProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.processing.dspChain          = {{.id          = u"fooyin.dsp.downmixtomono"_s,
+                                            .name        = u"Downmix to mono"_s,
+                                            .hasSettings = false,
+                                            .enabled     = true,
+                                            .instanceId  = 1,
+                                            .settings    = {}}};
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.dspRegistry     = &dspRegistry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results.front().status, ConversionResultStatus::Succeeded) << results.front().error.toStdString();
+    EXPECT_EQ(audioChannelCount(results.front().outputPath), 1);
+}
+
+TEST(ConversionRunnerTest, ResolvesLossySourceDitherPerTrack)
+{
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+
+    auto ditherModes = std::make_shared<std::vector<DitherMode>>();
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"capture"_s, u"Capture"_s,
+                                      [ditherModes] { return std::make_unique<CapturingAudioEncoder>(ditherModes); });
+
+    const QString sourcePath
+        = QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s);
+    Track lossyTrack{sourcePath};
+    lossyTrack.setTitle(u"Lossy Source"_s);
+    lossyTrack.setEncoding(u"Lossy"_s);
+    Track losslessTrack{sourcePath};
+    losslessTrack.setTitle(u"Lossless Source"_s);
+    losslessTrack.setEncoding(u"Lossless"_s);
+
+    ConversionPreset preset;
+    preset.encoder.profile.id            = u"capture-wav"_s;
+    preset.encoder.profile.name          = u"Capture WAV"_s;
+    preset.encoder.profile.extension     = u"wav"_s;
+    preset.encoder.profile.containerName = u"wav"_s;
+    preset.encoder.profile.codecName     = u"capture"_s;
+    preset.encoder.outputSampleFormat    = SampleFormat::S16;
+    preset.encoder.ditherMode            = DitherMode::LossySourceOnly;
+    preset.destination.mode              = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder       = outputDir.path();
+    preset.destination.filenamePattern   = u"%title%"_s;
+    preset.destination.existingFileMode  = ExistingFileMode::Overwrite;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {lossyTrack, losslessTrack};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0].status, ConversionResultStatus::Succeeded);
+    EXPECT_EQ(results[1].status, ConversionResultStatus::Succeeded);
+    ASSERT_EQ(ditherModes->size(), 2);
+    EXPECT_EQ((*ditherModes)[0], DitherMode::Always);
+    EXPECT_EQ((*ditherModes)[1], DitherMode::Never);
+}
+
+TEST(ConversionRunnerTest, GeneratesPercentagePreview)
+{
+    const auto wavProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-wav"_s);
+    if(!wavProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    Track track{QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s)};
+    track.setTitle(u"Preview Output"_s);
+    track.setDuration(1835);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = wavProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.preview.enabled              = true;
+    preset.preview.lengthPercentage     = 20;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results.front().status, ConversionResultStatus::Succeeded) << results.front().error.toStdString();
+    EXPECT_NEAR(static_cast<double>(audioDurationMs(results.front().outputPath)), 367.0, 5.0);
+
+    track.setTitle(u"Unknown Duration"_s);
+    track.setDuration(0);
+    request.job.tracks       = {track};
+    const auto failedResults = ConversionRunner::run(request);
+    ASSERT_EQ(failedResults.size(), 1);
+    EXPECT_EQ(failedResults.front().status, ConversionResultStatus::Failed);
+    EXPECT_TRUE(failedResults.front().error.contains(u"duration"_s, Qt::CaseInsensitive));
+}
+
+TEST(ConversionRunnerTest, CopiesMatchingSidecarFiles)
+{
+    const auto wavProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-wav"_s);
+    if(!wavProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
+    }
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    const QDir root{tempDir.path()};
+    ASSERT_TRUE(root.mkpath(u"source"_s));
+    ASSERT_TRUE(root.mkpath(u"output"_s));
+
+    const QString fixture = QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s);
+    const QString sourcePath = root.filePath(u"source/input.wav"_s);
+    ASSERT_TRUE(QFile::copy(fixture, sourcePath));
+
+    QFile cover{root.filePath(u"source/cover.jpg"_s)};
+    ASSERT_TRUE(cover.open(QIODevice::WriteOnly));
+    ASSERT_EQ(cover.write("cover"), 5);
+    cover.close();
+    QFile notes{root.filePath(u"source/notes.txt"_s)};
+    ASSERT_TRUE(notes.open(QIODevice::WriteOnly));
+    ASSERT_EQ(notes.write("notes"), 5);
+    notes.close();
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+    loader.addReader(u"TagLib"_s, [] { return std::make_unique<TagLibReader>(); });
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    Track track{sourcePath};
+    track.setTitle(u"Converted"_s);
+    ConversionPreset preset;
+    preset.encoder.profile              = wavProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = root.filePath(u"output"_s);
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.other.copyFilesPattern       = u"*.jpg; *.log"_s;
+    preset.other.verifyOutput           = true;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results.front().status, ConversionResultStatus::Succeeded) << results.front().error.toStdString();
+    EXPECT_TRUE(QFileInfo::exists(root.filePath(u"output/cover.jpg"_s)));
+    EXPECT_FALSE(QFileInfo::exists(root.filePath(u"output/notes.txt"_s)));
+    EXPECT_TRUE(results.front().warnings.isEmpty());
+}
+
+TEST(ConversionRunnerTest, GeneratesGroupedMultiTrackOutputs)
+{
+    const auto flacProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-flac"_s);
+    if(!flacProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg FLAC encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+    loader.addReader(u"TagLib"_s, [] { return std::make_unique<TagLibReader>(); });
+
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    const QString sourcePath
+        = QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s);
+    Track first{sourcePath};
+    first.setTitle(u"First Track"_s);
+    first.setAlbum(u"Album A"_s);
+    first.setRating(1.0F);
+    first.setPlayCount(42);
+    Track second{sourcePath};
+    second.setTitle(u"Second Track"_s);
+    second.setAlbum(u"Album A"_s);
+    Track third{sourcePath};
+    third.setTitle(u"Third Track"_s);
+    third.setAlbum(u"Album B"_s);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = flacProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%album%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.destination.outputStyle      = OutputStyle::MultiTrackFiles;
+    preset.processing.transferPlaycount = true;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {first, second, third};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(results.size(), 3);
+    for(const auto& result : results) {
+        ASSERT_EQ(result.status, ConversionResultStatus::Succeeded) << result.error.toStdString();
+    }
+
+    EXPECT_EQ(results[0].outputPath, results[1].outputPath);
+    EXPECT_EQ(QFileInfo{results[0].outputPath}.fileName(), u"Album A.flac"_s);
+    EXPECT_EQ(QFileInfo{results[2].outputPath}.fileName(), u"Album B.flac"_s);
+    EXPECT_NE(results[0].outputPath, results[2].outputPath);
+    EXPECT_NEAR(static_cast<double>(audioDurationMs(results[0].outputPath)), 3669.0, 5.0);
+    EXPECT_NEAR(static_cast<double>(audioDurationMs(results[2].outputPath)), 1834.0, 5.0);
+    EXPECT_EQ(outputTitle(results[0].outputPath), u"First Track"_s);
+    EXPECT_EQ(outputTitle(results[2].outputPath), u"Third Track"_s);
+
+    Track groupedTrack{results[0].outputPath};
+    ASSERT_TRUE(loader.readTrackMetadata(groupedTrack));
+    EXPECT_LT(groupedTrack.rating(), 0.0F);
+    EXPECT_EQ(groupedTrack.playCount(), 0);
+}
+
+TEST(ConversionRunnerTest, PreservesDspStateAcrossCombinedOutputWhenRequested)
+{
+    const auto wavProfile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-wav"_s);
+    if(!wavProfile) {
+        GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
+    }
+
+    QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+
+    AudioLoader loader;
+    loader.addDecoder(u"FFmpeg"_s, [] { return std::make_unique<FFmpegDecoder>(); });
+
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"ffmpeg"_s, u"FFmpeg"_s, [] { return std::make_unique<FFmpegEncoder>(); });
+
+    auto factoryCount = std::make_shared<int>(0);
+    DspRegistry dspRegistry;
+    dspRegistry.registerDsp({.id = u"test.dsp.counting"_s, .name = u"Counting DSP"_s, .factory = [factoryCount] {
+                                 ++(*factoryCount);
+                                 return std::make_unique<CountingDsp>();
+                             }});
+
+    const QString sourcePath
+        = QDir{QString::fromLatin1(FOOYIN_TEST_SOURCE_DIR)}.filePath(u"data/audio/audiotest.wav"_s);
+    Track first{sourcePath};
+    first.setTitle(u"Counting DSP"_s);
+    Track second{sourcePath};
+    second.setTitle(u"Second Track"_s);
+
+    ConversionPreset preset;
+    preset.encoder.profile              = wavProfile->profile;
+    preset.encoder.outputSampleFormat   = SampleFormat::S16;
+    preset.destination.mode             = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder      = outputDir.path();
+    preset.destination.filenamePattern  = u"%title%"_s;
+    preset.destination.existingFileMode = ExistingFileMode::Overwrite;
+    preset.destination.outputStyle      = OutputStyle::MergeTracks;
+    preset.processing.dspChain          = {{.id          = u"test.dsp.counting"_s,
+                                            .name        = u"Counting DSP"_s,
+                                            .hasSettings = false,
+                                            .enabled     = true,
+                                            .instanceId  = 1,
+                                            .settings    = {}}};
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.dspRegistry     = &dspRegistry;
+    request.job.tracks      = {first, second};
+    request.job.preset      = preset;
+
+    const auto resetResults = ConversionRunner::run(request);
+    ASSERT_EQ(resetResults.size(), 2);
+    ASSERT_EQ(resetResults[0].status, ConversionResultStatus::Succeeded) << resetResults[0].error.toStdString();
+    ASSERT_EQ(resetResults[1].status, ConversionResultStatus::Succeeded) << resetResults[1].error.toStdString();
+    EXPECT_EQ(*factoryCount, 2);
+
+    *factoryCount                                               = 0;
+    request.job.preset.processing.preserveDspStateBetweenTracks = true;
+    const auto preservedResults                                 = ConversionRunner::run(request);
+    ASSERT_EQ(preservedResults.size(), 2);
+    ASSERT_EQ(preservedResults[0].status, ConversionResultStatus::Succeeded) << preservedResults[0].error.toStdString();
+    ASSERT_EQ(preservedResults[1].status, ConversionResultStatus::Succeeded) << preservedResults[1].error.toStdString();
+    EXPECT_EQ(*factoryCount, 1);
+}
+} // namespace Fooyin::Testing

--- a/tests/core/engine/ffmpegencodertest.cpp
+++ b/tests/core/engine/ffmpegencodertest.cpp
@@ -1,0 +1,347 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/engine/input/ffmpeg/ffmpegencoder.h>
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFileInfo>
+#include <QScopeGuard>
+#include <QTemporaryDir>
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <optional>
+#include <set>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Testing {
+
+namespace {
+
+bool hasEncoder(const QStringList& codecNames)
+{
+    for(const QString& codecName : codecNames) {
+        if(avcodec_find_encoder_by_name(codecName.toUtf8().constData())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool hasMuxer(const QString& containerName, const QString& extension)
+{
+    return av_guess_format(containerName.toUtf8().constData(), nullptr, extension.toUtf8().constData()) != nullptr;
+}
+
+bool hasProfile(const std::vector<AudioEncoderInfo>& profiles, const QString& id)
+{
+    return std::ranges::any_of(profiles, [&id](const AudioEncoderInfo& info) { return info.id == id; });
+}
+
+std::optional<AudioEncoderInfo> profileById(const std::vector<AudioEncoderInfo>& profiles, const QString& id)
+{
+    const auto it = std::ranges::find_if(profiles, [&id](const AudioEncoderInfo& info) { return info.id == id; });
+    if(it == profiles.end()) {
+        return {};
+    }
+    return *it;
+}
+
+AudioBuffer makeSineBuffer()
+{
+    constexpr int SampleRate = 44100;
+    constexpr int Channels   = 2;
+    constexpr int Frames     = SampleRate / 10;
+
+    AudioFormat format{SampleFormat::S16, SampleRate, Channels};
+    std::vector<int16_t> samples(Frames * Channels);
+    for(int frame{0}; frame < Frames; ++frame) {
+        const double phase = (static_cast<double>(frame) * 440.0 * 2.0 * 3.14159265358979323846) / SampleRate;
+        const auto sample  = static_cast<int16_t>(std::sin(phase) * 12000.0);
+        samples[static_cast<size_t>(frame * Channels)]     = sample;
+        samples[static_cast<size_t>(frame * Channels + 1)] = sample;
+    }
+
+    return {reinterpret_cast<const uint8_t*>(samples.data()), samples.size() * sizeof(int16_t), format, 0};
+}
+
+bool outputHasAudioStream(const QString& path, AVCodecID expectedCodec, int expectedSampleRate,
+                          int expectedBitsPerSample = 0)
+{
+    AVFormatContext* context{nullptr};
+    if(avformat_open_input(&context, path.toLocal8Bit().constData(), nullptr, nullptr) < 0) {
+        return false;
+    }
+
+    const auto close = qScopeGuard([&context] { avformat_close_input(&context); });
+
+    if(avformat_find_stream_info(context, nullptr) < 0) {
+        return false;
+    }
+
+    for(unsigned i{0}; i < context->nb_streams; ++i) {
+        const AVCodecParameters* params = context->streams[i]->codecpar;
+        if(params->codec_type != AVMEDIA_TYPE_AUDIO || params->codec_id != expectedCodec) {
+            continue;
+        }
+        if(expectedBitsPerSample > 0
+           && std::max(params->bits_per_raw_sample, params->bits_per_coded_sample) != expectedBitsPerSample) {
+            return false;
+        }
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
+        return params->sample_rate == expectedSampleRate && params->channels == 2;
+#else
+        return params->sample_rate == expectedSampleRate && params->ch_layout.nb_channels == 2;
+#endif
+    }
+
+    return false;
+}
+
+void encodeSmokeTest(const QString& profileId, AVCodecID expectedCodec, int bitrateKbps = 0, int compressionLevel = -1,
+                     int expectedSampleRate = 44100, SampleFormat sampleFormat = SampleFormat::S16,
+                     int expectedBitsPerSample = 0, EncoderMode mode = EncoderMode::Default, double quality = 2.0)
+{
+    const auto profile = profileById(FFmpegEncoder{}.availableEncoders(), profileId);
+    if(!profile) {
+        GTEST_SKIP() << "Runtime FFmpeg profile is unavailable";
+    }
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    const QString outputPath = QDir{dir.path()}.filePath(u"encoded.%1"_s.arg(profile->profile.extension));
+    AudioEncoderSettings settings;
+    settings.profile            = profile->profile;
+    settings.outputSampleFormat = sampleFormat;
+    if(bitrateKbps > 0) {
+        settings.profile.bitrateKbps = bitrateKbps;
+    }
+    if(compressionLevel >= 0) {
+        settings.profile.compressionLevel = compressionLevel;
+    }
+    if(mode != EncoderMode::Default) {
+        settings.profile.mode = mode;
+    }
+    settings.profile.quality = quality;
+
+    FFmpegEncoder encoder;
+    auto result = encoder.init(outputPath, makeSineBuffer().format(), settings);
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    result = encoder.write(makeSineBuffer());
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    result = encoder.finish();
+    ASSERT_TRUE(result.ok) << result.error.toStdString();
+
+    EXPECT_TRUE(QFileInfo::exists(outputPath));
+    EXPECT_GT(QFileInfo{outputPath}.size(), 0);
+    EXPECT_TRUE(outputHasAudioStream(outputPath, expectedCodec, expectedSampleRate, expectedBitsPerSample));
+}
+
+} // namespace
+
+TEST(FFmpegEncoderTest, ListsOnlyProfilesWithRuntimeEncoderAndMuxer)
+{
+    const auto profiles = FFmpegEncoder{}.availableEncoders();
+
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-wav"_s), hasEncoder({u"pcm_s16le"_s}) && hasMuxer(u"wav"_s, u"wav"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-flac"_s), hasEncoder({u"flac"_s}) && hasMuxer(u"flac"_s, u"flac"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-alac"_s), hasEncoder({u"alac"_s}) && hasMuxer(u"ipod"_s, u"m4a"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-wavpack"_s), hasEncoder({u"wavpack"_s}) && hasMuxer(u"wv"_s, u"wv"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-mp3"_s),
+              hasEncoder({u"libmp3lame"_s, u"mp3"_s}) && hasMuxer(u"mp3"_s, u"mp3"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-aac"_s), hasEncoder({u"aac"_s}) && hasMuxer(u"ipod"_s, u"m4a"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-vorbis"_s), hasEncoder({u"libvorbis"_s}) && hasMuxer(u"ogg"_s, u"ogg"_s));
+    EXPECT_EQ(hasProfile(profiles, u"ffmpeg-opus"_s),
+              hasEncoder({u"libopus"_s, u"opus"_s}) && hasMuxer(u"ogg"_s, u"opus"_s));
+}
+
+TEST(FFmpegEncoderTest, ProfileIdsAreUniqueAndComplete)
+{
+    const auto profiles = FFmpegEncoder{}.availableEncoders();
+    std::set<QString> ids;
+
+    for(const AudioEncoderInfo& info : profiles) {
+        EXPECT_FALSE(info.id.isEmpty());
+        EXPECT_FALSE(info.backendId.isEmpty());
+        EXPECT_FALSE(info.name.isEmpty());
+        EXPECT_FALSE(info.profile.id.isEmpty());
+        EXPECT_FALSE(info.profile.extension.isEmpty());
+        EXPECT_FALSE(info.profile.containerName.isEmpty());
+        EXPECT_FALSE(info.profile.codecName.isEmpty());
+        EXPECT_TRUE(ids.insert(info.id).second);
+    }
+}
+
+TEST(FFmpegEncoderTest, Mp3AdvertisesGenericRateControlCapabilities)
+{
+    const auto profile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-mp3"_s);
+    if(!profile) {
+        GTEST_SKIP() << "Runtime FFmpeg MP3 encoder is unavailable";
+    }
+
+    EXPECT_EQ(profile->capabilities.modes,
+              (std::vector{EncoderMode::ConstantQuality, EncoderMode::AverageBitrate, EncoderMode::ConstantBitrate}));
+    EXPECT_TRUE(profile->capabilities.quality.isValid());
+    EXPECT_TRUE(profile->capabilities.bitrateKbps.isValid());
+    EXPECT_TRUE(profile->capabilities.compressionLevel.isValid());
+    ASSERT_TRUE(profile->estimateBitrateKbps);
+
+    EncoderProfile encoderProfile = profile->profile;
+    encoderProfile.quality        = 0.0;
+    EXPECT_EQ(profile->estimateBitrateKbps(encoderProfile), 245);
+    encoderProfile.quality = 2.0;
+    EXPECT_EQ(profile->estimateBitrateKbps(encoderProfile), 190);
+    encoderProfile.quality = 9.0;
+    EXPECT_EQ(profile->estimateBitrateKbps(encoderProfile), 65);
+}
+
+TEST(FFmpegEncoderTest, EncodesWav)
+{
+    encodeSmokeTest(u"ffmpeg-wav"_s, AV_CODEC_ID_PCM_S16LE);
+}
+
+TEST(FFmpegEncoderTest, EncodesFlac)
+{
+    encodeSmokeTest(u"ffmpeg-flac"_s, AV_CODEC_ID_FLAC, 0, 12);
+}
+
+TEST(FFmpegEncoderTest, EncodesAlac)
+{
+    encodeSmokeTest(u"ffmpeg-alac"_s, AV_CODEC_ID_ALAC);
+}
+
+TEST(FFmpegEncoderTest, EncodesWavPack)
+{
+    encodeSmokeTest(u"ffmpeg-wavpack"_s, AV_CODEC_ID_WAVPACK, 0, 8);
+}
+
+TEST(FFmpegEncoderTest, Encodes24BitWav)
+{
+    if(!hasEncoder({u"pcm_s24le"_s})) {
+        GTEST_SKIP() << "Runtime FFmpeg 24-bit PCM encoder is unavailable";
+    }
+    encodeSmokeTest(u"ffmpeg-wav"_s, AV_CODEC_ID_PCM_S24LE, 0, -1, 44100, SampleFormat::S24In32, 24);
+}
+
+TEST(FFmpegEncoderTest, EncodesRequestedWavSampleFormats)
+{
+    struct FormatCase
+    {
+        QString codecName;
+        AVCodecID codecId;
+        SampleFormat sampleFormat;
+        int bitsPerSample;
+    };
+    const std::array cases{
+        FormatCase{u"pcm_u8"_s, AV_CODEC_ID_PCM_U8, SampleFormat::U8, 8},
+        FormatCase{u"pcm_s32le"_s, AV_CODEC_ID_PCM_S32LE, SampleFormat::S32, 32},
+        FormatCase{u"pcm_f32le"_s, AV_CODEC_ID_PCM_F32LE, SampleFormat::F32, 32},
+    };
+
+    for(const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.codecName.toStdString());
+        if(!hasEncoder({testCase.codecName})) {
+            continue;
+        }
+        encodeSmokeTest(u"ffmpeg-wav"_s, testCase.codecId, 0, -1, 44100, testCase.sampleFormat, testCase.bitsPerSample);
+    }
+}
+
+TEST(FFmpegEncoderTest, Encodes24BitFlac)
+{
+    encodeSmokeTest(u"ffmpeg-flac"_s, AV_CODEC_ID_FLAC, 0, 5, 44100, SampleFormat::S24In32, 24);
+}
+
+TEST(FFmpegEncoderTest, RejectsUnsupportedExplicitSampleFormat)
+{
+    const auto profile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-flac"_s);
+    if(!profile) {
+        GTEST_SKIP() << "Runtime FFmpeg FLAC encoder is unavailable";
+    }
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    AudioEncoderSettings settings;
+    settings.profile            = profile->profile;
+    settings.outputSampleFormat = SampleFormat::F32;
+
+    FFmpegEncoder encoder;
+    const auto result
+        = encoder.init(QDir{dir.path()}.filePath(u"unsupported.flac"_s), makeSineBuffer().format(), settings);
+    EXPECT_FALSE(result.ok);
+    EXPECT_TRUE(result.error.contains(u"unsupported"_s, Qt::CaseInsensitive));
+}
+
+TEST(FFmpegEncoderTest, EncodesMp3InSupportedRateControlModes)
+{
+    encodeSmokeTest(u"ffmpeg-mp3"_s, AV_CODEC_ID_MP3, 224, 2, 44100, SampleFormat::S16, 0,
+                    EncoderMode::ConstantBitrate);
+    encodeSmokeTest(u"ffmpeg-mp3"_s, AV_CODEC_ID_MP3, 192, 2, 44100, SampleFormat::S16, 0, EncoderMode::AverageBitrate);
+    encodeSmokeTest(u"ffmpeg-mp3"_s, AV_CODEC_ID_MP3, 0, 2, 44100, SampleFormat::S16, 0, EncoderMode::ConstantQuality,
+                    2.0);
+}
+
+TEST(FFmpegEncoderTest, EncodesAacInSupportedRateControlModes)
+{
+    const auto profile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-aac"_s);
+    if(!profile) {
+        GTEST_SKIP() << "Runtime FFmpeg AAC encoder is unavailable";
+    }
+
+    encodeSmokeTest(u"ffmpeg-aac"_s, AV_CODEC_ID_AAC, 256, -1, 44100, SampleFormat::Unknown, 0,
+                    EncoderMode::ConstantBitrate);
+    encodeSmokeTest(u"ffmpeg-aac"_s, AV_CODEC_ID_AAC, 0, -1, 44100, SampleFormat::Unknown, 0,
+                    EncoderMode::ConstantQuality, 2.0);
+}
+
+TEST(FFmpegEncoderTest, EncodesVorbis)
+{
+    encodeSmokeTest(u"ffmpeg-vorbis"_s, AV_CODEC_ID_VORBIS, 0, -1, 44100, SampleFormat::Unknown, 0,
+                    EncoderMode::ConstantQuality, 5.0);
+}
+
+TEST(FFmpegEncoderTest, EncodesOpusInAdvertisedBitrateModes)
+{
+    const auto profile = profileById(FFmpegEncoder{}.availableEncoders(), u"ffmpeg-opus"_s);
+    if(!profile) {
+        GTEST_SKIP() << "Runtime FFmpeg Opus encoder is unavailable";
+    }
+
+    for(const EncoderMode mode : profile->capabilities.modes) {
+        SCOPED_TRACE(static_cast<int>(mode));
+        encodeSmokeTest(u"ffmpeg-opus"_s, AV_CODEC_ID_OPUS, 160, -1, 48000, SampleFormat::S16, 0, mode);
+    }
+}
+
+} // namespace Fooyin::Testing


### PR DESCRIPTION
Add an audio converter with FFmpeg-backed encoder profiles, reusable presets, ReplayGain/DSP processing and output verification.

<img width="908" height="650" alt="image" src="https://github.com/user-attachments/assets/6938c43c-8ce6-4a09-a372-47c5452fb1f0" />
<img width="908" height="650" alt="image" src="https://github.com/user-attachments/assets/54fca7cc-1059-4888-a657-a23947114be5" />
<img width="908" height="650" alt="image" src="https://github.com/user-attachments/assets/f8251cd2-32b9-498d-9491-66916612f8f0" />
<img width="908" height="650" alt="image" src="https://github.com/user-attachments/assets/fe8dc20c-b9c5-4f02-954b-a3817ec2305d" />
