### PR TITLE
[sleepinhibitor] Support display idle inhibition

### DIFF
--- a/src/plugins/sleepinhibitor/inhibitor.cpp
+++ b/src/plugins/sleepinhibitor/inhibitor.cpp
@@ -53,9 +53,9 @@ Inhibitor::Inhibitor(QObject* parent)
     , p{new InhibitorPlatform(this)}
 { }
 
-void Inhibitor::inhibitSleep()
+void Inhibitor::inhibitSleep(InhibitionType type)
 {
-    p->inhibitSleep();
+    p->inhibitSleep(type);
 }
 
 void Inhibitor::uninhibitSleep()

--- a/src/plugins/sleepinhibitor/inhibitor.h
+++ b/src/plugins/sleepinhibitor/inhibitor.h
@@ -41,8 +41,10 @@ public:
     {
         Initializing,
         Error,
-        Uninhibited,
+        Inhibiting,
+        Uninhibiting,
         Inhibited,
+        Uninhibited,
     };
 
     explicit InhibitorPrivate(QObject* parent = nullptr);

--- a/src/plugins/sleepinhibitor/inhibitor.h
+++ b/src/plugins/sleepinhibitor/inhibitor.h
@@ -26,6 +26,12 @@
 Q_DECLARE_LOGGING_CATEGORY(SLEEPINHIBITOR)
 
 namespace Fooyin::SleepInhibitor {
+enum class InhibitionType : uint8_t
+{
+    System,
+    DisplayAndSystem,
+};
+
 class InhibitorPrivate : public QObject
 {
     Q_OBJECT
@@ -51,8 +57,8 @@ public:
         m_state = state;
     }
 
-    virtual void inhibitSleep()   = 0;
-    virtual void uninhibitSleep() = 0;
+    virtual void inhibitSleep(InhibitionType type) = 0;
+    virtual void uninhibitSleep()                  = 0;
 
 private:
     State m_state{State::Initializing};
@@ -65,7 +71,7 @@ class Inhibitor : public QObject
 public:
     explicit Inhibitor(QObject* parent = nullptr);
 
-    void inhibitSleep();
+    void inhibitSleep(InhibitionType type);
     void uninhibitSleep();
 
 private:

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
@@ -87,16 +87,23 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
 
 void InhibitorDbus::inhibitScreenSaver()
 {
-    if(m_screenSaverError) {
+    m_screenSaverState.desiredState = State::Inhibited;
+
+    if(m_screenSaverState.currentState != State::Initializing
+       && m_screenSaverState.currentState != State::Uninhibited) {
         return;
     }
+
+    qCDebug(SLEEPINHIBITOR) << "Inhibiting ScreenSaver";
+    m_screenSaverState.currentState = State::Uninhibiting;
 
     if(!m_screenSaverInterface) {
         m_screenSaverInterface = new QDBusInterface(
             DbusConstants::FreedesktopScreenSaverService, DbusConstants::FreedesktopScreenSaverPath,
             DbusConstants::FreedesktopScreenSaverInterface, QDBusConnection::sessionBus(), this);
         if(!m_screenSaverInterface->isValid()) [[unlikely]] {
-            m_screenSaverError = true;
+            qCWarning(SLEEPINHIBITOR) << "Could not get usable ScreenSaver D-Bus interface";
+            m_screenSaverState.currentState = State::Error;
             return;
         }
     }
@@ -109,9 +116,14 @@ void InhibitorDbus::inhibitScreenSaver()
 
 void InhibitorDbus::uninhibitScreenSaver()
 {
-    if(m_screenSaverError || !m_screenSaverInhibitCookie) {
+    m_screenSaverState.desiredState = State::Uninhibited;
+
+    if(m_screenSaverState.currentState != State::Uninhibited || !m_screenSaverInhibitCookie) {
         return;
     }
+
+    qCDebug(SLEEPINHIBITOR) << "Uninhibiting ScreenSaver";
+    m_screenSaverState.currentState = State::Uninhibiting;
 
     const auto pendingCall = m_screenSaverInterface->asyncCall("UnInhibit"_L1, m_screenSaverInhibitCookie);
     auto* watcher          = new QDBusPendingCallWatcher(pendingCall, this);
@@ -125,11 +137,17 @@ void InhibitorDbus::onScreenSaverInhibitCallFinished(QDBusPendingCallWatcher* wa
     watcher->deleteLater();
 
     if(reply.isValid()) {
-        m_screenSaverInhibitCookie = reply.value();
+        m_screenSaverInhibitCookie      = reply.value();
+        m_screenSaverState.currentState = State::Inhibited;
     }
     else {
         qCWarning(SLEEPINHIBITOR) << "ScreenSaver Inhibit call error:" << reply.error().message();
-        m_screenSaverError = true;
+        m_screenSaverState.currentState = State::Error;
+    }
+
+    if(m_screenSaverState.desiredState == State::Uninhibited) {
+        uninhibitScreenSaver();
+        m_screenSaverState.desiredState = {};
     }
 }
 
@@ -139,24 +157,31 @@ void InhibitorDbus::onScreenSaverUninhibitCallFinished(QDBusPendingCallWatcher* 
     watcher->deleteLater();
 
     if(reply.isValid()) {
-        m_screenSaverInhibitCookie = 0;
+        m_screenSaverInhibitCookie      = 0;
+        m_screenSaverState.currentState = State::Uninhibited;
     }
     else {
         qCWarning(SLEEPINHIBITOR) << "ScreenSaver Uninhibit call error:" << reply.error().message();
-        m_screenSaverError = true;
+        m_screenSaverState.currentState = State::Error;
+    }
+
+    if(m_screenSaverState.desiredState == State::Inhibited) {
+        inhibitScreenSaver();
+        m_screenSaverState.desiredState = {};
     }
 }
 
 void InhibitorDbus::inhibitSleep(InhibitionType type)
 {
-    m_desiredState = State::Inhibited;
-    m_desiredType  = type;
+    m_powerState.desiredState = State::Inhibited;
+    m_powerState.desiredType  = type;
 
-    if(state() == State::Error || state() == State::Inhibited) {
+    if(state() != State::Initializing && state() != State::Uninhibited) {
         return;
     }
 
     qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
+    setState(State::Inhibiting);
 
     static constexpr auto BlockLogoutFlag  = 1U;
     static constexpr auto BlockSuspendFlag = 4U;
@@ -196,18 +221,19 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
     QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, &InhibitorDbus::onInhibitCallFinished);
 
-    m_currentType = type;
+    m_powerState.currentType = type;
 }
 
 void InhibitorDbus::uninhibitSleep()
 {
-    m_desiredState = State::Uninhibited;
+    m_powerState.desiredState = State::Uninhibited;
 
     if(state() != State::Inhibited) {
         return;
     }
 
     qCDebug(SLEEPINHIBITOR) << "Uninhibiting sleep";
+    setState(State::Uninhibiting);
 
     if(m_interface == Interface::FreedesktopPortal) {
         auto* inhibitRequestInterface
@@ -233,7 +259,7 @@ void InhibitorDbus::uninhibitSleep()
             return;
         }
 
-        if(m_interface == Interface::FreedesktopPower && m_currentType == InhibitionType::DisplayAndSystem) {
+        if(m_interface == Interface::FreedesktopPower && m_powerState.currentType == InhibitionType::DisplayAndSystem) {
             uninhibitScreenSaver();
         }
 
@@ -243,7 +269,7 @@ void InhibitorDbus::uninhibitSleep()
         QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, &InhibitorDbus::onUninhibitCallFinished);
     }
 
-    m_currentType = {};
+    m_powerState.currentType = {};
 }
 
 void InhibitorDbus::onInhibitCallFinished(QDBusPendingCallWatcher* watcher)
@@ -270,9 +296,9 @@ void InhibitorDbus::onInhibitCallFinished(QDBusPendingCallWatcher* watcher)
         handleReply(reply, m_inhibitCookie);
     }
 
-    if(m_desiredState == State::Uninhibited) {
+    if(m_powerState.desiredState == State::Uninhibited) {
         uninhibitSleep();
-        m_desiredState = {};
+        m_powerState.desiredState = {};
     }
 }
 
@@ -291,9 +317,9 @@ void InhibitorDbus::onUninhibitCallFinished(QDBusPendingCallWatcher* watcher)
         setState(State::Error);
     }
 
-    if(m_desiredState == State::Inhibited) {
-        inhibitSleep(m_desiredType);
-        m_desiredState = {};
+    if(m_powerState.desiredState == State::Inhibited) {
+        inhibitSleep(m_powerState.desiredType);
+        m_powerState.desiredState = {};
     }
 }
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
@@ -45,6 +45,15 @@ constexpr auto FreedesktopScreenSaverPath      = "/org/freedesktop/ScreenSaver"_
 constexpr auto FreedesktopScreenSaverInterface = "org.freedesktop.ScreenSaver"_L1;
 } // namespace DbusConstants
 
+namespace {
+using namespace Fooyin::SleepInhibitor;
+bool canInhibit(InhibitorPrivate::State state)
+{
+    using enum InhibitorPrivate::State;
+    return state == Initializing || state == Uninhibited;
+}
+} // namespace
+
 namespace Fooyin::SleepInhibitor {
 static const auto Reason = InhibitorDbus::tr("fooyin is running");
 
@@ -85,12 +94,18 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
     qCWarning(SLEEPINHIBITOR) << "Could not get usable D-Bus interface";
 }
 
+bool InhibitorDbus::usingScreenSaverInterface() const
+{
+    return m_interface == Interface::FreedesktopPower
+        && (m_powerState.desiredType == InhibitionType::DisplayAndSystem
+            || m_powerState.currentType == InhibitionType::DisplayAndSystem);
+}
+
 void InhibitorDbus::inhibitScreenSaver()
 {
     m_screenSaverState.desiredState = State::Inhibited;
 
-    if(m_screenSaverState.currentState != State::Initializing
-       && m_screenSaverState.currentState != State::Uninhibited) {
+    if(!canInhibit(m_screenSaverState.currentState)) {
         return;
     }
 
@@ -118,7 +133,7 @@ void InhibitorDbus::uninhibitScreenSaver()
 {
     m_screenSaverState.desiredState = State::Uninhibited;
 
-    if(m_screenSaverState.currentState != State::Uninhibited || !m_screenSaverInhibitCookie) {
+    if(m_screenSaverState.currentState != State::Inhibited || !m_screenSaverInhibitCookie) {
         return;
     }
 
@@ -176,7 +191,11 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
     m_powerState.desiredState = State::Inhibited;
     m_powerState.desiredType  = type;
 
-    if(state() != State::Initializing && state() != State::Uninhibited) {
+    if(usingScreenSaverInterface()) {
+        inhibitScreenSaver();
+    }
+
+    if(!canInhibit(state())) {
         return;
     }
 
@@ -190,9 +209,6 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
     auto flags = BlockLogoutFlag | BlockSuspendFlag;
     if(type == InhibitionType::DisplayAndSystem) {
         flags |= BlockIdleFlag;
-        if(m_interface == Interface::FreedesktopPower) {
-            inhibitScreenSaver();
-        }
     }
 
     QList<QVariant> args;
@@ -228,6 +244,10 @@ void InhibitorDbus::uninhibitSleep()
 {
     m_powerState.desiredState = State::Uninhibited;
 
+    if(m_screenSaverState.currentState == State::Inhibited && usingScreenSaverInterface()) {
+        uninhibitScreenSaver();
+    }
+
     if(state() != State::Inhibited) {
         return;
     }
@@ -257,10 +277,6 @@ void InhibitorDbus::uninhibitSleep()
             qCWarning(SLEEPINHIBITOR) << "Cookie is 0?";
             setState(State::Error);
             return;
-        }
-
-        if(m_interface == Interface::FreedesktopPower && m_powerState.currentType == InhibitionType::DisplayAndSystem) {
-            uninhibitScreenSaver();
         }
 
         const auto pendingCall = m_busInterface->asyncCall(

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
@@ -46,10 +46,6 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
 {
     using namespace DbusConstants;
 
-    const auto invalidateBusInterface = [this] {
-        delete m_busInterface;
-    };
-
     m_busInterface = new QDBusInterface(GnomeSessionManagerService, GnomeSessionManagerPath,
                                         GnomeSessionManagerInterface, QDBusConnection::sessionBus(), this);
     if(m_busInterface->isValid()) {
@@ -58,7 +54,7 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
         return;
     }
 
-    invalidateBusInterface();
+    delete m_busInterface;
     m_busInterface = new QDBusInterface(FreedesktopPowerMgmtService, FreedesktopPowerMgmtPath,
                                         FreedesktopPowerMgmtInterface, QDBusConnection::sessionBus(), this);
     if(m_busInterface->isValid()) {
@@ -67,7 +63,7 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
         return;
     }
 
-    invalidateBusInterface();
+    delete m_busInterface;
     m_busInterface = new QDBusInterface(FreedesktopPortalService, FreedesktopPortalPath, FreedesktopPortalInterface,
                                         QDBusConnection::sessionBus(), this);
     if(m_busInterface->isValid()) {
@@ -76,22 +72,39 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
         return;
     }
 
-    invalidateBusInterface();
+    delete m_busInterface;
+    m_busInterface = nullptr;
     setState(State::Error);
-    qCWarning(SLEEPINHIBITOR) << "Could not get usable DBus interface";
+    qCWarning(SLEEPINHIBITOR) << "Could not get usable D-Bus interface";
 }
 
-void InhibitorDbus::inhibitSleep()
+void InhibitorDbus::inhibitSleep(InhibitionType type)
 {
+    if(m_interface == Interface::FreedesktopPower && type == InhibitionType::DisplayAndSystem) {
+        // TODO: Support org.freedesktop.ScreenSaver
+        qCWarning(SLEEPINHIBITOR) << "Freedesktop power interface does not support display idle inhibition. Switching "
+                                     "to system idle inhibition.";
+        type = InhibitionType::System;
+    }
+
+    m_desiredState = State::Inhibited;
+    m_desiredType  = type;
+
     if(state() == State::Error || state() == State::Inhibited) {
         return;
     }
 
     qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
 
+    static const auto Reason               = tr("fooyin is running");
     static constexpr auto BlockLogoutFlag  = 1U;
     static constexpr auto BlockSuspendFlag = 4U;
-    static const auto Reason               = tr("fooyin is running");
+    static constexpr auto BlockIdleFlag    = 8U;
+
+    auto flags = BlockLogoutFlag | BlockSuspendFlag;
+    if(type == InhibitionType::DisplayAndSystem) {
+        flags |= BlockIdleFlag;
+    }
 
     QList<QVariant> args;
     switch(m_interface) {
@@ -99,7 +112,7 @@ void InhibitorDbus::inhibitSleep()
             break;
         case Interface::GnomeSessionManager: {
             static constexpr auto XWindowId = 0U;
-            args = {"org.fooyin.fooyin"_L1, XWindowId, Reason, BlockLogoutFlag | BlockSuspendFlag};
+            args                            = {"org.fooyin.fooyin"_L1, XWindowId, Reason, flags};
             break;
         }
         case Interface::FreedesktopPower:
@@ -110,7 +123,7 @@ void InhibitorDbus::inhibitSleep()
             options["reason"_L1] = Reason;
             // Pass empty string for parent_window
             // https://flatpak.github.io/xdg-desktop-portal/docs/window-identifiers.html
-            args = {QString{}, BlockLogoutFlag | BlockSuspendFlag, options};
+            args = {QString{}, flags, options};
             break;
         }
     }
@@ -122,6 +135,8 @@ void InhibitorDbus::inhibitSleep()
 
 void InhibitorDbus::uninhibitSleep()
 {
+    m_desiredState = State::Uninhibited;
+
     if(state() != State::Inhibited) {
         return;
     }
@@ -182,6 +197,11 @@ void InhibitorDbus::onInhibitCallFinished(QDBusPendingCallWatcher* watcher)
         const QDBusPendingReply<uint> reply = *watcher;
         handleReply(reply, m_inhibitCookie);
     }
+
+    if(m_desiredState == State::Uninhibited) {
+        uninhibitSleep();
+        m_desiredState = {};
+    }
 }
 
 void InhibitorDbus::onUninhibitCallFinished(QDBusPendingCallWatcher* watcher)
@@ -197,6 +217,11 @@ void InhibitorDbus::onUninhibitCallFinished(QDBusPendingCallWatcher* watcher)
     else {
         qCWarning(SLEEPINHIBITOR) << "Uninhibit call error:" << reply.error().message();
         setState(State::Error);
+    }
+
+    if(m_desiredState == State::Inhibited) {
+        inhibitSleep(m_desiredType);
+        m_desiredState = {};
     }
 }
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "inhibitordbus.h"
+#include "inhibitor.h"
 
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusPendingCall>
@@ -38,9 +39,15 @@ constexpr auto FreedesktopPowerMgmtInterface = "org.freedesktop.PowerManagement.
 constexpr auto FreedesktopPortalService   = "org.freedesktop.portal.Desktop"_L1;
 constexpr auto FreedesktopPortalPath      = "/org/freedesktop/portal/desktop"_L1;
 constexpr auto FreedesktopPortalInterface = "org.freedesktop.portal.Inhibit"_L1;
+
+constexpr auto FreedesktopScreenSaverService   = "org.freedesktop.ScreenSaver"_L1;
+constexpr auto FreedesktopScreenSaverPath      = "/org/freedesktop/ScreenSaver"_L1;
+constexpr auto FreedesktopScreenSaverInterface = "org.freedesktop.ScreenSaver"_L1;
 } // namespace DbusConstants
 
 namespace Fooyin::SleepInhibitor {
+static const auto Reason = InhibitorDbus::tr("fooyin is running");
+
 InhibitorDbus::InhibitorDbus(QObject* parent)
     : InhibitorPrivate{parent}
 {
@@ -78,15 +85,70 @@ InhibitorDbus::InhibitorDbus(QObject* parent)
     qCWarning(SLEEPINHIBITOR) << "Could not get usable D-Bus interface";
 }
 
-void InhibitorDbus::inhibitSleep(InhibitionType type)
+void InhibitorDbus::inhibitScreenSaver()
 {
-    if(m_interface == Interface::FreedesktopPower && type == InhibitionType::DisplayAndSystem) {
-        // TODO: Support org.freedesktop.ScreenSaver
-        qCWarning(SLEEPINHIBITOR) << "Freedesktop power interface does not support display idle inhibition. Switching "
-                                     "to system idle inhibition.";
-        type = InhibitionType::System;
+    if(m_screenSaverError) {
+        return;
     }
 
+    if(!m_screenSaverInterface) {
+        m_screenSaverInterface = new QDBusInterface(
+            DbusConstants::FreedesktopScreenSaverService, DbusConstants::FreedesktopScreenSaverPath,
+            DbusConstants::FreedesktopScreenSaverInterface, QDBusConnection::sessionBus());
+        if(!m_screenSaverInterface->isValid()) [[unlikely]] {
+            m_screenSaverError = true;
+            return;
+        }
+    }
+
+    const auto pendingCall = m_screenSaverInterface->asyncCall("Inhibit"_L1, "fooyin"_L1, Reason);
+    auto* watcher          = new QDBusPendingCallWatcher(pendingCall, this);
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                     &InhibitorDbus::onScreenSaverInhibitCallFinished);
+}
+
+void InhibitorDbus::uninhibitScreenSaver()
+{
+    if(m_screenSaverError || !m_screenSaverInhibitCookie) {
+        return;
+    }
+
+    const auto pendingCall = m_screenSaverInterface->asyncCall("UnInhibit"_L1, m_screenSaverInhibitCookie);
+    auto* watcher          = new QDBusPendingCallWatcher(pendingCall, this);
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                     &InhibitorDbus::onScreenSaverUninhibitCallFinished);
+}
+
+void InhibitorDbus::onScreenSaverInhibitCallFinished(QDBusPendingCallWatcher* watcher)
+{
+    const QDBusPendingReply<uint> reply = *watcher;
+    watcher->deleteLater();
+
+    if(reply.isValid()) {
+        m_screenSaverInhibitCookie = reply.value();
+    }
+    else {
+        qCWarning(SLEEPINHIBITOR) << "ScreenSaver Inhibit call error:" << reply.error().message();
+        m_screenSaverError = true;
+    }
+}
+
+void InhibitorDbus::onScreenSaverUninhibitCallFinished(QDBusPendingCallWatcher* watcher)
+{
+    const QDBusPendingReply<> reply = *watcher;
+    watcher->deleteLater();
+
+    if(reply.isValid()) {
+        m_screenSaverInhibitCookie = 0;
+    }
+    else {
+        qCWarning(SLEEPINHIBITOR) << "ScreenSaver Uninhibit call error:" << reply.error().message();
+        m_screenSaverError = true;
+    }
+}
+
+void InhibitorDbus::inhibitSleep(InhibitionType type)
+{
     m_desiredState = State::Inhibited;
     m_desiredType  = type;
 
@@ -96,7 +158,6 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
 
     qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
 
-    static const auto Reason               = tr("fooyin is running");
     static constexpr auto BlockLogoutFlag  = 1U;
     static constexpr auto BlockSuspendFlag = 4U;
     static constexpr auto BlockIdleFlag    = 8U;
@@ -104,6 +165,9 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
     auto flags = BlockLogoutFlag | BlockSuspendFlag;
     if(type == InhibitionType::DisplayAndSystem) {
         flags |= BlockIdleFlag;
+        if(m_interface == Interface::FreedesktopPower) {
+            inhibitScreenSaver();
+        }
     }
 
     QList<QVariant> args;
@@ -131,6 +195,8 @@ void InhibitorDbus::inhibitSleep(InhibitionType type)
 
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
     QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, &InhibitorDbus::onInhibitCallFinished);
+
+    m_currentType = type;
 }
 
 void InhibitorDbus::uninhibitSleep()
@@ -167,11 +233,17 @@ void InhibitorDbus::uninhibitSleep()
             return;
         }
 
+        if(m_interface == Interface::FreedesktopPower && m_currentType == InhibitionType::DisplayAndSystem) {
+            uninhibitScreenSaver();
+        }
+
         const auto pendingCall = m_busInterface->asyncCall(
             m_interface == Interface::FreedesktopPower ? "UnInhibit"_L1 : "Uninhibit"_L1, m_inhibitCookie);
         auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
         QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, &InhibitorDbus::onUninhibitCallFinished);
     }
+
+    m_currentType = {};
 }
 
 void InhibitorDbus::onInhibitCallFinished(QDBusPendingCallWatcher* watcher)

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.cpp
@@ -94,7 +94,7 @@ void InhibitorDbus::inhibitScreenSaver()
     if(!m_screenSaverInterface) {
         m_screenSaverInterface = new QDBusInterface(
             DbusConstants::FreedesktopScreenSaverService, DbusConstants::FreedesktopScreenSaverPath,
-            DbusConstants::FreedesktopScreenSaverInterface, QDBusConnection::sessionBus());
+            DbusConstants::FreedesktopScreenSaverInterface, QDBusConnection::sessionBus(), this);
         if(!m_screenSaverInterface->isValid()) [[unlikely]] {
             m_screenSaverError = true;
             return;

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
@@ -52,11 +52,20 @@ private:
     void onInhibitCallFinished(QDBusPendingCallWatcher* watcher);
     void onUninhibitCallFinished(QDBusPendingCallWatcher* watcher);
 
+    void inhibitScreenSaver();
+    void uninhibitScreenSaver();
+    void onScreenSaverInhibitCallFinished(QDBusPendingCallWatcher* watcher);
+    void onScreenSaverUninhibitCallFinished(QDBusPendingCallWatcher* watcher);
+
     QPointer<QDBusInterface> m_busInterface;
+    QPointer<QDBusInterface> m_screenSaverInterface;
     Interface m_interface{Interface::None};
     std::optional<State> m_desiredState;
+    std::optional<InhibitionType> m_currentType;
     InhibitionType m_desiredType;
-    uint32_t m_inhibitCookie{0};     // Used by GnomeSessionManager and FreedesktopPower
-    QDBusObjectPath m_inhibitHandle; // Used by FreedesktopPortal
+    bool m_screenSaverError{false};
+    uint32_t m_inhibitCookie{0};            // Used by GnomeSessionManager and FreedesktopPower
+    uint32_t m_screenSaverInhibitCookie{0}; // Used by FreedesktopScreenSaver
+    QDBusObjectPath m_inhibitHandle;        // Used by FreedesktopPortal
 };
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
@@ -49,6 +49,14 @@ private:
         FreedesktopPortal,
     };
 
+    struct InterfaceState
+    {
+        std::optional<State> desiredState;
+        InhibitionType desiredType;
+        std::optional<InhibitionType> currentType;
+        State currentState{State::Initializing};
+    };
+
     void onInhibitCallFinished(QDBusPendingCallWatcher* watcher);
     void onUninhibitCallFinished(QDBusPendingCallWatcher* watcher);
 
@@ -60,10 +68,8 @@ private:
     QPointer<QDBusInterface> m_busInterface;
     QPointer<QDBusInterface> m_screenSaverInterface;
     Interface m_interface{Interface::None};
-    std::optional<State> m_desiredState;
-    std::optional<InhibitionType> m_currentType;
-    InhibitionType m_desiredType;
-    bool m_screenSaverError{false};
+    InterfaceState m_powerState;
+    InterfaceState m_screenSaverState;
     uint32_t m_inhibitCookie{0};            // Used by GnomeSessionManager and FreedesktopPower
     uint32_t m_screenSaverInhibitCookie{0}; // Used by FreedesktopScreenSaver
     QDBusObjectPath m_inhibitHandle;        // Used by FreedesktopPortal

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
@@ -27,6 +27,8 @@
 #include <QtDBus/QDBusObjectPath>
 #include <QtDBus/QDBusPendingCallWatcher>
 
+#include <optional>
+
 namespace Fooyin::SleepInhibitor {
 class InhibitorDbus : public InhibitorPrivate
 {
@@ -35,7 +37,7 @@ class InhibitorDbus : public InhibitorPrivate
 public:
     explicit InhibitorDbus(QObject* parent = nullptr);
 
-    void inhibitSleep() override;
+    void inhibitSleep(InhibitionType type) override;
     void uninhibitSleep() override;
 
 private:
@@ -52,6 +54,8 @@ private:
 
     QPointer<QDBusInterface> m_busInterface;
     Interface m_interface{Interface::None};
+    std::optional<State> m_desiredState;
+    InhibitionType m_desiredType;
     uint32_t m_inhibitCookie{0};     // Used by GnomeSessionManager and FreedesktopPower
     QDBusObjectPath m_inhibitHandle; // Used by FreedesktopPortal
 };

--- a/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitordbus.h
@@ -60,6 +60,7 @@ private:
     void onInhibitCallFinished(QDBusPendingCallWatcher* watcher);
     void onUninhibitCallFinished(QDBusPendingCallWatcher* watcher);
 
+    [[nodiscard]] bool usingScreenSaverInterface() const;
     void inhibitScreenSaver();
     void uninhibitScreenSaver();
     void onScreenSaverInhibitCallFinished(QDBusPendingCallWatcher* watcher);

--- a/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
@@ -47,7 +47,7 @@ void InhibitorMacOs::inhibitSleep(InhibitionType type)
             = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, assertionName, &m_assertionId);
         CFRelease(assertionName);
         return status;
-    }).then([this](IOReturn status) {
+    }).then(this, [this](IOReturn status) {
         if(status == kIOReturnSuccess) {
             setState(State::Inhibited);
         }
@@ -73,7 +73,7 @@ void InhibitorMacOs::uninhibitSleep()
     QtConcurrent::run([this] -> IOReturn {
         qCDebug(SLEEPINHIBITOR) << "Uninhibiting sleep";
         return IOPMAssertionRelease(m_assertionId);
-    }).then([this](IOReturn status) {
+    }).then(this, [this](IOReturn status) {
         if(status == kIOReturnSuccess) {
             setState(State::Uninhibited);
         }

--- a/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
@@ -25,7 +25,7 @@ InhibitorMacOs::InhibitorMacOs(QObject* parent)
     : InhibitorPrivate{parent}
 { }
 
-void InhibitorMacOs::inhibitSleep()
+void InhibitorMacOs::inhibitSleep(InhibitionType type)
 {
     if(state() == State::Error || state() == State::Inhibited) {
         return;
@@ -34,8 +34,10 @@ void InhibitorMacOs::inhibitSleep()
     qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
 
     const auto assertionName = tr("fooyin is running").toCFString();
-    const auto status = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, assertionName,
-                                                    &m_assertionId);
+    const auto assertionType = type == InhibitionType::DisplayAndSystem ? kIOPMAssertionTypePreventUserIdleDisplaySleep
+                                                                        : kIOPMAssertionTypePreventUserIdleSystemSleep;
+    const auto status
+        = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, assertionName, &m_assertionId);
     CFRelease(assertionName);
     if(status == kIOReturnSuccess) {
         setState(State::Inhibited);

--- a/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitormacos.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <QtConcurrent>
+
 #include "inhibitormacos.h"
 
 namespace Fooyin::SleepInhibitor {
@@ -27,42 +29,62 @@ InhibitorMacOs::InhibitorMacOs(QObject* parent)
 
 void InhibitorMacOs::inhibitSleep(InhibitionType type)
 {
+    m_desiredState = State::Inhibited;
+    m_desiredType  = type;
+
     if(state() == State::Error || state() == State::Inhibited) {
         return;
     }
 
-    qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
+    QtConcurrent::run([this, type] -> IOReturn {
+        qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
 
-    const auto assertionName = tr("fooyin is running").toCFString();
-    const auto assertionType = type == InhibitionType::DisplayAndSystem ? kIOPMAssertionTypePreventUserIdleDisplaySleep
-                                                                        : kIOPMAssertionTypePreventUserIdleSystemSleep;
-    const auto status
-        = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, assertionName, &m_assertionId);
-    CFRelease(assertionName);
-    if(status == kIOReturnSuccess) {
-        setState(State::Inhibited);
-    }
-    else {
-        qCWarning(SLEEPINHIBITOR) << "Inhibit call error, status:" << status;
-        setState(State::Error);
-    }
+        const auto assertionName = tr("fooyin is running").toCFString();
+        const auto assertionType = type == InhibitionType::DisplayAndSystem
+                                     ? kIOPMAssertionTypePreventUserIdleDisplaySleep
+                                     : kIOPMAssertionTypePreventUserIdleSystemSleep;
+        const auto status
+            = IOPMAssertionCreateWithName(assertionType, kIOPMAssertionLevelOn, assertionName, &m_assertionId);
+        CFRelease(assertionName);
+        return status;
+    }).then([this](IOReturn status) {
+        if(status == kIOReturnSuccess) {
+            setState(State::Inhibited);
+        }
+        else {
+            qCWarning(SLEEPINHIBITOR) << "Inhibit call error, status:" << status;
+            setState(State::Error);
+        }
+        if(m_desiredState == State::Uninhibited) {
+            uninhibitSleep();
+            m_desiredState = {};
+        }
+    });
 }
 
 void InhibitorMacOs::uninhibitSleep()
 {
+    m_desiredState = State::Uninhibited;
+
     if(state() != State::Inhibited) {
         return;
     }
 
-    qCDebug(SLEEPINHIBITOR) << "Uninhibiting sleep";
-
-    const auto status = IOPMAssertionRelease(m_assertionId);
-    if(status == kIOReturnSuccess) {
-        setState(State::Uninhibited);
-    }
-    else {
-        qCWarning(SLEEPINHIBITOR) << "Uninhibit call error, status:" << status;
-        setState(State::Error);
-    }
+    QtConcurrent::run([this] -> IOReturn {
+        qCDebug(SLEEPINHIBITOR) << "Uninhibiting sleep";
+        return IOPMAssertionRelease(m_assertionId);
+    }).then([this](IOReturn status) {
+        if(status == kIOReturnSuccess) {
+            setState(State::Uninhibited);
+        }
+        else {
+            qCWarning(SLEEPINHIBITOR) << "Uninhibit call error, status:" << status;
+            setState(State::Error);
+        }
+        if(m_desiredState == State::Inhibited) {
+            inhibitSleep(m_desiredType);
+            m_desiredState = {};
+        }
+    });
 }
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/platforms/inhibitormacos.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitormacos.h
@@ -22,6 +22,8 @@
 
 #include "inhibitor.h"
 
+#include <optional>
+
 #include <IOKit/pwr_mgt/IOPMLib.h>
 
 namespace Fooyin::SleepInhibitor {
@@ -37,5 +39,7 @@ public:
 
 private:
     IOPMAssertionID m_assertionId{};
+    std::optional<State> m_desiredState;
+    InhibitionType m_desiredType;
 };
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/platforms/inhibitormacos.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitormacos.h
@@ -32,7 +32,7 @@ class InhibitorMacOs : public InhibitorPrivate
 public:
     explicit InhibitorMacOs(QObject* parent = nullptr);
 
-    void inhibitSleep() override;
+    void inhibitSleep(InhibitionType type) override;
     void uninhibitSleep() override;
 
 private:

--- a/src/plugins/sleepinhibitor/platforms/inhibitorwin32.cpp
+++ b/src/plugins/sleepinhibitor/platforms/inhibitorwin32.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "inhibitorwin32.h"
+#include "inhibitor.h"
 
 #include <windows.h>
 
@@ -27,7 +28,7 @@ InhibitorWin32::InhibitorWin32(QObject* parent)
     : InhibitorPrivate{parent}
 { }
 
-void InhibitorWin32::inhibitSleep()
+void InhibitorWin32::inhibitSleep(InhibitionType type)
 {
     if(state() == State::Error || state() == State::Inhibited) {
         return;
@@ -35,7 +36,11 @@ void InhibitorWin32::inhibitSleep()
 
     qCDebug(SLEEPINHIBITOR) << "Inhibiting sleep";
 
-    const auto prevState = SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+    EXECUTION_STATE flags = ES_CONTINUOUS | ES_SYSTEM_REQUIRED;
+    if(type == InhibitionType::DisplayAndSystem) {
+        flags |= ES_DISPLAY_REQUIRED;
+    }
+    const auto prevState = SetThreadExecutionState(flags);
     if(prevState != 0) {
         setState(State::Inhibited);
     }

--- a/src/plugins/sleepinhibitor/platforms/inhibitorwin32.h
+++ b/src/plugins/sleepinhibitor/platforms/inhibitorwin32.h
@@ -28,7 +28,7 @@ class InhibitorWin32 : public InhibitorPrivate
 public:
     explicit InhibitorWin32(QObject* parent = nullptr);
 
-    void inhibitSleep() override;
+    void inhibitSleep(InhibitionType type) override;
     void uninhibitSleep() override;
 };
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/sleepinhibitorplugin.cpp
+++ b/src/plugins/sleepinhibitor/sleepinhibitorplugin.cpp
@@ -47,7 +47,11 @@ Q_SIGNALS:
 
 SleepInhibitorPlugin::SleepInhibitorPlugin()
     : m_inhibitor{new Inhibitor(this)}
-{ }
+{
+    m_inhibitionType = m_settings.value(Settings::PreventDisplaySleep, false).toBool()
+                         ? InhibitionType::DisplayAndSystem
+                         : InhibitionType::System;
+}
 
 void SleepInhibitorPlugin::initialise(const CorePluginContext& context)
 {
@@ -72,10 +76,19 @@ std::unique_ptr<PluginSettingsProvider> SleepInhibitorPlugin::settingsProvider()
 
 void SleepInhibitorPlugin::updateInhibition()
 {
-    const auto enabled            = m_settings.value(Settings::Enabled, true).toBool();
-    const auto onlyDuringPlayback = m_settings.value(Settings::OnlyDuringPlayback, true).toBool();
+    const auto enabled             = m_settings.value(Settings::Enabled, true).toBool();
+    const auto onlyDuringPlayback  = m_settings.value(Settings::OnlyDuringPlayback, true).toBool();
+    const auto preventDisplaySleep = m_settings.value(Settings::PreventDisplaySleep, false).toBool();
+    const auto inhibitionType      = preventDisplaySleep ? InhibitionType::DisplayAndSystem : InhibitionType::System;
+
+    if(enabled && m_inhibitionType != inhibitionType) {
+        m_inhibitionType = inhibitionType;
+        // Release the previous inhibitor so the next inhibitSleep call uses the new inhibition type.
+        m_inhibitor->uninhibitSleep();
+    }
+
     if(enabled && (!onlyDuringPlayback || m_playerController->playState() == Player::PlayState::Playing)) {
-        m_inhibitor->inhibitSleep();
+        m_inhibitor->inhibitSleep(m_inhibitionType);
     }
     else {
         m_inhibitor->uninhibitSleep();

--- a/src/plugins/sleepinhibitor/sleepinhibitorplugin.h
+++ b/src/plugins/sleepinhibitor/sleepinhibitorplugin.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "inhibitor.h"
+
 #include <core/coresettings.h>
 #include <core/plugins/coreplugin.h>
 #include <core/plugins/plugin.h>
@@ -54,5 +56,6 @@ private:
     PlayerController* m_playerController;
     FySettings m_settings;
     Inhibitor* m_inhibitor;
+    InhibitionType m_inhibitionType;
 };
 } // namespace Fooyin::SleepInhibitor

--- a/src/plugins/sleepinhibitor/sleepinhibitorsettings.cpp
+++ b/src/plugins/sleepinhibitor/sleepinhibitorsettings.cpp
@@ -32,6 +32,7 @@ SleepInhibitorSettings::SleepInhibitorSettings(QWidget* parent)
     : QDialog{parent}
     , m_enabled{new QCheckBox(tr("Inhibit system sleep"), this)}
     , m_onlyDuringPlayback{new QCheckBox(tr("Inhibit system sleep during playback only"), this)}
+    , m_preventDisplaySleep{new QCheckBox(tr("Prevent display from turning off"), this)}
 {
     namespace Settings = SleepInhibitor::Settings;
 
@@ -48,13 +49,18 @@ SleepInhibitorSettings::SleepInhibitorSettings(QWidget* parent)
     int row{0};
     layout->addWidget(m_enabled, row++, 0);
     layout->addWidget(m_onlyDuringPlayback, row++, 0);
+    layout->addWidget(m_preventDisplaySleep, row++, 0);
     layout->addWidget(buttons, row++, 0, 1, 2, Qt::AlignBottom);
 
-    m_enabled->setChecked(m_settings.value(Settings::Enabled, true).toBool());
+    const auto enabled = m_settings.value(Settings::Enabled, true).toBool();
+    m_enabled->setChecked(enabled);
     m_onlyDuringPlayback->setChecked(m_settings.value(Settings::OnlyDuringPlayback, true).toBool());
-    m_onlyDuringPlayback->setEnabled(m_settings.value(Settings::Enabled, true).toBool());
+    m_onlyDuringPlayback->setEnabled(enabled);
+    m_preventDisplaySleep->setChecked(m_settings.value(Settings::PreventDisplaySleep, false).toBool());
+    m_preventDisplaySleep->setEnabled(enabled);
 
     QObject::connect(m_enabled, &QCheckBox::clicked, m_onlyDuringPlayback, &QCheckBox::setEnabled);
+    QObject::connect(m_enabled, &QCheckBox::clicked, m_preventDisplaySleep, &QCheckBox::setEnabled);
 }
 
 void SleepInhibitorSettings::accept()
@@ -63,6 +69,7 @@ void SleepInhibitorSettings::accept()
 
     m_settings.setValue(Settings::Enabled, m_enabled->isChecked());
     m_settings.setValue(Settings::OnlyDuringPlayback, m_onlyDuringPlayback->isChecked());
+    m_settings.setValue(Settings::PreventDisplaySleep, m_preventDisplaySleep->isChecked());
 
     Q_EMIT settingsChanged();
     done(Accepted);

--- a/src/plugins/sleepinhibitor/sleepinhibitorsettings.h
+++ b/src/plugins/sleepinhibitor/sleepinhibitorsettings.h
@@ -28,8 +28,9 @@
 
 namespace Fooyin {
 namespace SleepInhibitor::Settings {
-constexpr auto Enabled            = "SleepInhibitor/Enabled";
-constexpr auto OnlyDuringPlayback = "SleepInhibitor/OnlyDuringPlayback";
+constexpr auto Enabled             = "SleepInhibitor/Enabled";
+constexpr auto OnlyDuringPlayback  = "SleepInhibitor/OnlyDuringPlayback";
+constexpr auto PreventDisplaySleep = "SleepInhibitor/PreventDisplaySleep";
 } // namespace SleepInhibitor::Settings
 
 class SleepInhibitorSettings : public QDialog
@@ -48,5 +49,6 @@ private:
     FySettings m_settings;
     QCheckBox* m_enabled;
     QCheckBox* m_onlyDuringPlayback;
+    QCheckBox* m_preventDisplaySleep;
 };
 } // namespace Fooyin


### PR DESCRIPTION
A range of visualizers is available now, so users might want to inhibit display sleep. Supporting this is relatively easy in most cases, just a matter of adding some flags to API calls. Notes:

* The D-Bus `org.freedesktop.PowerManagement.Inhibit` interface doesn't support display idle inhibition, so we have to add and track a second inhibitor on `org.freedesktop.ScreenSaver`. It's kind of hacky with the current design but it does work. We treat errors on that interface separately and still try to inhibit system suspend if we encounter one.
* There are races with disabling + re-enabling inhibition asynchronously (such as on D-Bus) so I added `m_desiredState` and `m_desiredType` to deal with them.
* The macOS thread commit is motivated by [this](https://source.chromium.org/chromium/chromium/src/+/main:services/device/wake_lock/power_save_blocker/power_save_blocker_mac.cc;l=22-25). It does look like newer versions of macOS try to [create assertions asynchronously](https://github.com/apple-oss-distributions/IOKitUser/blob/IOKitUser-100231.120.3/pwr_mgt.subproj/IOPMAssertions.c#L814) but there are many conditions that can let that function fail so let's be safe.

I know 0.12 is landing very soon so if it's too late for enhancement work I'm fine with delaying this patch.

Tested on GNOME, KDE and macOS Tahoe (VM).