### PR TITLE
Add `ENABLE_SYSTEM_GLM` CMake's option for using system GLM package i…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ or comma-separated list to build only those plugins, or prefix names with '-' to
 )
 fooyin_option(BUILD_ALSA "Build ALSA plugin" ON)
 fooyin_option(FETCH_PROJECTM "Fetch projectM when a system package is unavailable" OFF)
+fooyin_option(ENABLE_SYSTEM_GLM "Use system GLM package for fetched projectM" OFF)
 fooyin_option(BUILD_TRANSLATIONS "Build translation files" ON)
 fooyin_option(BUILD_CCACHE "Build using CCache if found" ON)
 fooyin_option(BUILD_PCH "Build with precompiled header support" OFF)


### PR DESCRIPTION
…n fetched projectM

GLM library in projectM is "slightly" outdated (version [0.9.9.0](https://github.com/g-truc/glm/releases/tag/0.9.9.0) was released May 22, 2018).
I've tested this PR with glm-git (version 1.1.0).
You might also want to update GLM in your builds. :)