### PR TITLE
Make settings and config dialogs non-modal

### DIFF
--- a/include/gui/configdialog.h
+++ b/include/gui/configdialog.h
@@ -23,6 +23,8 @@
 
 #include <QDialog>
 
+#include <optional>
+
 class QGridLayout;
 
 namespace Fooyin {
@@ -89,6 +91,8 @@ private:
  * Subclasses only need to translate between UI controls and the config value by
  * implementing @fn config() and @fn setConfig(). Call @fn loadCurrentConfig()
  * during construction to initialise the editor from the widget's current state.
+ * Dialogs that observe external config changes should connect the notification to
+ * @fn syncCurrentConfig() and override @fn mergeExternalConfig() to preserve draft values.
  */
 template <typename WidgetType, typename ConfigType>
 class WidgetConfigDialog : public ConfigDialog
@@ -102,7 +106,7 @@ public:
     void apply() override
     {
         m_widget->applyConfig(config());
-        setConfig(m_widget->currentConfig());
+        loadCurrentConfig();
     }
 
     void saveDefaults() override
@@ -132,7 +136,63 @@ protected:
      */
     void loadCurrentConfig()
     {
-        setConfig(m_widget->currentConfig());
+        const ConfigType currentConfig = m_widget->currentConfig();
+        setConfig(currentConfig);
+        m_syncedConfig = currentConfig;
+    }
+
+    /*!
+     * Merges changes made outside the dialog into the editor state.
+     */
+    void syncCurrentConfig()
+    {
+        const ConfigType currentConfig = m_widget->currentConfig();
+        if(!m_syncedConfig) {
+            setConfig(currentConfig);
+        }
+        else {
+            mergeExternalConfig(*m_syncedConfig, currentConfig);
+        }
+
+        m_syncedConfig = currentConfig;
+    }
+
+    /*!
+     * Copies an externally changed value into the dialog's draft.
+     */
+    template <typename Value>
+    static void mergeExternalValue(const Value& previous, const Value& current, Value& draft)
+    {
+        if(previous != current) {
+            draft = current;
+        }
+    }
+
+    /*!
+     * Copies externally changed member values from @p current into @p draft.
+     *
+     * @p members must be pointers to members of @c Object. Draft values are
+     * preserved for members that have not changed since @p previous.
+     */
+    template <typename Object, typename... Members>
+    static void mergeExternalFieldValues(const Object& previous, const Object& current, Object& draft,
+                                         Members... members)
+    {
+        (mergeExternalValue(previous.*members, current.*members, draft.*members), ...);
+    }
+
+    /*!
+     * Merges externally changed ConfigType members into the dialog's draft.
+     *
+     * @p members must be pointers to members of ConfigType. The merged draft is
+     * written back to the editor with setConfig().
+     */
+    template <typename... Members>
+    void mergeExternalFields(const ConfigType& previous, const ConfigType& current, Members... members)
+    {
+        auto draft{config()};
+        mergeExternalFieldValues(previous, current, draft, members...);
+        setConfig(draft);
     }
 
     /*!
@@ -151,8 +211,17 @@ protected:
      * Updates the editor state from a config value.
      */
     virtual void setConfig(const ConfigType& config) = 0;
+    /*!
+     * Updates only values changed outside the dialog.
+     * The default replaces the entire editor state.
+     */
+    virtual void mergeExternalConfig(const ConfigType& /*previous*/, const ConfigType& current)
+    {
+        setConfig(current);
+    }
 
 private:
     WidgetType* m_widget;
+    std::optional<ConfigType> m_syncedConfig;
 };
 } // namespace Fooyin

--- a/include/gui/fywidget.h
+++ b/include/gui/fywidget.h
@@ -220,10 +220,15 @@ protected:
      */
     QAction* addConfigureAction(QMenu* menu, bool addSeparator = true);
     /*!
-     * Opens @p dialog and keeps it singleton per widget instance.
+     * Opens @p dialog as window-modal and keeps it singleton per widget instance.
      * If a config dialog is already open for this widget, that dialog is focused instead.
      */
     void showConfigDialog(QDialog* dialog);
+    /*!
+     * Shows @p dialog with @p modality and keeps it singleton per widget instance.
+     * If a config dialog is already open for this widget, that dialog is focused instead.
+     */
+    void showConfigDialog(QDialog* dialog, Qt::WindowModality modality);
 
 Q_SIGNALS:
     /*!

--- a/include/utils/jsonutils.h
+++ b/include/utils/jsonutils.h
@@ -1,0 +1,45 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fyutils_export.h"
+
+#include <QJsonValue>
+#include <QString>
+
+#include <functional>
+
+namespace Fooyin::Utils {
+using JsonArrayItemIdentity = std::function<QString(const QJsonValue&)>;
+
+/**
+ * Performs a recursive three-way merge of JSON values.
+ *
+ * Changes made only in @p first or @p second relative to @p base are retained. When both sides change the same value,
+ * @p second wins.
+ *
+ * Objects are merged by key. Equal-length arrays are merged by position unless @p arrayItemIdentity is supplied.
+ * Identified arrays are matched by identity and ordered according to @p second, with items added only in @p first
+ * appended. If an identity is empty or duplicated, the conflicting array resolves to @p second.
+ */
+[[nodiscard]] FYUTILS_EXPORT QJsonValue mergeJsonThreeWay(const QJsonValue& base, const QJsonValue& first,
+                                                          const QJsonValue& second,
+                                                          const JsonArrayItemIdentity& arrayItemIdentity = {});
+} // namespace Fooyin::Utils

--- a/src/core/engine/dsp/dspchainstore.cpp
+++ b/src/core/engine/dsp/dspchainstore.cpp
@@ -189,8 +189,8 @@ void DspChainStore::syncActiveChain(const DspChains& chain)
     Q_EMIT activeChainChanged(m_activeChain);
 }
 
-bool DspChainStore::updateLiveDspSettings(const DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
-                                          bool persist)
+bool DspChainStore::updateLiveDspSettings(DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
+                                          bool persist, QObject* source)
 {
     if(instanceId == 0) {
         return false;
@@ -230,6 +230,30 @@ bool DspChainStore::updateLiveDspSettings(const DspChainScope scope, uint64_t in
         });
     }
 
+    Q_EMIT liveDspSettingsChanged(scope, instanceId, settings, persist, source);
+    return true;
+}
+
+bool DspChainStore::setDspEnabled(DspChainScope scope, uint64_t instanceId, bool enabled, QObject* source)
+{
+    if(instanceId == 0) {
+        return false;
+    }
+
+    auto chain        = m_activeChain;
+    auto& targetChain = scope == DspChainScope::Master ? chain.masterChain : chain.perTrackChain;
+
+    const auto entry = std::ranges::find(targetChain, instanceId, &DspDefinition::instanceId);
+    if(entry == targetChain.end()) {
+        return false;
+    }
+    if(entry->enabled == enabled) {
+        return true;
+    }
+
+    entry->enabled = enabled;
+    setActiveChain(chain);
+    Q_EMIT dspEnabledChanged(scope, instanceId, enabled, source);
     return true;
 }
 

--- a/src/core/engine/dsp/dspchainstore.h
+++ b/src/core/engine/dsp/dspchainstore.h
@@ -50,10 +50,14 @@ public:
     void setActiveChain(const Engine::DspChains& chain);
     void syncActiveChain(const Engine::DspChains& chain);
     bool updateLiveDspSettings(Engine::DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
-                               bool persist);
+                               bool persist, QObject* source = nullptr);
+    bool setDspEnabled(Engine::DspChainScope scope, uint64_t instanceId, bool enabled, QObject* source = nullptr);
 
 Q_SIGNALS:
     void activeChainChanged(const Fooyin::Engine::DspChains& chain);
+    void liveDspSettingsChanged(Fooyin::Engine::DspChainScope scope, uint64_t instanceId, const QByteArray& settings,
+                                bool persisted, QObject* source);
+    void dspEnabledChanged(Fooyin::Engine::DspChainScope scope, uint64_t instanceId, bool enabled, QObject* source);
 
 private:
     [[nodiscard]] uint64_t nextInstanceId();

--- a/src/core/internalcoresettings.cpp
+++ b/src/core/internalcoresettings.cpp
@@ -121,6 +121,7 @@ CoreSettings::CoreSettings(SettingsManager* settingsManager)
 
     m_settings->createSetting<Internal::MonitorLibraryDirectories>(false, u"Library/MonitorLibraries"_s);
     m_settings->createSetting<Internal::MonitorTrackFiles>(false, u"Library/MonitorTrackFiles"_s);
+    m_settings->createSetting<Internal::PlaylistSkipUnavailable>(false, u"Playlist/SkipUnavailable"_s);
     m_settings->createTempSetting<Internal::MuteVolume>(m_settings->value<OutputVolume>());
     m_settings->createSetting<Internal::DisabledPlugins>(QStringList{}, u"Plugins/Disabled"_s);
     m_settings->createSetting<Internal::EngineFading>(false, u"Engine/Fading"_s);

--- a/src/core/internalcoresettings.h
+++ b/src/core/internalcoresettings.h
@@ -39,7 +39,6 @@ enum class ReplayGainType : uint8_t
 namespace Settings::Core::Internal {
 Q_NAMESPACE_EXPORT(FYCORE_EXPORT)
 
-constexpr auto PlaylistSkipUnavailable           = "Playlist/SkipUnavailable";
 constexpr auto PlaylistSaveMetadata              = "Playlist/SaveMetadata";
 constexpr auto PlaylistSavePathType              = "Playlist/SavePathType";
 constexpr auto AutoExportPlaylists               = "Playlist/AutoExport";
@@ -97,6 +96,7 @@ enum CoreInternalSettings : uint32_t
     MonitorTrackFiles         = 24 | Type::Bool,
     OutputAutoResample        = 25 | Type::Bool,
     OutputResamplerPreference = 26 | Type::StringList,
+    PlaylistSkipUnavailable   = 27 | Type::Bool,
 };
 Q_ENUM_NS(CoreInternalSettings)
 } // namespace Settings::Core::Internal

--- a/src/gui/controls/commandbutton.cpp
+++ b/src/gui/controls/commandbutton.cpp
@@ -263,7 +263,7 @@ void CommandButton::contextMenuEvent(QContextMenuEvent* event)
 
 void CommandButton::openConfigDialog()
 {
-    showConfigDialog(new CommandButtonConfigDialog(this, m_actionManager, this));
+    showConfigDialog(new CommandButtonConfigDialog(this, m_actionManager, this), Qt::NonModal);
 }
 
 CommandButton::ConfigData CommandButton::configFromLayout(const QJsonObject& layout) const

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -380,6 +380,7 @@ void DirBrowser::updateDir(const QString& dir)
 {
     const QModelIndex root = m_model->setRootPath(dir);
     m_rootPath             = m_model->rootPath();
+    m_config.rootPath      = m_rootPath;
     m_dirTree->setRootIndex(m_proxyModel->mapFromSource(root));
 
     if(m_dirEdit) {
@@ -480,6 +481,8 @@ void DirBrowser::applyConfig(const ConfigData& config)
     setShowHidden(m_config.showHidden);
     setRootPath(m_config.rootPath);
     updateControlState();
+
+    Q_EMIT configChanged();
 }
 
 void DirBrowser::playstateChanged(Player::PlayState state)
@@ -645,7 +648,7 @@ void DirBrowser::keyPressEvent(QKeyEvent* event)
 
 void DirBrowser::openConfigDialog()
 {
-    showConfigDialog(new DirBrowserConfigDialog(this, this));
+    showConfigDialog(new DirBrowserConfigDialog(this, this), Qt::NonModal);
 }
 
 void DirBrowser::checkIconProvider()

--- a/src/gui/dirbrowser/dirbrowser.h
+++ b/src/gui/dirbrowser/dirbrowser.h
@@ -99,6 +99,7 @@ public:
     void applyConfig(const ConfigData& config);
 
 Q_SIGNALS:
+    void configChanged();
     void rootChanged();
 
 public Q_SLOTS:

--- a/src/gui/dirbrowser/dirbrowserconfigwidget.cpp
+++ b/src/gui/dirbrowser/dirbrowserconfigwidget.cpp
@@ -98,6 +98,8 @@ DirBrowserConfigDialog::DirBrowserConfigDialog(DirBrowser* browser, QWidget* par
     QObject::connect(m_treeMode, &QRadioButton::toggled, this,
                      [this](bool checked) { m_indentList->setEnabled(!checked); });
 
+    QObject::connect(browser, &DirBrowser::configChanged, this, &DirBrowserConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -139,5 +141,16 @@ void DirBrowserConfigDialog::setConfig(const DirBrowser::ConfigData& config)
 
     TrackSelectionController::setCurrentAction(m_doubleClick, config.doubleClickAction);
     TrackSelectionController::setCurrentAction(m_middleClick, config.middleClickAction);
+}
+
+void DirBrowserConfigDialog::mergeExternalConfig(const DirBrowser::ConfigData& previous,
+                                                 const DirBrowser::ConfigData& current)
+{
+    mergeExternalFields(
+        previous, current, &DirBrowser::ConfigData::doubleClickAction, &DirBrowser::ConfigData::middleClickAction,
+        &DirBrowser::ConfigData::sendPlayback, &DirBrowser::ConfigData::showIcons, &DirBrowser::ConfigData::indentList,
+        &DirBrowser::ConfigData::showHorizScrollbar, &DirBrowser::ConfigData::mode,
+        &DirBrowser::ConfigData::showControls, &DirBrowser::ConfigData::showLocation,
+        &DirBrowser::ConfigData::showSymLinks, &DirBrowser::ConfigData::showHidden, &DirBrowser::ConfigData::rootPath);
 }
 } // namespace Fooyin

--- a/src/gui/dirbrowser/dirbrowserconfigwidget.h
+++ b/src/gui/dirbrowser/dirbrowserconfigwidget.h
@@ -38,6 +38,7 @@ public:
 protected:
     [[nodiscard]] DirBrowser::ConfigData config() const override;
     void setConfig(const DirBrowser::ConfigData& config) override;
+    void mergeExternalConfig(const DirBrowser::ConfigData& previous, const DirBrowser::ConfigData& current) override;
 
 private:
     QRadioButton* m_treeMode;

--- a/src/gui/dsp/dspsettingscontroller.cpp
+++ b/src/gui/dsp/dspsettingscontroller.cpp
@@ -34,7 +34,6 @@
 #include <QSignalBlocker>
 
 #include <algorithm>
-#include <functional>
 #include <unordered_map>
 
 using namespace Qt::StringLiterals;
@@ -70,7 +69,7 @@ class DspSettingsDialogSession : public QObject
 
 public:
     DspSettingsDialogSession(DspSettingsController* controller, QString dspId, DspSettingsDialog* editor,
-                             std::vector<DspSettingsController::Target> targets, std::function<void()> rollback);
+                             std::vector<DspSettingsController::Target> targets);
 
     void open();
     void finish(int result);
@@ -85,6 +84,8 @@ private:
     void setupControls();
     void populateSelector(const std::vector<DspSettingsController::Target>& targets);
     void refreshInstances();
+    void syncSettings(uint64_t instanceId, const QByteArray& settings, QObject* source);
+    void syncEnabled(uint64_t instanceId, bool enabled, QObject* source);
 
     PendingState& pendingFor(const DspSettingsController::Target& target);
 
@@ -93,16 +94,17 @@ private:
     void loadTarget(uint64_t instanceId);
 
     void commit();
+    void rollback();
 
     DspSettingsController* m_controller;
     QString m_dspId;
     QPointer<DspSettingsDialog> m_editor;
     std::vector<DspSettingsController::Target> m_targets;
-    std::function<void()> m_rollback;
 
     QComboBox* m_instanceSelector;
     QCheckBox* m_enabledToggle;
 
+    std::unordered_map<uint64_t, PendingState> m_original;
     std::unordered_map<uint64_t, PendingState> m_pending;
     uint64_t m_currentInstanceId{0};
 
@@ -112,14 +114,12 @@ private:
 
 DspSettingsDialogSession::DspSettingsDialogSession(DspSettingsController* controller, QString dspId,
                                                    DspSettingsDialog* editor,
-                                                   std::vector<DspSettingsController::Target> targets,
-                                                   std::function<void()> rollback)
+                                                   std::vector<DspSettingsController::Target> targets)
     : QObject{controller}
     , m_controller{controller}
     , m_dspId{std::move(dspId)}
     , m_editor{editor}
     , m_targets{std::move(targets)}
-    , m_rollback{std::move(rollback)}
     , m_instanceSelector{addInstanceSelector(m_editor)}
     , m_enabledToggle{addEnabledToggle(m_editor, m_targets.front().enabled)}
 {
@@ -132,13 +132,14 @@ void DspSettingsDialogSession::open()
     loadTarget(m_targets.front().instanceId);
 
     QObject::connect(m_editor, &QDialog::finished, this, &DspSettingsDialogSession::finish);
-    m_editor->open();
+    m_editor->setWindowModality(Qt::NonModal);
+    m_editor->show();
 }
 
 void DspSettingsDialogSession::finish(int result)
 {
     if(result != QDialog::Accepted) {
-        m_rollback();
+        rollback();
     }
     else {
         commit();
@@ -155,6 +156,10 @@ void DspSettingsDialogSession::setupControls()
     QObject::connect(m_instanceSelector, &QComboBox::currentIndexChanged, this, &DspSettingsDialogSession::selectIndex);
     QObject::connect(m_controller, &DspSettingsController::dspInstancesChanged, this,
                      &DspSettingsDialogSession::refreshInstances);
+    QObject::connect(m_controller, &DspSettingsController::dspSettingsChanged, this,
+                     &DspSettingsDialogSession::syncSettings);
+    QObject::connect(m_controller, &DspSettingsController::dspEnabledChanged, this,
+                     &DspSettingsDialogSession::syncEnabled);
 }
 
 void DspSettingsDialogSession::populateSelector(const std::vector<DspSettingsController::Target>& targets)
@@ -190,7 +195,64 @@ void DspSettingsDialogSession::refreshInstances()
         return;
     }
 
+    bool reloadCurrent{false};
+    for(const auto& target : targets) {
+        const auto original = m_original.find(target.instanceId);
+        if(original == m_original.end()) {
+            continue;
+        }
+
+        auto& pending = m_pending[target.instanceId];
+        if(original->second.settings != target.settings) {
+            original->second.settings = target.settings;
+            pending.settings          = target.settings;
+            reloadCurrent |= target.instanceId == m_currentInstanceId;
+        }
+        if(original->second.enabled != target.enabled) {
+            original->second.enabled = target.enabled;
+            pending.enabled          = target.enabled;
+            reloadCurrent |= target.instanceId == m_currentInstanceId;
+        }
+    }
+
     populateSelector(targets);
+
+    if(reloadCurrent) {
+        loadTarget(m_currentInstanceId);
+    }
+}
+
+void DspSettingsDialogSession::syncSettings(uint64_t instanceId, const QByteArray& settings, QObject* source)
+{
+    const auto target = m_controller->targetForInstance(m_dspId, instanceId);
+    if(source == m_editor || !target) {
+        return;
+    }
+
+    pendingFor(*target);
+    m_original[instanceId].settings = settings;
+    m_pending[instanceId].settings  = settings;
+
+    if(instanceId == m_currentInstanceId) {
+        loadTarget(instanceId);
+    }
+}
+
+void DspSettingsDialogSession::syncEnabled(uint64_t instanceId, const bool enabled, QObject* source)
+{
+    const auto target = m_controller->targetForInstance(m_dspId, instanceId);
+    if(source == m_editor || !target) {
+        return;
+    }
+
+    pendingFor(*target);
+    m_original[instanceId].enabled = enabled;
+    m_pending[instanceId].enabled  = enabled;
+
+    if(instanceId == m_currentInstanceId) {
+        const QSignalBlocker blocker{m_enabledToggle};
+        m_enabledToggle->setChecked(enabled);
+    }
 }
 
 void DspSettingsDialogSession::saveCurrent()
@@ -239,12 +301,12 @@ void DspSettingsDialogSession::loadTarget(const uint64_t instanceId)
     m_previewConnection = QObject::connect(
         m_editor, &DspSettingsDialog::previewSettingsChanged, this, [this, target](const QByteArray& settings) {
             m_pending[target->instanceId].settings = settings;
-            m_controller->updateDspSettings(target->scope, target->instanceId, settings, false);
+            m_controller->updateDspSettings(target->scope, target->instanceId, settings, false, m_editor);
         });
     m_enabledConnection
         = QObject::connect(m_enabledToggle, &QCheckBox::toggled, this, [this, target](const bool enabled) {
               m_pending[target->instanceId].enabled = enabled;
-              m_controller->setDspEnabled(target->scope, target->instanceId, enabled);
+              m_controller->setDspEnabled(target->scope, target->instanceId, enabled, m_editor);
           });
 }
 
@@ -254,8 +316,18 @@ void DspSettingsDialogSession::commit()
 
     for(const auto& [instanceId, state] : m_pending) {
         if(const auto target = m_controller->targetForInstance(m_dspId, instanceId)) {
-            m_controller->setDspEnabled(target->scope, target->instanceId, state.enabled);
-            m_controller->updateDspSettings(target->scope, target->instanceId, state.settings, true);
+            m_controller->setDspEnabled(target->scope, target->instanceId, state.enabled, m_editor);
+            m_controller->updateDspSettings(target->scope, target->instanceId, state.settings, true, m_editor);
+        }
+    }
+}
+
+void DspSettingsDialogSession::rollback()
+{
+    for(const auto& [instanceId, state] : m_original) {
+        if(const auto target = m_controller->targetForInstance(m_dspId, instanceId)) {
+            m_controller->setDspEnabled(target->scope, target->instanceId, state.enabled, m_editor);
+            m_controller->updateDspSettings(target->scope, target->instanceId, state.settings, true, m_editor);
         }
     }
 }
@@ -263,8 +335,9 @@ void DspSettingsDialogSession::commit()
 DspSettingsDialogSession::PendingState&
 DspSettingsDialogSession::pendingFor(const DspSettingsController::Target& target)
 {
-    auto [it, _]
-        = m_pending.emplace(target.instanceId, PendingState{.settings = target.settings, .enabled = target.enabled});
+    const PendingState initialState{.settings = target.settings, .enabled = target.enabled};
+    m_original.emplace(target.instanceId, initialState);
+    auto [it, _] = m_pending.emplace(target.instanceId, initialState);
     return it->second;
 }
 } // namespace
@@ -273,9 +346,21 @@ DspSettingsController::DspSettingsController(DspChainStore* chainStore, DspSetti
     : QObject{parent}
     , m_chainStore{chainStore}
     , m_registry{registry}
+    , m_settingEnabled{false}
 {
-    QObject::connect(m_chainStore, &DspChainStore::activeChainChanged, this,
-                     &DspSettingsController::dspInstancesChanged);
+    QObject::connect(m_chainStore, &DspChainStore::activeChainChanged, this, [this]() {
+        if(!m_settingEnabled) {
+            Q_EMIT dspInstancesChanged();
+        }
+    });
+    QObject::connect(m_chainStore, &DspChainStore::liveDspSettingsChanged, this,
+                     [this](Engine::DspChainScope /*scope*/, uint64_t instanceId, const QByteArray& settings,
+                            bool /*persisted*/,
+                            QObject* source) { Q_EMIT dspSettingsChanged(instanceId, settings, source); });
+    QObject::connect(m_chainStore, &DspChainStore::dspEnabledChanged, this,
+                     [this](Engine::DspChainScope /*scope*/, uint64_t instanceId, bool enabled, QObject* source) {
+                         Q_EMIT dspEnabledChanged(instanceId, enabled, source);
+                     });
 }
 
 QString DspSettingsController::displayName(const QString& dspId) const
@@ -305,6 +390,16 @@ DspLayoutEditor* DspSettingsController::createLayoutEditor(const QString& dspId,
 
 void DspSettingsController::showDialog(const QString& dspId, QWidget* parent)
 {
+    if(const auto dialog = m_dialogs.find(dspId); dialog != m_dialogs.end()) {
+        if(dialog->second) {
+            dialog->second->show();
+            dialog->second->raise();
+            dialog->second->activateWindow();
+            return;
+        }
+        m_dialogs.erase(dialog);
+    }
+
     auto* editor = createEditor(dspId, parent);
     if(!editor) {
         QMessageBox::warning(parent, tr("DSP Settings"), tr("Unable to open settings for DSP \"%1\".").arg(dspId));
@@ -318,13 +413,14 @@ void DspSettingsController::showDialog(const QString& dspId, QWidget* parent)
         return;
     }
 
-    const auto originalChain = m_chainStore->activeChain();
+    m_dialogs.insert_or_assign(dspId, editor);
+    QObject::connect(editor, &QObject::destroyed, this, [this, dspId, editor]() {
+        if(const auto dialog = m_dialogs.find(dspId); dialog != m_dialogs.end() && dialog->second == editor) {
+            m_dialogs.erase(dialog);
+        }
+    });
 
-    const auto rollback = [this, originalChain]() {
-        m_chainStore->setActiveChain(originalChain);
-    };
-
-    auto* session = new DspSettingsDialogSession(this, dspId, editor, targets, rollback);
+    auto* session = new DspSettingsDialogSession(this, dspId, editor, targets);
     session->open();
 }
 
@@ -409,42 +505,30 @@ void DspSettingsController::bindEditor(DspSettingsDialog* editor, const Target& 
         return;
     }
 
-    QObject::connect(
-        editor, &DspSettingsDialog::previewSettingsChanged, this,
-        [this, scope = target.scope, instanceId = target.instanceId, persistPreview](const QByteArray& settings) {
-            updateDspSettings(scope, instanceId, settings, persistPreview);
-        });
+    QObject::connect(editor, &DspSettingsDialog::previewSettingsChanged, this,
+                     [this, editor, scope = target.scope, instanceId = target.instanceId,
+                      persistPreview](const QByteArray& settings) {
+                         updateDspSettings(scope, instanceId, settings, persistPreview, editor);
+                     });
 }
 
-bool DspSettingsController::updateDspSettings(const Engine::DspChainScope scope, const uint64_t instanceId,
-                                              const QByteArray& settings, const bool persist)
+bool DspSettingsController::updateDspSettings(Engine::DspChainScope scope, uint64_t instanceId,
+                                              const QByteArray& settings, bool persist, QObject* source)
 {
-    return m_chainStore->updateLiveDspSettings(scope, instanceId, settings, persist);
+    return m_chainStore->updateLiveDspSettings(scope, instanceId, settings, persist, source);
 }
 
-bool DspSettingsController::setDspEnabled(const Engine::DspChainScope scope, const uint64_t instanceId,
-                                          const bool enabled)
+bool DspSettingsController::setDspEnabled(Engine::DspChainScope scope, uint64_t instanceId, bool enabled,
+                                          QObject* source)
 {
     if(instanceId == 0) {
         return false;
     }
 
-    auto chain        = m_chainStore->activeChain();
-    auto& targetChain = (scope == Engine::DspChainScope::Master) ? chain.masterChain : chain.perTrackChain;
-
-    for(auto& entry : targetChain) {
-        if(entry.instanceId == instanceId) {
-            if(entry.enabled == enabled) {
-                return true;
-            }
-
-            entry.enabled = enabled;
-            m_chainStore->setActiveChain(chain);
-            return true;
-        }
-    }
-
-    return false;
+    m_settingEnabled  = true;
+    const bool result = m_chainStore->setDspEnabled(scope, instanceId, enabled, source);
+    m_settingEnabled  = false;
+    return result;
 }
 } // namespace Fooyin
 

--- a/src/gui/dsp/dspsettingscontroller.h
+++ b/src/gui/dsp/dspsettingscontroller.h
@@ -22,8 +22,10 @@
 #include <core/engine/enginedefs.h>
 
 #include <QObject>
+#include <QPointer>
 
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace Fooyin {
@@ -65,16 +67,21 @@ public:
     [[nodiscard]] std::optional<Target> targetForInstance(const QString& dspId, uint64_t instanceId) const;
 
     void bindEditor(DspSettingsDialog* editor, const Target& target, bool persistPreview);
-    bool updateDspSettings(Engine::DspChainScope scope, uint64_t instanceId, const QByteArray& settings, bool persist);
-    bool setDspEnabled(Engine::DspChainScope scope, uint64_t instanceId, bool enabled);
+    bool updateDspSettings(Engine::DspChainScope scope, uint64_t instanceId, const QByteArray& settings, bool persist,
+                           QObject* source = nullptr);
+    bool setDspEnabled(Engine::DspChainScope scope, uint64_t instanceId, bool enabled, QObject* source = nullptr);
 
 Q_SIGNALS:
     void dspInstancesChanged();
+    void dspSettingsChanged(uint64_t instanceId, const QByteArray& settings, QObject* source);
+    void dspEnabledChanged(uint64_t instanceId, bool enabled, QObject* source);
 
 private:
     [[nodiscard]] DspSettingsProvider* providerFor(const QString& dspId) const;
 
     DspChainStore* m_chainStore;
     DspSettingsRegistry* m_registry;
+    std::unordered_map<QString, QPointer<DspSettingsDialog>> m_dialogs;
+    bool m_settingEnabled;
 };
 } // namespace Fooyin

--- a/src/gui/dsp/dspsettingslayoutwidget.cpp
+++ b/src/gui/dsp/dspsettingslayoutwidget.cpp
@@ -75,6 +75,28 @@ DspLayoutWidgetBase::DspLayoutWidgetBase(DspSettingsController* controller, QStr
 {
     QObject::connect(m_controller, &DspSettingsController::dspInstancesChanged, this,
                      &DspLayoutWidgetBase::refreshInstances);
+    QObject::connect(m_controller, &DspSettingsController::dspSettingsChanged, this,
+                     [this](uint64_t instanceId, const QByteArray& settings, QObject* source) {
+                         if(instanceId != m_currentInstanceId || source == editorObject()) {
+                             return;
+                         }
+
+                         const auto target = m_controller->targetForInstance(m_dspId, instanceId);
+                         if(!target) {
+                             return;
+                         }
+
+                         disconnectEditor();
+                         loadEditorSettings(settings);
+                         connectEditor(*target);
+                     });
+    QObject::connect(m_controller, &DspSettingsController::dspEnabledChanged, this,
+                     [this](const uint64_t instanceId, const bool enabled, const QObject* source) {
+                         if(instanceId == m_currentInstanceId && source != editorObject()) {
+                             updateEnabledState(enabled);
+                             setEditorControlsEnabled(enabled);
+                         }
+                     });
 }
 
 QString DspLayoutWidgetBase::name() const
@@ -229,7 +251,7 @@ void DspLayoutWidgetBase::addEnabledAction(QMenu* menu)
 
     QObject::connect(enabled, &QAction::triggered, this, [this](const bool checked) {
         if(const auto target = m_controller->targetForInstance(m_dspId, m_currentInstanceId)) {
-            m_controller->setDspEnabled(target->scope, target->instanceId, checked);
+            m_controller->setDspEnabled(target->scope, target->instanceId, checked, editorObject());
             updateEnabledState(checked);
             setEditorControlsEnabled(checked);
         }
@@ -297,16 +319,17 @@ void DspSettingsDialogLayoutWidget::updateEnabledState(bool enabled)
 
 void DspSettingsDialogLayoutWidget::connectEditor(const DspSettingsController::Target& target)
 {
-    m_previewConnection = QObject::connect(
-        m_editor, &DspSettingsDialog::previewSettingsChanged, m_editor,
-        [controller = controller(), scope = target.scope, instanceId = target.instanceId](const QByteArray& settings) {
-            controller->updateDspSettings(scope, instanceId, settings, true);
-        });
+    m_previewConnection
+        = QObject::connect(m_editor, &DspSettingsDialog::previewSettingsChanged, m_editor,
+                           [this, controller = controller(), scope = target.scope,
+                            instanceId = target.instanceId](const QByteArray& settings) {
+                               controller->updateDspSettings(scope, instanceId, settings, true, m_editor);
+                           });
 
     m_enabledConnection = QObject::connect(
         m_enabledToggle, &QCheckBox::toggled, m_editor,
         [this, controller = controller(), scope = target.scope, instanceId = target.instanceId](const bool enabled) {
-            controller->setDspEnabled(scope, instanceId, enabled);
+            controller->setDspEnabled(scope, instanceId, enabled, m_editor);
             setEditorControlsEnabled(enabled);
         });
 }
@@ -315,6 +338,11 @@ void DspSettingsDialogLayoutWidget::disconnectEditor()
 {
     QObject::disconnect(m_previewConnection);
     QObject::disconnect(m_enabledConnection);
+}
+
+QObject* DspSettingsDialogLayoutWidget::editorObject() const
+{
+    return m_editor;
 }
 
 void DspSettingsDialogLayoutWidget::loadEditorSettings(const QByteArray& settings)
@@ -374,7 +402,8 @@ void DspCompactLayoutWidget::addEditorActions(QMenu* menu)
         m_editor->restoreDefaults();
         const auto target = controller()->targetForInstance(dspId(), currentInstanceId());
         if(target) {
-            controller()->updateDspSettings(target->scope, target->instanceId, m_editor->saveSettings(), true);
+            controller()->updateDspSettings(target->scope, target->instanceId, m_editor->saveSettings(), true,
+                                            m_editor);
         }
     });
 
@@ -386,16 +415,22 @@ void DspCompactLayoutWidget::addEditorActions(QMenu* menu)
 
 void DspCompactLayoutWidget::connectEditor(const DspSettingsController::Target& target)
 {
-    m_previewConnection = QObject::connect(
-        m_editor, &DspLayoutEditor::previewSettingsChanged, m_editor,
-        [controller = controller(), scope = target.scope, instanceId = target.instanceId](const QByteArray& settings) {
-            controller->updateDspSettings(scope, instanceId, settings, true);
-        });
+    m_previewConnection
+        = QObject::connect(m_editor, &DspLayoutEditor::previewSettingsChanged, m_editor,
+                           [this, controller = controller(), scope = target.scope,
+                            instanceId = target.instanceId](const QByteArray& settings) {
+                               controller->updateDspSettings(scope, instanceId, settings, true, m_editor);
+                           });
 }
 
 void DspCompactLayoutWidget::disconnectEditor()
 {
     QObject::disconnect(m_previewConnection);
+}
+
+QObject* DspCompactLayoutWidget::editorObject() const
+{
+    return m_editor;
 }
 
 void DspCompactLayoutWidget::loadEditorSettings(const QByteArray& settings)

--- a/src/gui/dsp/dspsettingslayoutwidget.h
+++ b/src/gui/dsp/dspsettingslayoutwidget.h
@@ -64,6 +64,7 @@ protected:
     virtual void addEditorActions(QMenu* menu);
     virtual void connectEditor(const DspSettingsController::Target& target) = 0;
     virtual void disconnectEditor();
+    [[nodiscard]] virtual QObject* editorObject() const         = 0;
     virtual void loadEditorSettings(const QByteArray& settings) = 0;
     virtual void setEditorControlsEnabled(bool enabled)         = 0;
 
@@ -93,6 +94,7 @@ protected:
     void updateEnabledState(bool enabled) override;
     void connectEditor(const DspSettingsController::Target& target) override;
     void disconnectEditor() override;
+    [[nodiscard]] QObject* editorObject() const override;
     void loadEditorSettings(const QByteArray& settings) override;
     void setEditorControlsEnabled(bool enabled) override;
 
@@ -118,6 +120,7 @@ protected:
     void addEditorActions(QMenu* menu) override;
     void connectEditor(const DspSettingsController::Target& target) override;
     void disconnectEditor() override;
+    [[nodiscard]] QObject* editorObject() const override;
     void loadEditorSettings(const QByteArray& settings) override;
     void setEditorControlsEnabled(bool enabled) override;
 

--- a/src/gui/fywidget.cpp
+++ b/src/gui/fywidget.cpp
@@ -223,6 +223,11 @@ QAction* FyWidget::addConfigureAction(QMenu* menu, bool addSeparator)
 
 void FyWidget::showConfigDialog(QDialog* dialog)
 {
+    showConfigDialog(dialog, Qt::WindowModal);
+}
+
+void FyWidget::showConfigDialog(QDialog* dialog, const Qt::WindowModality modality)
+{
     if(!dialog) {
         return;
     }
@@ -235,8 +240,10 @@ void FyWidget::showConfigDialog(QDialog* dialog)
     }
 
     p->m_configDialog = dialog;
+
     QObject::connect(dialog, &QDialog::destroyed, this, [this]() { p->m_configDialog = nullptr; });
-    dialog->open();
+    dialog->setWindowModality(modality);
+    dialog->show();
 }
 } // namespace Fooyin
 

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -1668,7 +1668,7 @@ void GuiApplication::showEngineError(const QString& error) const
 
 void GuiApplication::showMessage(const QString& title, const Track& track) const
 {
-    if(m_settings->fileValue(Settings::Core::Internal::PlaylistSkipUnavailable).toBool()) {
+    if(m_settings->value<Settings::Core::Internal::PlaylistSkipUnavailable>()) {
         m_playerController->next();
         if(m_playerController->playState() == Player::PlayState::Playing) {
             m_playerController->play();
@@ -1695,7 +1695,7 @@ void GuiApplication::showMessage(const QString& title, const Track& track) const
     message.exec();
 
     if(alwaysSkip->isChecked()) {
-        m_settings->fileSet(Settings::Core::Internal::PlaylistSkipUnavailable, true);
+        m_settings->set<Settings::Core::Internal::PlaylistSkipUnavailable>(true);
     }
 
     if(message.clickedButton() == stopButton) {

--- a/src/gui/librarytree/librarytreeconfigwidget.cpp
+++ b/src/gui/librarytree/librarytreeconfigwidget.cpp
@@ -205,6 +205,8 @@ LibraryTreeConfigDialog::LibraryTreeConfigDialog(LibraryTreeWidget* libraryTree,
         dialog->open();
     });
 
+    QObject::connect(libraryTree, &LibraryTreeWidget::configChanged, this, &LibraryTreeConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -260,5 +262,21 @@ void LibraryTreeConfigDialog::setConfig(const LibraryTreeWidget::ConfigData& con
     m_playlistName->setEnabled(m_playlistEnabled->isChecked());
     m_autoSwitch->setEnabled(m_playlistEnabled->isChecked());
     m_keepAlive->setEnabled(m_playlistEnabled->isChecked());
+}
+
+void LibraryTreeConfigDialog::mergeExternalConfig(const LibraryTreeWidget::ConfigData& previous,
+                                                  const LibraryTreeWidget::ConfigData& current)
+{
+    mergeExternalFields(
+        previous, current, &LibraryTreeWidget::ConfigData::doubleClickAction,
+        &LibraryTreeWidget::ConfigData::middleClickAction, &LibraryTreeWidget::ConfigData::sendPlayback,
+        &LibraryTreeWidget::ConfigData::playlistEnabled, &LibraryTreeWidget::ConfigData::autoSwitch,
+        &LibraryTreeWidget::ConfigData::keepAlive, &LibraryTreeWidget::ConfigData::playlistName,
+        &LibraryTreeWidget::ConfigData::restoreState, &LibraryTreeWidget::ConfigData::expandOnSingleClick,
+        &LibraryTreeWidget::ConfigData::autoExpandSearchResultLimit, &LibraryTreeWidget::ConfigData::animated,
+        &LibraryTreeWidget::ConfigData::showHeader, &LibraryTreeWidget::ConfigData::showScrollbar,
+        &LibraryTreeWidget::ConfigData::alternatingRows, &LibraryTreeWidget::ConfigData::showSummaryNode,
+        &LibraryTreeWidget::ConfigData::summaryNodeTitle, &LibraryTreeWidget::ConfigData::rowHeight,
+        &LibraryTreeWidget::ConfigData::iconSize);
 }
 } // namespace Fooyin

--- a/src/gui/librarytree/librarytreeconfigwidget.h
+++ b/src/gui/librarytree/librarytreeconfigwidget.h
@@ -43,6 +43,8 @@ public:
 protected:
     [[nodiscard]] LibraryTreeWidget::ConfigData config() const override;
     void setConfig(const LibraryTreeWidget::ConfigData& config) override;
+    void mergeExternalConfig(const LibraryTreeWidget::ConfigData& previous,
+                             const LibraryTreeWidget::ConfigData& current) override;
 
 private:
     LibraryTreeGroupRegistry* m_groupsRegistry;

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -429,6 +429,8 @@ void LibraryTreeWidget::applyConfig(const ConfigData& config)
     m_libraryTree->setIconSize(m_config.iconSize);
 
     QMetaObject::invokeMethod(m_libraryTree->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
+
+    Q_EMIT configChanged();
 }
 
 void LibraryTreeWidget::contextMenuEvent(QContextMenuEvent* event)
@@ -549,7 +551,7 @@ void LibraryTreeWidget::saveConfigToLayout(const ConfigData& config, QJsonObject
 
 void LibraryTreeWidget::openConfigDialog()
 {
-    showConfigDialog(new LibraryTreeConfigDialog(this, m_groupsRegistry, this));
+    showConfigDialog(new LibraryTreeConfigDialog(this, m_groupsRegistry, this), Qt::NonModal);
 }
 
 void LibraryTreeWidget::setupConnections()
@@ -577,6 +579,7 @@ void LibraryTreeWidget::setupConnections()
         if(size.isValid() && m_config.iconSize != size) {
             m_config.iconSize = size;
             QMetaObject::invokeMethod(m_libraryTree->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
+            Q_EMIT configChanged();
         }
     });
     QObject::connect(m_groupsRegistry, &LibraryTreeGroupRegistry::groupingChanged, this,

--- a/src/gui/librarytree/librarytreewidget.h
+++ b/src/gui/librarytree/librarytreewidget.h
@@ -111,6 +111,9 @@ public:
     void clearSavedDefaults() const;
     void applyConfig(const ConfigData& config);
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -786,7 +786,7 @@ void PlaylistOrganiser::saveConfigToLayout(const ConfigData& config, QJsonObject
 
 void PlaylistOrganiser::openConfigDialog()
 {
-    showConfigDialog(new PlaylistOrganiserConfigDialog(this, this));
+    showConfigDialog(new PlaylistOrganiserConfigDialog(this, this), Qt::NonModal);
 }
 } // namespace Fooyin
 

--- a/src/gui/queueviewer/queueviewer.cpp
+++ b/src/gui/queueviewer/queueviewer.cpp
@@ -276,6 +276,7 @@ void QueueViewer::setupConnections()
 
         m_config.iconSize = size;
         m_model->setIconSize(size);
+        Q_EMIT configChanged();
     });
     QObject::connect(m_view, &QAbstractItemView::doubleClicked, this, &QueueViewer::handleQueueDoubleClicked);
 
@@ -835,6 +836,8 @@ void QueueViewer::applyConfig(const ConfigData& config)
     m_view->setAlternatingRowColors(m_config.alternatingRows);
 
     QMetaObject::invokeMethod(m_view->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
+
+    Q_EMIT configChanged();
 }
 
 QueueViewer::ConfigData QueueViewer::configFromLayout(const QJsonObject& layout) const
@@ -917,6 +920,6 @@ void QueueViewer::loadTopLevelState()
 
 void QueueViewer::openConfigDialog()
 {
-    showConfigDialog(new QueueViewerConfigDialog(this, this));
+    showConfigDialog(new QueueViewerConfigDialog(this, this), Qt::NonModal);
 }
 } // namespace Fooyin

--- a/src/gui/queueviewer/queueviewer.h
+++ b/src/gui/queueviewer/queueviewer.h
@@ -86,6 +86,9 @@ public:
     void clearSavedDefaults() const;
     void applyConfig(const ConfigData& config);
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void showEvent(QShowEvent* event) override;

--- a/src/gui/queueviewer/queueviewerconfigwidget.cpp
+++ b/src/gui/queueviewer/queueviewerconfigwidget.cpp
@@ -93,6 +93,8 @@ QueueViewerConfigDialog::QueueViewerConfigDialog(QueueViewer* queueViewer, QWidg
         m_headers->setEnabled(false);
     }
 
+    QObject::connect(queueViewer, &QueueViewer::configChanged, this, &QueueViewerConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -121,5 +123,14 @@ QueueViewer::ConfigData QueueViewerConfigDialog::config() const
         .showScrollBar   = m_scrollBars->isChecked(),
         .alternatingRows = m_altRowColours->isChecked(),
     };
+}
+
+void QueueViewerConfigDialog::mergeExternalConfig(const QueueViewer::ConfigData& previous,
+                                                  const QueueViewer::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &QueueViewer::ConfigData::leftScript, &QueueViewer::ConfigData::rightScript,
+                        &QueueViewer::ConfigData::showCurrent, &QueueViewer::ConfigData::showIcon,
+                        &QueueViewer::ConfigData::iconSize, &QueueViewer::ConfigData::showHeader,
+                        &QueueViewer::ConfigData::showScrollBar, &QueueViewer::ConfigData::alternatingRows);
 }
 } // namespace Fooyin

--- a/src/gui/queueviewer/queueviewerconfigwidget.h
+++ b/src/gui/queueviewer/queueviewerconfigwidget.h
@@ -37,10 +37,12 @@ class QueueViewerConfigDialog : public WidgetConfigDialog<QueueViewer, QueueView
 public:
     explicit QueueViewerConfigDialog(QueueViewer* queueViewer, QWidget* parent = nullptr);
 
-private:
+protected:
     void setConfig(const QueueViewer::ConfigData& config) override;
     [[nodiscard]] QueueViewer::ConfigData config() const override;
+    void mergeExternalConfig(const QueueViewer::ConfigData& previous, const QueueViewer::ConfigData& current) override;
 
+private:
     ScriptLineEdit* m_titleScript;
     ScriptLineEdit* m_subtitleScript;
 

--- a/src/gui/scriptdisplay/scriptdisplay.cpp
+++ b/src/gui/scriptdisplay/scriptdisplay.cpp
@@ -233,6 +233,8 @@ void ScriptDisplay::applyConfig(const ConfigData& config)
 
     applyAppearance();
     updateText();
+
+    Q_EMIT configChanged();
 }
 
 void ScriptDisplay::saveDefaults(const ConfigData& config) const
@@ -348,7 +350,7 @@ void ScriptDisplay::contextMenuEvent(QContextMenuEvent* event)
 
 void ScriptDisplay::openConfigDialog()
 {
-    showConfigDialog(new ScriptDisplayConfigDialog(this, this));
+    showConfigDialog(new ScriptDisplayConfigDialog(this, this), Qt::NonModal);
 }
 
 void ScriptDisplay::resizeEvent(QResizeEvent* event)

--- a/src/gui/scriptdisplay/scriptdisplay.h
+++ b/src/gui/scriptdisplay/scriptdisplay.h
@@ -81,6 +81,9 @@ public:
     [[nodiscard]] QSize sizeHint() const override;
     [[nodiscard]] QSize minimumSizeHint() const override;
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void openConfigDialog() override;

--- a/src/gui/scriptdisplay/scriptdisplayconfigdialog.cpp
+++ b/src/gui/scriptdisplay/scriptdisplayconfigdialog.cpp
@@ -121,6 +121,8 @@ ScriptDisplayConfigDialog::ScriptDisplayConfigDialog(ScriptDisplay* widget, QWid
 
     formatLayout->addWidget(m_script, 1, 0);
 
+    QObject::connect(widget, &ScriptDisplay::configChanged, this, &ScriptDisplayConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -141,6 +143,7 @@ ScriptDisplay::ConfigData ScriptDisplayConfigDialog::config() const
 
         .horizontalAlignment = m_horizontalAlignment->currentData().toInt(),
         .verticalAlignment   = m_verticalAlignment->currentData().toInt(),
+        .showScrollBar       = widget()->currentConfig().showScrollBar,
     };
 }
 
@@ -167,5 +170,14 @@ void ScriptDisplayConfigDialog::setConfig(const ScriptDisplay::ConfigData& confi
     if(const int index = m_verticalAlignment->findData(config.verticalAlignment); index >= 0) {
         m_verticalAlignment->setCurrentIndex(index);
     }
+}
+
+void ScriptDisplayConfigDialog::mergeExternalConfig(const ScriptDisplay::ConfigData& previous,
+                                                    const ScriptDisplay::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &ScriptDisplay::ConfigData::script, &ScriptDisplay::ConfigData::font,
+                        &ScriptDisplay::ConfigData::bgColour, &ScriptDisplay::ConfigData::fgColour,
+                        &ScriptDisplay::ConfigData::linkColour, &ScriptDisplay::ConfigData::horizontalAlignment,
+                        &ScriptDisplay::ConfigData::verticalAlignment, &ScriptDisplay::ConfigData::showScrollBar);
 }
 } // namespace Fooyin

--- a/src/gui/scriptdisplay/scriptdisplayconfigdialog.h
+++ b/src/gui/scriptdisplay/scriptdisplayconfigdialog.h
@@ -42,6 +42,8 @@ public:
 protected:
     [[nodiscard]] ScriptDisplay::ConfigData config() const override;
     void setConfig(const ScriptDisplay::ConfigData& config) override;
+    void mergeExternalConfig(const ScriptDisplay::ConfigData& previous,
+                             const ScriptDisplay::ConfigData& current) override;
 
 private:
     ScriptTextEdit* m_script;

--- a/src/gui/settings/guigeneralpage.cpp
+++ b/src/gui/settings/guigeneralpage.cpp
@@ -188,6 +188,9 @@ GuiGeneralPageWidget::GuiGeneralPageWidget(LayoutProvider* layoutProvider, Edita
 
     QObject::connect(m_overrideMargin, &QCheckBox::toggled, m_editableLayoutMargin, &QWidget::setEnabled);
     QObject::connect(m_overrideSplitterHandle, &QCheckBox::toggled, m_splitterHandleGap, &QWidget::setEnabled);
+
+    m_settings->subscribe<ShowMenuBar>(m_showMenuBar, &QCheckBox::setChecked);
+    m_settings->subscribe<LockSplitterHandles>(m_lockSplitters, &QCheckBox::setChecked);
 }
 
 void GuiGeneralPageWidget::load()

--- a/src/gui/settings/guilayoutpage.cpp
+++ b/src/gui/settings/guilayoutpage.cpp
@@ -21,12 +21,14 @@
 
 #include "layouttreemodel.h"
 
+#include <core/constants.h>
 #include <gui/editablelayout.h>
 #include <gui/guiconstants.h>
 #include <gui/guisettings.h>
 #include <gui/layoutprovider.h>
 #include <gui/theme/fytheme.h>
 #include <gui/widgetprovider.h>
+#include <utils/jsonutils.h>
 #include <utils/settings/settingsmanager.h>
 
 #include <QCheckBox>
@@ -44,6 +46,9 @@
 #include <QTreeView>
 
 #include <algorithm>
+#include <optional>
+#include <ranges>
+#include <unordered_map>
 #include <vector>
 
 using namespace Qt::StringLiterals;
@@ -112,6 +117,22 @@ void setEqualButtonWidth(std::initializer_list<QPushButton*> buttons)
         button->setFixedWidth(width);
     }
 }
+
+QString arrayItemId(const QJsonValue& value)
+{
+    if(!value.isObject()) {
+        return {};
+    }
+
+    const auto object = value.toObject();
+    if(object.size() != 1 || !object.constBegin()->isObject()) {
+        return {};
+    }
+
+    const QString id = object.constBegin()->toObject().value("ID"_L1).toString();
+    return id.isEmpty() ? QString{} : object.constBegin().key() + QLatin1String{Constants::UnitSeparator} + id;
+}
+
 } // namespace
 
 class GuiLayoutPageWidget : public SettingsPageWidget
@@ -127,6 +148,24 @@ public:
     void reset() override;
 
 private:
+    struct LayoutDraft
+    {
+        FyLayout baseline;
+        FyLayout layout;
+        bool applyTheme{false};
+        bool applyWindowSize{false};
+    };
+
+    void refreshLayouts(const QString& selectedName);
+    void showLayout(const QString& name);
+    void saveDisplayedDraft();
+    void mergeExternalLayout(const FyLayout& layout);
+    void onCurrentLayoutChanged(const FyLayout& layout);
+    void onLayoutChanged(const FyLayout& layout);
+    void onLayoutAdded(const FyLayout& layout);
+    void onLayoutRemoved(const QString& name);
+    [[nodiscard]] FyLayout finaliseDraft(const LayoutDraft& draft) const;
+
     void onContextMenuRequested(const QPoint& pos);
     void onChangeLayout();
     void onSelectionChanged();
@@ -170,7 +209,10 @@ private:
     QComboBox* m_layoutCombo;
     QPushButton* m_deleteLayout;
     QJsonObject m_clipboardItem;
+    std::unordered_map<QString, LayoutDraft> m_drafts;
+    QString m_displayedLayoutName;
     bool m_loading{false};
+    bool m_applying{false};
     bool m_updatingMargins{false};
     bool m_updatingSplitterSpacing{false};
 };
@@ -257,7 +299,11 @@ GuiLayoutPageWidget::GuiLayoutPageWidget(LayoutProvider* layoutProvider, Editabl
                      &GuiLayoutPageWidget::onContextMenuRequested);
 
     QObject::connect(m_layoutCombo, &QComboBox::currentIndexChanged, this, &GuiLayoutPageWidget::onChangeLayout);
-    QObject::connect(m_layoutProvider, &LayoutProvider::currentLayoutChanged, this, &GuiLayoutPageWidget::load);
+    QObject::connect(m_layoutProvider, &LayoutProvider::currentLayoutChanged, this,
+                     &GuiLayoutPageWidget::onCurrentLayoutChanged);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutChanged, this, &GuiLayoutPageWidget::onLayoutChanged);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutAdded, this, &GuiLayoutPageWidget::onLayoutAdded);
+    QObject::connect(m_layoutProvider, &LayoutProvider::layoutRemoved, this, &GuiLayoutPageWidget::onLayoutRemoved);
 
     QObject::connect(newLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onNewLayout);
     QObject::connect(m_deleteLayout, &QPushButton::clicked, this, &GuiLayoutPageWidget::onDeleteLayout);
@@ -284,6 +330,12 @@ GuiLayoutPageWidget::GuiLayoutPageWidget(LayoutProvider* layoutProvider, Editabl
 
 void GuiLayoutPageWidget::load()
 {
+    m_drafts.clear();
+    refreshLayouts(m_layoutProvider->currentLayout().name());
+}
+
+void GuiLayoutPageWidget::refreshLayouts(const QString& selectedName)
+{
     m_loading = true;
 
     m_layoutCombo->clear();
@@ -305,55 +357,219 @@ void GuiLayoutPageWidget::load()
         }
     }
 
-    const QString current = m_layoutProvider->currentLayout().name();
-    const int idx         = m_layoutCombo->findText(current);
+    const int idx = m_layoutCombo->findText(selectedName);
     if(idx >= 0) {
         m_layoutCombo->setCurrentIndex(idx);
     }
 
-    m_model->populate(m_layoutProvider->currentLayout());
+    showLayout(idx >= 0 ? selectedName : QString{});
     m_layoutTree->setEnabled(idx >= 0);
-    updateMarginControls();
-    updateSplitterControls();
-    updateMetadataControls();
     updateButtonStates();
 
     m_loading = false;
 }
 
+void GuiLayoutPageWidget::showLayout(const QString& name)
+{
+    m_displayedLayoutName = name;
+
+    if(name.isEmpty()) {
+        m_model->populate({});
+    }
+    else {
+        const auto draft = m_drafts.find(name);
+        if(draft != m_drafts.end()) {
+            m_model->populate(draft->second.layout);
+        }
+        else {
+            const FyLayout layout = m_layoutProvider->layoutByName(name);
+            m_drafts.emplace(name, LayoutDraft{
+                                       .baseline        = layout,
+                                       .layout          = layout,
+                                       .applyTheme      = layout.appliesTheme(),
+                                       .applyWindowSize = layout.appliesWindowSize(),
+                                   });
+            m_model->populate(layout);
+        }
+    }
+
+    updateMarginControls();
+    updateSplitterControls();
+    updateMetadataControls();
+
+    if(const auto draft = m_drafts.find(name); draft != m_drafts.end()) {
+        m_applyTheme->setChecked(draft->second.applyTheme);
+        m_applyWindowSize->setChecked(draft->second.applyWindowSize);
+    }
+}
+
+void GuiLayoutPageWidget::saveDisplayedDraft()
+{
+    if(m_loading || m_displayedLayoutName.isEmpty()) {
+        return;
+    }
+
+    const FyLayout layout = m_model->layout();
+    if(!layout.isValid()) {
+        return;
+    }
+
+    auto draft = m_drafts.find(m_displayedLayoutName);
+    if(draft == m_drafts.end()) {
+        const FyLayout baseline = m_layoutProvider->layoutByName(m_displayedLayoutName);
+        draft                   = m_drafts
+                                      .emplace(m_displayedLayoutName,
+                                               LayoutDraft{
+                                                   .baseline        = baseline,
+                                                   .layout          = layout,
+                                                   .applyTheme      = m_applyTheme->isChecked(),
+                                                   .applyWindowSize = m_applyWindowSize->isChecked(),
+                                               })
+                                      .first;
+    }
+
+    draft->second.layout          = layout;
+    draft->second.applyTheme      = m_applyTheme->isChecked();
+    draft->second.applyWindowSize = m_applyWindowSize->isChecked();
+}
+
+void GuiLayoutPageWidget::mergeExternalLayout(const FyLayout& layout)
+{
+    if(!layout.isValid()) {
+        return;
+    }
+
+    const auto draft = m_drafts.find(layout.name());
+    if(draft == m_drafts.end()) {
+        return;
+    }
+
+    auto& state = draft->second;
+    const auto mergedJson
+        = Utils::mergeJsonThreeWay(state.baseline.json(), layout.json(), state.layout.json(), arrayItemId).toObject();
+
+    if(state.applyTheme == state.baseline.appliesTheme()) {
+        state.applyTheme = layout.appliesTheme();
+    }
+    if(state.applyWindowSize == state.baseline.appliesWindowSize()) {
+        state.applyWindowSize = layout.appliesWindowSize();
+    }
+
+    state.baseline = layout;
+    state.layout   = FyLayout{layout.name(), mergedJson};
+}
+
+void GuiLayoutPageWidget::onCurrentLayoutChanged(const FyLayout& layout)
+{
+    if(m_applying) {
+        return;
+    }
+
+    saveDisplayedDraft();
+    mergeExternalLayout(layout);
+    refreshLayouts(layout.name());
+}
+
+void GuiLayoutPageWidget::onLayoutChanged(const FyLayout& layout)
+{
+    if(m_applying) {
+        return;
+    }
+
+    saveDisplayedDraft();
+    mergeExternalLayout(layout);
+
+    if(layout.name() == m_displayedLayoutName) {
+        const TreeSelectionGuard selectionGuard{m_layoutTree, m_model};
+        showLayout(layout.name());
+    }
+}
+
+void GuiLayoutPageWidget::onLayoutAdded(const FyLayout& /*layout*/)
+{
+    if(!m_applying) {
+        saveDisplayedDraft();
+        refreshLayouts(m_displayedLayoutName);
+    }
+}
+
+void GuiLayoutPageWidget::onLayoutRemoved(const QString& name)
+{
+    if(m_applying) {
+        return;
+    }
+
+    saveDisplayedDraft();
+    m_drafts.erase(name);
+    const QString selected
+        = name == m_displayedLayoutName ? m_layoutProvider->currentLayout().name() : m_displayedLayoutName;
+    refreshLayouts(selected);
+}
+
+FyLayout GuiLayoutPageWidget::finaliseDraft(const LayoutDraft& draft) const
+{
+    FyLayout layout{draft.layout};
+
+    if(draft.applyTheme) {
+        const auto theme = m_settings->value<Settings::Gui::CustomTheme>().value<FyTheme>();
+        layout.removeTheme();
+        layout.setAppliesTheme(true);
+        if(theme.isValid()) {
+            layout.saveTheme(theme);
+        }
+    }
+    else {
+        layout.removeTheme();
+    }
+
+    if(draft.applyWindowSize) {
+        layout.saveWindowSize();
+    }
+    else {
+        layout.removeWindowSize();
+    }
+
+    return layout;
+}
+
 void GuiLayoutPageWidget::apply()
 {
-    FyLayout layout = m_model->layout();
-    if(layout.isValid()) {
-        if(m_applyTheme->isChecked()) {
-            const auto theme = m_settings->value<Settings::Gui::CustomTheme>().value<FyTheme>();
-            layout.removeTheme();
-            layout.setAppliesTheme(true);
-            if(theme.isValid()) {
-                layout.saveTheme(theme);
-            }
-        }
-        else {
-            layout.removeTheme();
+    saveDisplayedDraft();
+
+    const QString currentName = m_layoutProvider->currentLayout().name();
+
+    std::vector<FyLayout> layouts;
+    layouts.reserve(m_drafts.size());
+
+    for(const auto& draft : m_drafts | std::views::values) {
+        const bool changed = draft.layout.json() != draft.baseline.json()
+                          || draft.applyTheme != draft.baseline.appliesTheme()
+                          || draft.applyWindowSize != draft.baseline.appliesWindowSize();
+        if(!changed) {
+            continue;
         }
 
-        if(m_applyWindowSize->isChecked()) {
-            layout.saveWindowSize();
+        FyLayout layout = finaliseDraft(draft);
+        if(layout.isValid()) {
+            layouts.push_back(std::move(layout));
         }
-        else {
-            layout.removeWindowSize();
-        }
-
-        const FyLayout currentLayout = m_layoutProvider->currentLayout();
-        if(currentLayout.isValid() && layout.name() == currentLayout.name() && layout.json() == currentLayout.json()) {
-            return;
-        }
-
-        const TreeSelectionGuard selectionGuard{m_layoutTree, m_model};
-        m_editableLayout->changeLayout(layout);
-        m_layoutProvider->saveCurrentLayout();
-        load();
     }
+
+    m_applying = true;
+
+    for(const auto& layout : layouts) {
+        if(layout.name() != currentName) {
+            m_layoutProvider->saveLayout(layout);
+        }
+    }
+    if(const auto current = std::ranges::find(layouts, currentName, &FyLayout::name); current != layouts.end()) {
+        const TreeSelectionGuard selectionGuard{m_layoutTree, m_model};
+        m_editableLayout->changeLayout(*current);
+        m_layoutProvider->saveCurrentLayout();
+    }
+
+    m_applying = false;
+    load();
 }
 
 void GuiLayoutPageWidget::reset() { }
@@ -413,13 +629,12 @@ void GuiLayoutPageWidget::onChangeLayout()
         return;
     }
 
-    const FyLayout layout = m_layoutProvider->layoutByName(m_layoutCombo->currentText());
-    m_model->populate(layout);
-    m_layoutTree->setEnabled(layout.isValid());
+    saveDisplayedDraft();
+
+    const QString name = m_layoutCombo->currentText();
+    showLayout(name);
+    m_layoutTree->setEnabled(m_model->layout().isValid());
     updateButtonStates();
-    updateMarginControls();
-    updateSplitterControls();
-    updateMetadataControls();
 }
 
 void GuiLayoutPageWidget::onSelectionChanged()
@@ -584,12 +799,11 @@ void GuiLayoutPageWidget::onNewLayout()
                                                defaultName, &success)
                              .trimmed();
 
-    static const QJsonObject layout{
+    const QJsonObject layout{
         {u"Name"_s, name}, {u"Version"_s, 1}, {u"Widgets"_s, QJsonArray{QJsonObject{{u"Playlist"_s, QJsonObject{}}}}}};
 
     if(success && !name.isEmpty() && m_layoutProvider->createLayout(name, FyLayout{name, layout})) {
-        load();
-        m_layoutCombo->setCurrentText(name);
+        refreshLayouts(name);
     }
 }
 
@@ -606,8 +820,8 @@ void GuiLayoutPageWidget::onDeleteLayout()
             if(wasCurrent) {
                 m_editableLayout->changeLayout(m_layoutProvider->currentLayout());
             }
-            load();
-            m_layoutCombo->setCurrentText(name);
+            m_drafts.erase(name);
+            refreshLayouts(name);
         }
         return;
     }
@@ -624,7 +838,8 @@ void GuiLayoutPageWidget::onDeleteLayout()
         if(wasCurrent && m_layoutProvider->currentLayout().isValid()) {
             m_editableLayout->changeLayout(m_layoutProvider->currentLayout());
         }
-        load();
+        m_drafts.erase(name);
+        refreshLayouts(m_layoutProvider->currentLayout().name());
     }
 }
 
@@ -640,9 +855,21 @@ void GuiLayoutPageWidget::onRenameLayout()
                                                   QLineEdit::Normal, oldName, &success)
                                 .trimmed();
 
+    saveDisplayedDraft();
+    const auto oldDraft = m_drafts.find(oldName);
+    const std::optional<LayoutDraft> renamedDraft
+        = oldDraft == m_drafts.end() ? std::nullopt : std::optional{oldDraft->second};
+
     if(success && m_layoutProvider->renameLayout(oldName, newName)) {
-        load();
-        m_layoutCombo->setCurrentText(newName);
+        if(renamedDraft) {
+            auto state      = *renamedDraft;
+            auto json       = state.layout.json();
+            json["Name"_L1] = newName;
+            state.baseline  = m_layoutProvider->layoutByName(newName);
+            state.layout    = FyLayout{newName, json};
+            m_drafts.insert_or_assign(newName, std::move(state));
+        }
+        refreshLayouts(newName);
     }
 }
 
@@ -659,9 +886,13 @@ void GuiLayoutPageWidget::onDuplicateLayout()
                                                   QLineEdit::Normal, defaultName, &success)
                                 .trimmed();
 
-    if(success && m_layoutProvider->duplicateLayout(sourceName, newName)) {
-        load();
-        m_layoutCombo->setCurrentText(newName);
+    saveDisplayedDraft();
+    const auto source = m_drafts.find(sourceName);
+    const FyLayout sourceLayout
+        = source == m_drafts.end() ? m_layoutProvider->layoutByName(sourceName) : source->second.layout;
+
+    if(success && m_layoutProvider->createLayout(newName, sourceLayout)) {
+        refreshLayouts(newName);
     }
 }
 

--- a/src/gui/settings/guithemespage.cpp
+++ b/src/gui/settings/guithemespage.cpp
@@ -42,10 +42,63 @@
 
 #include <optional>
 #include <ranges>
+#include <set>
 
 constexpr auto ThemeIdRole = Qt::UserRole;
 
 namespace Fooyin {
+namespace {
+template <typename T>
+T mergeThemeValue(const T& base, const T& external, const T& draft)
+{
+    return draft == base ? external : draft;
+}
+
+template <typename Map>
+Map mergeThemeMap(const Map& base, const Map& external, const Map& draft)
+{
+    using Key   = Map::key_type;
+    using Value = Map::mapped_type;
+
+    std::set<Key> keys;
+    for(auto it = base.cbegin(); it != base.cend(); ++it) {
+        keys.emplace(it.key());
+    }
+    for(auto it = external.cbegin(); it != external.cend(); ++it) {
+        keys.emplace(it.key());
+    }
+    for(auto it = draft.cbegin(); it != draft.cend(); ++it) {
+        keys.emplace(it.key());
+    }
+
+    const auto value = [](const Map& map, const Key& key) -> std::optional<Value> {
+        const auto it = map.constFind(key);
+        return it == map.cend() ? std::nullopt : std::make_optional(it.value());
+    };
+
+    Map merged;
+    for(const auto& key : keys) {
+        const auto mergedValue = mergeThemeValue(value(base, key), value(external, key), value(draft, key));
+        if(mergedValue) {
+            merged.insert(key, *mergedValue);
+        }
+    }
+    return merged;
+}
+
+FyTheme mergeTheme(const FyTheme& base, const FyTheme& external, const FyTheme& draft)
+{
+    return {
+        .id        = mergeThemeValue(base.id, external.id, draft.id),
+        .name      = mergeThemeValue(base.name, external.name, draft.name),
+        .index     = mergeThemeValue(base.index, external.index, draft.index),
+        .isDefault = mergeThemeValue(base.isDefault, external.isDefault, draft.isDefault),
+        .colours   = mergeThemeMap(base.colours, external.colours, draft.colours),
+        .fonts     = mergeThemeMap(base.fonts, external.fonts, draft.fonts),
+    };
+}
+} // namespace
+
 class GuiColoursPageWidget : public SettingsPageWidget
 {
     Q_OBJECT
@@ -67,6 +120,8 @@ private:
     [[nodiscard]] FyTheme currentTheme() const;
     void loadDefaults();
     void loadCurrentTheme();
+    void displayTheme(const FyTheme& theme);
+    void mergeExternalTheme();
 
     void saveTheme();
     void newTheme();
@@ -86,6 +141,9 @@ private:
     std::map<PaletteKey, ColourButton*> m_colourMapping;
     std::map<QString, FontButton*> m_fontMapping;
     std::optional<FyTheme> m_loadedTheme;
+    FyTheme m_themeBaseline;
+    bool m_isLoaded{false};
+    bool m_updatingSetting{false};
 };
 
 GuiColoursPageWidget::GuiColoursPageWidget(ThemeRegistry* themeRegistry, SettingsManager* settings)
@@ -102,6 +160,8 @@ GuiColoursPageWidget::GuiColoursPageWidget(ThemeRegistry* themeRegistry, Setting
     QObject::connect(m_newButton, &QPushButton::clicked, this, &GuiColoursPageWidget::newTheme);
     QObject::connect(m_saveButton, &QPushButton::clicked, this, &GuiColoursPageWidget::saveTheme);
     QObject::connect(m_deleteButton, &QPushButton::clicked, this, &GuiColoursPageWidget::deleteTheme);
+
+    m_settings->subscribe<Settings::Gui::CustomTheme>(this, &GuiColoursPageWidget::mergeExternalTheme);
 
     auto* themesLayout = new QGridLayout();
 
@@ -207,26 +267,35 @@ void GuiColoursPageWidget::load()
 
     loadDefaults();
     loadCurrentTheme();
+    m_themeBaseline = current;
+    m_isLoaded      = true;
     updateButtonState();
 }
 
 void GuiColoursPageWidget::apply()
 {
     const FyTheme theme = currentTheme();
+    m_updatingSetting   = true;
     if(theme.isValid()) {
         m_settings->set<Settings::Gui::CustomTheme>(QVariant::fromValue(theme));
     }
     else {
         m_settings->reset<Settings::Gui::CustomTheme>();
     }
-    loadDefaults();
-    loadCurrentTheme();
+    m_updatingSetting = false;
+
+    m_themeBaseline = m_settings->value<Settings::Gui::CustomTheme>().value<FyTheme>();
+    displayTheme(m_themeBaseline);
 }
 
 void GuiColoursPageWidget::reset()
 {
+    m_updatingSetting = true;
     m_settings->reset<Settings::Gui::CustomTheme>();
-    m_loadedTheme.reset();
+    m_updatingSetting = false;
+
+    m_themeBaseline = m_settings->value<Settings::Gui::CustomTheme>().value<FyTheme>();
+    displayTheme(m_themeBaseline);
 }
 
 void GuiColoursPageWidget::addColourOption(QGridLayout* layout, const QString& title, QPalette::ColorRole role,
@@ -279,8 +348,12 @@ FyTheme GuiColoursPageWidget::currentTheme() const
     FyTheme theme;
     if(m_loadedTheme) {
         theme = *m_loadedTheme;
-        theme.colours.clear();
-        theme.fonts.clear();
+        for(const auto& key : m_colourMapping | std::views::keys) {
+            theme.colours.remove(key);
+        }
+        for(const auto& key : m_fontMapping | std::views::keys) {
+            theme.fonts.remove(key);
+        }
     }
 
     for(const auto& [key, button] : m_colourMapping) {
@@ -336,6 +409,59 @@ void GuiColoursPageWidget::loadCurrentTheme()
             }
         }
     }
+}
+
+void GuiColoursPageWidget::displayTheme(const FyTheme& theme)
+{
+    {
+        const QSignalBlocker blocker{m_themesList};
+
+        int currentThemeRow{0};
+        for(int row{1}; row < m_themesList->count(); ++row) {
+            const auto* item         = m_themesList->item(row);
+            const auto registryTheme = m_themeRegistry->itemById(item->data(ThemeIdRole).toInt());
+            if(registryTheme && registryTheme->id == theme.id && registryTheme->name == theme.name) {
+                currentThemeRow = row;
+                break;
+            }
+            if(currentThemeRow == 0 && registryTheme && registryTheme->name == theme.name) {
+                currentThemeRow = row;
+            }
+        }
+        m_themesList->setCurrentRow(currentThemeRow);
+    }
+
+    loadDefaults();
+    m_loadedTheme = theme.isValid() ? std::make_optional(theme) : std::nullopt;
+
+    for(const auto& [key, colour] : Utils::asRange(theme.colours)) {
+        if(m_colourMapping.contains(key)) {
+            auto* button = m_colourMapping.at(key);
+            button->setColour(colour);
+            button->setChecked(true);
+        }
+    }
+    for(const auto& [key, font] : Utils::asRange(theme.fonts)) {
+        if(m_fontMapping.contains(key)) {
+            auto* button = m_fontMapping.at(key);
+            button->setButtonFont(font);
+            button->setChecked(true);
+        }
+    }
+
+    updateButtonState();
+}
+
+void GuiColoursPageWidget::mergeExternalTheme()
+{
+    if(!m_isLoaded || m_updatingSetting) {
+        return;
+    }
+
+    const FyTheme external = m_settings->value<Settings::Gui::CustomTheme>().value<FyTheme>();
+    const FyTheme merged   = mergeTheme(m_themeBaseline, external, currentTheme());
+    m_themeBaseline        = external;
+    displayTheme(merged);
 }
 
 void GuiColoursPageWidget::saveTheme()

--- a/src/gui/settings/playback/dspmanagerpage.cpp
+++ b/src/gui/settings/playback/dspmanagerpage.cpp
@@ -36,6 +36,7 @@
 #include <QListWidget>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPointer>
 #include <QPushButton>
 #include <QSortFilterProxyModel>
 #include <QTableView>
@@ -44,7 +45,10 @@
 
 #include <algorithm>
 #include <limits>
-#include <memory>
+#include <optional>
+#include <ranges>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -114,6 +118,157 @@ void removeEntriesFromChain(Engine::DspChain& chain, const Engine::DspChain& ent
         }
     }
 }
+
+bool equalIgnoringEnabled(Engine::DspChains lhs, Engine::DspChains rhs)
+{
+    const auto clearEnabled = [](Engine::DspChain& chain) {
+        for(auto& dsp : chain) {
+            dsp.enabled = false;
+        }
+    };
+
+    clearEnabled(lhs.perTrackChain);
+    clearEnabled(lhs.masterChain);
+    clearEnabled(rhs.perTrackChain);
+    clearEnabled(rhs.masterChain);
+    return lhs == rhs;
+}
+
+struct LocatedDsp
+{
+    Engine::DspDefinition dsp;
+    Engine::DspChainScope scope;
+
+    bool operator==(const LocatedDsp&) const = default;
+};
+using LocatedDsps = std::unordered_map<uint64_t, LocatedDsp>;
+
+LocatedDsps locateDsps(const Engine::DspChains& chains)
+{
+    LocatedDsps located;
+    located.reserve(chains.perTrackChain.size() + chains.masterChain.size());
+
+    const auto addChain = [&located](const Engine::DspChain& chain, Engine::DspChainScope scope) {
+        for(const auto& dsp : chain) {
+            located.insert_or_assign(dsp.instanceId, LocatedDsp{dsp, scope});
+        }
+    };
+
+    addChain(chains.perTrackChain, Engine::DspChainScope::PerTrack);
+    addChain(chains.masterChain, Engine::DspChainScope::Master);
+    return located;
+}
+
+std::optional<LocatedDsp> findDsp(const LocatedDsps& dsps, uint64_t instanceId)
+{
+    if(const auto it = dsps.find(instanceId); it != dsps.end()) {
+        return it->second;
+    }
+    return {};
+}
+
+void avoidAdditionIdCollisions(const LocatedDsps& baseline, const LocatedDsps& external, Engine::DspChains& draft)
+{
+    std::unordered_set<uint64_t> usedIds;
+    uint64_t maxId{0};
+
+    const auto noteIds = [&usedIds, &maxId](const LocatedDsps& dsps) {
+        for(const auto instanceId : dsps | std::views::keys) {
+            usedIds.emplace(instanceId);
+            maxId = std::max(maxId, instanceId);
+        }
+    };
+    noteIds(baseline);
+    noteIds(external);
+
+    const auto nextId = [&usedIds, &maxId]() {
+        while(true) {
+            maxId = maxId == std::numeric_limits<uint64_t>::max() ? 1 : maxId + 1;
+            if(!usedIds.contains(maxId)) {
+                usedIds.emplace(maxId);
+                return maxId;
+            }
+        }
+    };
+
+    const auto updateChain = [&baseline, &external, &usedIds, &nextId](Engine::DspChain& chain) {
+        for(auto& dsp : chain) {
+            const bool isLocalAddition = !baseline.contains(dsp.instanceId);
+            if(isLocalAddition && external.contains(dsp.instanceId)) {
+                dsp.instanceId = nextId();
+            }
+            else {
+                usedIds.emplace(dsp.instanceId);
+            }
+        }
+    };
+
+    updateChain(draft.perTrackChain);
+    updateChain(draft.masterChain);
+}
+
+Engine::DspChains mergeDspChainsThreeWay(const Engine::DspChains& baseline, const Engine::DspChains& external,
+                                         Engine::DspChains draft)
+{
+    if(draft == baseline) {
+        return external;
+    }
+
+    const auto baselineDsps = locateDsps(baseline);
+    const auto externalDsps = locateDsps(external);
+
+    avoidAdditionIdCollisions(baselineDsps, externalDsps, draft);
+
+    const auto draftDsps = locateDsps(draft);
+
+    std::unordered_map<uint64_t, std::optional<LocatedDsp>> mergedDsps;
+    mergedDsps.reserve(baselineDsps.size() + externalDsps.size() + draftDsps.size());
+
+    const auto mergeId = [&](uint64_t instanceId) {
+        const auto baselineDsp = findDsp(baselineDsps, instanceId);
+        const auto draftDsp    = findDsp(draftDsps, instanceId);
+        mergedDsps.insert_or_assign(instanceId, draftDsp == baselineDsp ? findDsp(externalDsps, instanceId) : draftDsp);
+    };
+
+    for(const auto instanceId : baselineDsps | std::views::keys) {
+        mergeId(instanceId);
+    }
+    for(const auto instanceId : externalDsps | std::views::keys) {
+        if(!mergedDsps.contains(instanceId)) {
+            mergeId(instanceId);
+        }
+    }
+    for(const auto instanceId : draftDsps | std::views::keys) {
+        if(!mergedDsps.contains(instanceId)) {
+            mergeId(instanceId);
+        }
+    }
+
+    Engine::DspChains merged;
+    std::unordered_set<uint64_t> appended;
+    appended.reserve(mergedDsps.size());
+
+    const auto appendChain = [&mergedDsps, &appended](const Engine::DspChain& order, Engine::DspChainScope scope,
+                                                      Engine::DspChain& target) {
+        for(const auto& orderedDsp : order) {
+            const auto mergedIt = mergedDsps.find(orderedDsp.instanceId);
+            if(mergedIt == mergedDsps.end() || !mergedIt->second || mergedIt->second->scope != scope
+               || appended.contains(orderedDsp.instanceId)) {
+                continue;
+            }
+
+            target.push_back(mergedIt->second->dsp);
+            appended.emplace(orderedDsp.instanceId);
+        }
+    };
+
+    appendChain(draft.perTrackChain, Engine::DspChainScope::PerTrack, merged.perTrackChain);
+    appendChain(external.perTrackChain, Engine::DspChainScope::PerTrack, merged.perTrackChain);
+    appendChain(draft.masterChain, Engine::DspChainScope::Master, merged.masterChain);
+    appendChain(external.masterChain, Engine::DspChainScope::Master, merged.masterChain);
+
+    return merged;
+}
 } // namespace
 
 class DspManagerPageWidget : public SettingsPageWidget
@@ -126,9 +281,18 @@ public:
 
     void load() override;
     void apply() override;
+    void finish() override;
     void reset() override;
 
 private:
+    struct DspDialogSession
+    {
+        QPointer<DspSettingsDialog> dialog;
+        QByteArray originalSettings;
+        QByteArray lastPreviewSettings;
+        bool supportsLive{false};
+    };
+
     [[nodiscard]] Engine::DspDefinition resolveDisplayName(Engine::DspDefinition dsp) const;
     void resolveDisplayNames(Engine::DspChain& dsps) const;
 
@@ -142,8 +306,18 @@ private:
     [[nodiscard]] Engine::DspChain& pendingRemovedForModel(DspModel* model);
     [[nodiscard]] const Engine::DspChain& pendingRemovedForModel(const DspModel* model) const;
     [[nodiscard]] uint64_t nextDialogInstanceId() const;
+    [[nodiscard]] std::optional<std::pair<DspModel*, Engine::DspChainScope>>
+    modelForInstance(uint64_t instanceId) const;
+    [[nodiscard]] std::optional<Engine::DspChainScope> liveScopeForInstance(uint64_t instanceId) const;
 
     void configureActiveDsp(DspModel* model, const QModelIndex& index);
+    void finishDspDialog(uint64_t instanceId, int result);
+    void closeDspDialog(uint64_t instanceId);
+    void closeDspDialogs(bool rollback = true);
+    void updateLiveDspSettings(uint64_t instanceId, const QByteArray& settings, QObject* source);
+    void syncActiveChain(const Engine::DspChains& chain);
+    void syncLiveDspSettings(uint64_t instanceId, const QByteArray& settings, bool persisted, QObject* source);
+    void syncDspEnabled(uint64_t instanceId, bool enabled);
     void moveActiveDsp(DspModel* model, const QModelIndex& index, int offset);
     void removeActiveDsp(DspModel* model, const QModelIndex& index);
     void addAvailableDsp(const QModelIndex& index, DspModel* targetModel);
@@ -179,8 +353,11 @@ private:
 
     Engine::DspChain m_pendingRemovedPerTrack;
     Engine::DspChain m_pendingRemovedMaster;
+    Engine::DspChains m_chainBaseline;
     Engine::DspChains m_chain;
+    std::unordered_map<uint64_t, DspDialogSession> m_dspDialogs;
     bool m_updating{false};
+    bool m_applyingChain{false};
     bool m_changed{false};
 };
 
@@ -320,15 +497,28 @@ DspManagerPageWidget::DspManagerPageWidget(DspChainStore* chainStore, DspPresetR
                      [this](const QPoint& pos) { showActiveContextMenu(m_masterModel, m_masterList, pos); });
     QObject::connect(m_availableList, &QWidget::customContextMenuRequested, this,
                      [this](const QPoint& pos) { showAvailableContextMenu(pos); });
+    QObject::connect(m_chainStore, &DspChainStore::liveDspSettingsChanged, this,
+                     [this](Engine::DspChainScope /*scope*/, uint64_t instanceId, const QByteArray& settings,
+                            bool persisted,
+                            QObject* source) { syncLiveDspSettings(instanceId, settings, persisted, source); });
+    QObject::connect(m_chainStore, &DspChainStore::activeChainChanged, this, &DspManagerPageWidget::syncActiveChain);
+    QObject::connect(m_chainStore, &DspChainStore::dspEnabledChanged, this,
+                     [this](Engine::DspChainScope /*scope*/, uint64_t instanceId, bool enabled, QObject* /*source*/) {
+                         syncDspEnabled(instanceId, enabled);
+                     });
 
     updatePresetButtons();
 }
 
 void DspManagerPageWidget::load()
 {
+    closeDspDialogs();
+
     m_pendingRemovedPerTrack.clear();
     m_pendingRemovedMaster.clear();
-    m_chain = m_chainStore->activeChain();
+    m_chainBaseline = m_chainStore->activeChain();
+    m_chain         = m_chainBaseline;
+    m_changed       = false;
 
     refreshAvailable();
     refreshActive();
@@ -344,10 +534,13 @@ void DspManagerPageWidget::apply()
     bool applied{false};
 
     if(m_changed) {
+        m_applyingChain = true;
         m_chainStore->setActiveChain(m_chain);
+        m_applyingChain = false;
         // Retrieve the normalised chain so live-setting updates can target newly added DSP instances
-        m_chain = m_chainStore->activeChain();
-        applied = true;
+        m_chain         = m_chainStore->activeChain();
+        m_chainBaseline = m_chain;
+        applied         = true;
     }
 
     if(hasPendingRemoved) {
@@ -359,8 +552,11 @@ void DspManagerPageWidget::apply()
         m_pendingRemovedMaster.clear();
 
         if(finalChain != m_chain || !applied) {
+            m_applyingChain = true;
             m_chainStore->setActiveChain(finalChain);
-            m_chain = m_chainStore->activeChain();
+            m_applyingChain = false;
+            m_chain         = m_chainStore->activeChain();
+            m_chainBaseline = m_chain;
         }
 
         m_changed = false;
@@ -372,8 +568,15 @@ void DspManagerPageWidget::apply()
     }
 }
 
+void DspManagerPageWidget::finish()
+{
+    closeDspDialogs();
+}
+
 void DspManagerPageWidget::reset()
 {
+    closeDspDialogs();
+
     m_pendingRemovedPerTrack.clear();
     m_pendingRemovedMaster.clear();
     m_chain.clear();
@@ -477,13 +680,25 @@ void DspManagerPageWidget::configureActiveDsp(DspModel* model, const QModelIndex
         return;
     }
 
-    const QString dspId = index.data(DspModel::Id).toString();
+    const auto dsps = model->dsps();
+    const int row   = index.row();
+    if(row < 0 || std::cmp_greater_equal(row, dsps.size())) {
+        return;
+    }
 
-    auto dsps                         = model->dsps();
-    const int row                     = index.row();
-    auto& dspEntry                    = dsps.at(row);
-    const QString dspName             = dspEntry.name;
-    const QByteArray originalSettings = dspEntry.settings;
+    const auto& dspEntry      = dsps.at(row);
+    const QString dspId       = dspEntry.id;
+    const uint64_t instanceId = dspEntry.instanceId;
+    if(instanceId == 0) {
+        return;
+    }
+
+    if(const auto session = m_dspDialogs.find(instanceId); session != m_dspDialogs.end() && session->second.dialog) {
+        session->second.dialog->show();
+        session->second.dialog->raise();
+        session->second.dialog->activateWindow();
+        return;
+    }
 
     auto* provider = m_settingsRegistry ? m_settingsRegistry->providerFor(dspId) : nullptr;
     if(!provider) {
@@ -491,44 +706,228 @@ void DspManagerPageWidget::configureActiveDsp(DspModel* model, const QModelIndex
         return;
     }
 
-    auto settingsDialog = std::unique_ptr<DspSettingsDialog>{provider->createSettingsWidget(this)};
+    auto* settingsDialog = provider->createSettingsWidget(this);
     if(!settingsDialog) {
-        QMessageBox::warning(this, tr("DSP Settings"), tr("Unable to open settings for DSP \"%1\".").arg(dspName));
+        QMessageBox::warning(this, tr("DSP Settings"),
+                             tr("Unable to open settings for DSP \"%1\".").arg(dspEntry.name));
         return;
     }
-    settingsDialog->setWindowTitle(dspName);
+    settingsDialog->setWindowTitle(dspEntry.name);
     settingsDialog->loadSettings(dspEntry.settings);
-
-    const auto scope = (model == m_masterModel) ? Engine::DspChainScope::Master : Engine::DspChainScope::PerTrack;
-    const uint64_t instanceId = dspEntry.instanceId;
 
     bool supportsLive{false};
     if(auto node = m_chainStore->createDsp(dspId)) {
         supportsLive = node->supportsLiveSettings();
     }
 
-    QByteArray lastPreviewSettings{originalSettings};
-    if(supportsLive && instanceId != 0) {
-        QObject::connect(settingsDialog.get(), &DspSettingsDialog::previewSettingsChanged, this,
-                         [this, scope, instanceId, &lastPreviewSettings](const QByteArray& settings) {
-                             lastPreviewSettings = settings;
-                             m_chainStore->updateLiveDspSettings(scope, instanceId, settings, false);
-                         });
-    }
+    m_dspDialogs.insert_or_assign(instanceId, DspDialogSession{
+                                                  .dialog              = settingsDialog,
+                                                  .originalSettings    = dspEntry.settings,
+                                                  .lastPreviewSettings = dspEntry.settings,
+                                                  .supportsLive        = supportsLive,
+                                              });
 
-    if(settingsDialog->exec() != QDialog::Accepted) {
-        if(supportsLive && instanceId != 0 && lastPreviewSettings != originalSettings) {
-            m_chainStore->updateLiveDspSettings(scope, instanceId, originalSettings, false);
-        }
+    QObject::connect(settingsDialog, &DspSettingsDialog::previewSettingsChanged, this,
+                     [this, instanceId, settingsDialog](const QByteArray& settings) {
+                         const auto session = m_dspDialogs.find(instanceId);
+                         if(session == m_dspDialogs.end()) {
+                             return;
+                         }
+
+                         session->second.lastPreviewSettings = settings;
+                         if(session->second.supportsLive) {
+                             updateLiveDspSettings(instanceId, settings, settingsDialog);
+                         }
+                     });
+    QObject::connect(settingsDialog, &QDialog::finished, this,
+                     [this, instanceId](int result) { finishDspDialog(instanceId, result); });
+    QObject::connect(settingsDialog, &QObject::destroyed, this,
+                     [this, instanceId]() { m_dspDialogs.erase(instanceId); });
+
+    settingsDialog->setWindowModality(Qt::NonModal);
+    settingsDialog->show();
+}
+
+void DspManagerPageWidget::finishDspDialog(uint64_t instanceId, int result)
+{
+    const auto sessionIt = m_dspDialogs.find(instanceId);
+    if(sessionIt == m_dspDialogs.end()) {
         return;
     }
 
-    dsps[row].settings = settingsDialog->saveSettings();
-    dsps[row]          = resolveDisplayName(std::move(dsps[row]));
-    model->setup(dsps);
+    const DspDialogSession session = sessionIt->second;
 
-    if(supportsLive && instanceId != 0 && dsps[row].settings != lastPreviewSettings) {
-        m_chainStore->updateLiveDspSettings(scope, instanceId, dsps[row].settings, false);
+    if(result == QDialog::Accepted && session.dialog) {
+        if(const auto target = modelForInstance(instanceId)) {
+            auto* model      = target->first;
+            auto dsps        = model->dsps();
+            const auto dspIt = std::ranges::find(dsps, instanceId, &Engine::DspDefinition::instanceId);
+
+            if(dspIt != dsps.end()) {
+                dspIt->settings = session.dialog->saveSettings();
+                *dspIt          = resolveDisplayName(std::move(*dspIt));
+                model->setup(dsps);
+                syncChainFromActiveList();
+                refreshAvailable();
+
+                if(session.supportsLive && dspIt->settings != session.lastPreviewSettings) {
+                    updateLiveDspSettings(instanceId, dspIt->settings, session.dialog);
+                }
+            }
+        }
+    }
+    else if(session.supportsLive && session.lastPreviewSettings != session.originalSettings) {
+        updateLiveDspSettings(instanceId, session.originalSettings, session.dialog);
+    }
+
+    m_dspDialogs.erase(sessionIt);
+    if(session.dialog) {
+        session.dialog->deleteLater();
+    }
+}
+
+void DspManagerPageWidget::closeDspDialog(uint64_t instanceId)
+{
+    if(const auto session = m_dspDialogs.find(instanceId); session != m_dspDialogs.end() && session->second.dialog) {
+        session->second.dialog->reject();
+    }
+}
+
+void DspManagerPageWidget::closeDspDialogs(bool rollback)
+{
+    std::vector<QPointer<DspSettingsDialog>> dialogs;
+    dialogs.reserve(m_dspDialogs.size());
+
+    for(auto& session : m_dspDialogs | std::views::values) {
+        if(!rollback) {
+            session.originalSettings = session.lastPreviewSettings;
+        }
+        dialogs.push_back(session.dialog);
+    }
+
+    for(const auto& dialog : dialogs) {
+        if(dialog) {
+            dialog->reject();
+        }
+    }
+}
+
+void DspManagerPageWidget::updateLiveDspSettings(uint64_t instanceId, const QByteArray& settings, QObject* source)
+{
+    if(const auto scope = liveScopeForInstance(instanceId)) {
+        m_chainStore->updateLiveDspSettings(*scope, instanceId, settings, false, source);
+    }
+}
+
+void DspManagerPageWidget::syncActiveChain(const Engine::DspChains& chain)
+{
+    if(m_applyingChain) {
+        return;
+    }
+
+    syncChainFromActiveList();
+
+    auto draft{m_chain};
+    removeEntriesFromChain(draft.perTrackChain, m_pendingRemovedPerTrack);
+    removeEntriesFromChain(draft.masterChain, m_pendingRemovedMaster);
+
+    if(!equalIgnoringEnabled(m_chainBaseline, chain)) {
+        closeDspDialogs(false);
+    }
+
+    const auto baseline = std::exchange(m_chainBaseline, chain);
+    m_chain             = mergeDspChainsThreeWay(baseline, chain, std::move(draft));
+    m_pendingRemovedPerTrack.clear();
+    m_pendingRemovedMaster.clear();
+    m_changed = m_chain != chain;
+
+    refreshActive();
+    refreshAvailable();
+}
+
+void DspManagerPageWidget::syncLiveDspSettings(uint64_t instanceId, const QByteArray& settings, bool persisted,
+                                               QObject* source)
+{
+    if(persisted) {
+        const auto updateChain = [instanceId, &settings](Engine::DspChains& chains) {
+            for(auto* chain : {&chains.perTrackChain, &chains.masterChain}) {
+                if(const auto it = std::ranges::find(*chain, instanceId, &Engine::DspDefinition::instanceId);
+                   it != chain->end()) {
+                    it->settings = settings;
+                    break;
+                }
+            }
+        };
+        updateChain(m_chainBaseline);
+        updateChain(m_chain);
+    }
+
+    const auto target = modelForInstance(instanceId);
+    if(!target) {
+        return;
+    }
+
+    auto* model      = target->first;
+    auto dsps        = model->dsps();
+    const auto dspIt = std::ranges::find(dsps, instanceId, &Engine::DspDefinition::instanceId);
+    if(dspIt != dsps.end()) {
+        auto displayDsp     = *dspIt;
+        displayDsp.settings = settings;
+        displayDsp          = resolveDisplayName(std::move(displayDsp));
+        dspIt->name         = displayDsp.name;
+
+        if(persisted) {
+            dspIt->settings = settings;
+        }
+
+        m_updating = true;
+        model->setup(dsps);
+        m_updating = false;
+
+        if(persisted) {
+            auto& chain = target->second == Engine::DspChainScope::Master ? m_chain.masterChain : m_chain.perTrackChain;
+            if(const auto chainIt = std::ranges::find(chain, instanceId, &Engine::DspDefinition::instanceId);
+               chainIt != chain.end()) {
+                chainIt->settings = settings;
+                chainIt->name     = displayDsp.name;
+            }
+        }
+    }
+
+    const auto session = m_dspDialogs.find(instanceId);
+    if(session == m_dspDialogs.end() || !session->second.dialog || source == session->second.dialog) {
+        return;
+    }
+
+    session->second.lastPreviewSettings = settings;
+    if(persisted) {
+        session->second.originalSettings = settings;
+    }
+    session->second.dialog->loadSettings(settings);
+}
+
+void DspManagerPageWidget::syncDspEnabled(uint64_t instanceId, bool enabled)
+{
+    const auto target = modelForInstance(instanceId);
+    if(!target) {
+        return;
+    }
+
+    auto* model      = target->first;
+    auto dsps        = model->dsps();
+    const auto dspIt = std::ranges::find(dsps, instanceId, &Engine::DspDefinition::instanceId);
+    if(dspIt != dsps.end()) {
+        dspIt->enabled = enabled;
+
+        m_updating = true;
+        model->setup(dsps);
+        m_updating = false;
+    }
+
+    auto& chain = target->second == Engine::DspChainScope::Master ? m_chain.masterChain : m_chain.perTrackChain;
+    if(const auto chainIt = std::ranges::find(chain, instanceId, &Engine::DspDefinition::instanceId);
+       chainIt != chain.end()) {
+        chainIt->enabled = enabled;
     }
 }
 
@@ -568,6 +967,8 @@ void DspManagerPageWidget::removeActiveDsp(DspModel* model, const QModelIndex& i
 
     auto entry    = dsps[static_cast<size_t>(row)];
     entry.enabled = false;
+
+    closeDspDialog(entry.instanceId);
 
     auto& pendingRemoved = pendingRemovedForModel(model);
     if(std::ranges::find(pendingRemoved, entry) == pendingRemoved.end()) {
@@ -727,6 +1128,39 @@ uint64_t DspManagerPageWidget::nextDialogInstanceId() const
     return maxId + 1;
 }
 
+std::optional<std::pair<DspModel*, Engine::DspChainScope>>
+DspManagerPageWidget::modelForInstance(uint64_t instanceId) const
+{
+    const auto containsInstance = [instanceId](const DspModel* model) {
+        const auto dsps = model->dsps();
+        return std::ranges::find(dsps, instanceId, &Engine::DspDefinition::instanceId) != dsps.end();
+    };
+
+    if(containsInstance(m_masterModel)) {
+        return std::pair{m_masterModel, Engine::DspChainScope::Master};
+    }
+    if(containsInstance(m_perTrackModel)) {
+        return std::pair{m_perTrackModel, Engine::DspChainScope::PerTrack};
+    }
+    return {};
+}
+
+std::optional<Engine::DspChainScope> DspManagerPageWidget::liveScopeForInstance(uint64_t instanceId) const
+{
+    const auto chain            = m_chainStore->activeChain();
+    const auto containsInstance = [instanceId](const Engine::DspChain& dsps) {
+        return std::ranges::find(dsps, instanceId, &Engine::DspDefinition::instanceId) != dsps.end();
+    };
+
+    if(containsInstance(chain.masterChain)) {
+        return Engine::DspChainScope::Master;
+    }
+    if(containsInstance(chain.perTrackChain)) {
+        return Engine::DspChainScope::PerTrack;
+    }
+    return {};
+}
+
 Engine::DspDefinition DspManagerPageWidget::resolveDisplayName(Engine::DspDefinition dsp) const
 {
     dsp.hasSettings = m_settingsRegistry && m_settingsRegistry->hasProvider(dsp.id);
@@ -766,6 +1200,8 @@ void DspManagerPageWidget::loadPreset()
     if(!presetOpt) {
         return;
     }
+
+    closeDspDialogs();
 
     if(std::exchange(m_chain, presetOpt->chain) != m_chain) {
         m_changed = true;

--- a/src/gui/settings/playback/outputpage.cpp
+++ b/src/gui/settings/playback/outputpage.cpp
@@ -58,6 +58,7 @@ public:
 
 private:
     void refreshBufferConstraints();
+    void syncCurrentOutput();
 
     EngineController* m_engine;
     SettingsManager* m_settings;
@@ -203,6 +204,9 @@ OutputPageWidget::OutputPageWidget(EngineController* engine, SettingsManager* se
         }
     });
 
+    QObject::connect(m_engine, &EngineController::outputChanged, this, &OutputPageWidget::syncCurrentOutput);
+    QObject::connect(m_engine, &EngineController::deviceChanged, this, &OutputPageWidget::syncCurrentOutput);
+
     syncWatermarkRatioBounds();
     updateWatermarkHint();
 }
@@ -236,8 +240,7 @@ void OutputPageWidget::load()
         return std::pair{lowRatio, highRatio};
     };
 
-    setupOutputs();
-    setupDevices(m_outputBox->currentText());
+    syncCurrentOutput();
     m_gaplessPlayback->setChecked(m_settings->value<Settings::Core::GaplessPlayback>());
 
     refreshBufferConstraints();
@@ -247,23 +250,6 @@ void OutputPageWidget::load()
                          m_settings->value<Settings::Core::Internal::DecodeHighWatermarkRatio>());
     m_decodeLowWatermark->setValue(static_cast<int>(std::lround(lowWatermarkRatio * 100.0)));
     m_decodeHighWatermark->setValue(static_cast<int>(std::lround(highWatermarkRatio * 100.0)));
-
-    const int bitDepthSetting = m_settings->value<Settings::Core::OutputBitDepth>();
-    const bool ditherSetting
-        = bitDepthSetting == static_cast<int>(SampleFormat::S16) && m_settings->value<Settings::Core::OutputDither>();
-
-    int bitDepthIndex{-1};
-    const int bitDepthItemCount = m_bitDepthBox->count();
-    for(int i{0}; i < bitDepthItemCount; ++i) {
-        if(m_bitDepthBox->itemData(i).toInt() == bitDepthSetting
-           && m_bitDepthBox->itemData(i, Qt::UserRole + 1).toBool() == ditherSetting) {
-            bitDepthIndex = i;
-            break;
-        }
-    }
-
-    m_bitDepthBox->setCurrentIndex(bitDepthIndex >= 0 ? bitDepthIndex : 0);
-    m_bitDepthBox->resizeToFitCurrent();
 }
 
 void OutputPageWidget::apply()
@@ -360,6 +346,29 @@ void OutputPageWidget::setupDevices(const QString& output)
 
     m_deviceBox->resizeDropDown();
     m_deviceBox->resizeToFitCurrent();
+}
+
+void OutputPageWidget::syncCurrentOutput()
+{
+    setupOutputs();
+    setupDevices(m_outputBox->currentText());
+
+    const int bitDepthSetting = m_settings->value<Settings::Core::OutputBitDepth>();
+    const bool ditherSetting
+        = bitDepthSetting == static_cast<int>(SampleFormat::S16) && m_settings->value<Settings::Core::OutputDither>();
+
+    int bitDepthIndex{-1};
+    const int bitDepthItemCount = m_bitDepthBox->count();
+    for(int i{0}; i < bitDepthItemCount; ++i) {
+        if(m_bitDepthBox->itemData(i).toInt() == bitDepthSetting
+           && m_bitDepthBox->itemData(i, Qt::UserRole + 1).toBool() == ditherSetting) {
+            bitDepthIndex = i;
+            break;
+        }
+    }
+
+    m_bitDepthBox->setCurrentIndex(bitDepthIndex >= 0 ? bitDepthIndex : 0);
+    m_bitDepthBox->resizeToFitCurrent();
 }
 
 OutputPage::OutputPage(EngineController* engine, SettingsManager* settings, QObject* parent)

--- a/src/gui/settings/playback/playbackpage.cpp
+++ b/src/gui/settings/playback/playbackpage.cpp
@@ -198,6 +198,15 @@ PlaybackPageWidget::PlaybackPageWidget(SettingsManager* settings)
     layout->setColumnStretch(0, 1);
     layout->setColumnStretch(1, 1);
     layout->setRowStretch(row, 1);
+
+    m_settings->subscribe<Settings::Gui::CursorFollowsPlayback>(m_cursorFollowsPlayback, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Gui::PlaybackFollowsCursor>(m_playbackFollowsCursor, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Core::StopAfterCurrent>(this, [this](const bool enabled) {
+        m_stopAfterCurrent->setChecked(enabled);
+        updateWidgetState();
+    });
+    m_settings->subscribe<Settings::Core::ResetStopAfterCurrent>(m_resetStopAfterCurrent, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Core::Internal::PlaylistSkipUnavailable>(m_skipUnavailable, &QCheckBox::setChecked);
 }
 
 void PlaybackPageWidget::load()
@@ -214,8 +223,7 @@ void PlaybackPageWidget::load()
     m_stopAfterCurrent->setChecked(m_settings->value<Settings::Core::StopAfterCurrent>());
     m_resetStopAfterCurrent->setChecked(m_settings->value<Settings::Core::ResetStopAfterCurrent>());
     m_rewindPrevious->setChecked(m_settings->value<Settings::Core::RewindPreviousTrack>());
-    m_skipUnavailable->setChecked(
-        m_settings->fileValue(Settings::Core::Internal::PlaylistSkipUnavailable, false).toBool());
+    m_skipUnavailable->setChecked(m_settings->value<Settings::Core::Internal::PlaylistSkipUnavailable>());
     m_stopIfActiveDeleted->setChecked(m_settings->value<Settings::Core::StopIfActivePlaylistDeleted>());
 
     m_seekStep->setValue(m_settings->value<Settings::Gui::SeekStepSmall>());
@@ -245,7 +253,7 @@ void PlaybackPageWidget::apply()
     m_settings->set<Settings::Core::StopAfterCurrent>(m_stopAfterCurrent->isChecked());
     m_settings->set<Settings::Core::ResetStopAfterCurrent>(m_resetStopAfterCurrent->isChecked());
     m_settings->set<Settings::Core::RewindPreviousTrack>(m_rewindPrevious->isChecked());
-    m_settings->fileSet(Settings::Core::Internal::PlaylistSkipUnavailable, m_skipUnavailable->isChecked());
+    m_settings->set<Settings::Core::Internal::PlaylistSkipUnavailable>(m_skipUnavailable->isChecked());
     m_settings->set<Settings::Core::StopIfActivePlaylistDeleted>(m_stopIfActiveDeleted->isChecked());
 
     m_settings->set<Settings::Gui::SeekStepSmall>(m_seekStep->value());
@@ -273,7 +281,7 @@ void PlaybackPageWidget::reset()
     m_settings->reset<Settings::Core::StopAfterCurrent>();
     m_settings->reset<Settings::Core::ResetStopAfterCurrent>();
     m_settings->reset<Settings::Core::RewindPreviousTrack>();
-    m_settings->fileRemove(Settings::Core::Internal::PlaylistSkipUnavailable);
+    m_settings->reset<Settings::Core::Internal::PlaylistSkipUnavailable>();
     m_settings->reset<Settings::Core::StopIfActivePlaylistDeleted>();
     m_settings->reset<Settings::Gui::SeekStepSmall>();
     m_settings->reset<Settings::Gui::SeekStepLarge>();

--- a/src/gui/settings/widgets/statuswidgetpage.cpp
+++ b/src/gui/settings/widgets/statuswidgetpage.cpp
@@ -97,6 +97,11 @@ StatusWidgetPageWidget::StatusWidgetPageWidget(SettingsManager* settings)
 
     layout->setColumnStretch(0, 1);
     layout->setRowStretch(2, 1);
+
+    m_settings->subscribe<Settings::Gui::Internal::StatusShowIcon>(m_showIcon, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Gui::Internal::StatusShowSelection>(m_showSelection, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Gui::Internal::StatusShowPlaylist>(m_showPlaylist, &QCheckBox::setChecked);
+    m_settings->subscribe<Settings::Gui::ShowStatusTips>(m_showStatusTips, &QCheckBox::setChecked);
 }
 
 void StatusWidgetPageWidget::load()

--- a/src/gui/widgets/coverwidget.cpp
+++ b/src/gui/widgets/coverwidget.cpp
@@ -167,6 +167,8 @@ void CoverWidget::applyConfig(const ConfigData& config)
     m_fadeController->setDurationMs(m_config.fadeDurationMs);
     m_fadeController->setEnabled(m_config.fadeCoverChanges);
 
+    Q_EMIT configChanged();
+
     if(!m_fadeCoverChanges) {
         stopCoverFade();
     }
@@ -604,7 +606,7 @@ void CoverWidget::paintEvent(QPaintEvent* /*event*/)
 
 void CoverWidget::openConfigDialog()
 {
-    showConfigDialog(new CoverWidgetConfigDialog(this, this));
+    showConfigDialog(new CoverWidgetConfigDialog(this, this), Qt::NonModal);
 }
 
 void CoverWidget::showArtworkViewer()

--- a/src/gui/widgets/coverwidget.h
+++ b/src/gui/widgets/coverwidget.h
@@ -72,6 +72,7 @@ public:
     void loadLayoutData(const QJsonObject& layout) override;
 
 Q_SIGNALS:
+    void configChanged();
     void requestArtworkSearch(const Fooyin::TrackList& tracks, Fooyin::Track::Cover type, bool quick);
     void requestArtworkRemoval(const Fooyin::TrackList& tracks, Fooyin::Track::Cover type);
 

--- a/src/gui/widgets/coverwidgetconfigwidget.cpp
+++ b/src/gui/widgets/coverwidgetconfigwidget.cpp
@@ -99,6 +99,8 @@ CoverWidgetConfigDialog::CoverWidgetConfigDialog(CoverWidget* coverWidget, QWidg
     layout->setColumnStretch(0, 1);
     layout->setRowStretch(2, 1);
 
+    QObject::connect(coverWidget, &CoverWidget::configChanged, this, &CoverWidgetConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -125,5 +127,13 @@ CoverWidget::ConfigData CoverWidgetConfigDialog::config() const
         .fadeCoverChanges = m_fadeEnabled->isChecked(),
         .fadeDurationMs   = m_fadeDuration->value(),
     };
+}
+
+void CoverWidgetConfigDialog::mergeExternalConfig(const CoverWidget::ConfigData& previous,
+                                                  const CoverWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &CoverWidget::ConfigData::coverType,
+                        &CoverWidget::ConfigData::coverAlignment, &CoverWidget::ConfigData::keepAspectRatio,
+                        &CoverWidget::ConfigData::fadeCoverChanges, &CoverWidget::ConfigData::fadeDurationMs);
 }
 } // namespace Fooyin

--- a/src/gui/widgets/coverwidgetconfigwidget.h
+++ b/src/gui/widgets/coverwidgetconfigwidget.h
@@ -39,6 +39,7 @@ public:
 protected:
     void setConfig(const CoverWidget::ConfigData& config) override;
     [[nodiscard]] CoverWidget::ConfigData config() const override;
+    void mergeExternalConfig(const CoverWidget::ConfigData& previous, const CoverWidget::ConfigData& current) override;
 
 private:
     QButtonGroup* m_coverTypeGroup;

--- a/src/plugins/alsa/alsasettings.cpp
+++ b/src/plugins/alsa/alsasettings.cpp
@@ -33,7 +33,6 @@ AlsaSettings::AlsaSettings(QWidget* parent)
     , m_periodLength{new QSpinBox(this)}
 {
     setWindowTitle(tr("ALSA Settings"));
-    setModal(true);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     QObject::connect(buttons, &QDialogButtonBox::accepted, this, &AlsaSettings::accept);

--- a/src/plugins/filters/filterconfigwidget.cpp
+++ b/src/plugins/filters/filterconfigwidget.cpp
@@ -147,6 +147,8 @@ FilterConfigDialog::FilterConfigDialog(FilterWidget* filterWidget, FilterColumnR
         dialog->open();
     });
 
+    QObject::connect(filterWidget, &FilterWidget::configChanged, this, &FilterConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -187,5 +189,16 @@ void FilterConfigDialog::setConfig(const FilterWidget::ConfigData& config)
     m_playlistName->setEnabled(m_playlistEnabled->isChecked());
     m_autoSwitch->setEnabled(m_playlistEnabled->isChecked());
     m_keepAlive->setEnabled(m_playlistEnabled->isChecked());
+}
+
+void FilterConfigDialog::mergeExternalConfig(const FilterWidget::ConfigData& previous,
+                                             const FilterWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &FilterWidget::ConfigData::doubleClickAction,
+                        &FilterWidget::ConfigData::middleClickAction, &FilterWidget::ConfigData::sendPlayback,
+                        &FilterWidget::ConfigData::playlistEnabled, &FilterWidget::ConfigData::autoSwitch,
+                        &FilterWidget::ConfigData::keepAlive, &FilterWidget::ConfigData::playlistName,
+                        &FilterWidget::ConfigData::rowHeight, &FilterWidget::ConfigData::iconSize,
+                        &FilterWidget::ConfigData::iconHorizontalGap, &FilterWidget::ConfigData::iconVerticalGap);
 }
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/filterconfigwidget.h
+++ b/src/plugins/filters/filterconfigwidget.h
@@ -43,6 +43,8 @@ public:
 protected:
     [[nodiscard]] FilterWidget::ConfigData config() const override;
     void setConfig(const FilterWidget::ConfigData& config) override;
+    void mergeExternalConfig(const FilterWidget::ConfigData& previous,
+                             const FilterWidget::ConfigData& current) override;
 
 private:
     FilterColumnRegistry* m_columnRegistry;

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -541,7 +541,14 @@ void FilterWidget::applyConfig(const ConfigData& config)
         validated.iconSize = factoryConfig().iconSize;
     }
 
-    const bool sendPlaybackChanged = m_config.sendPlayback != validated.sendPlayback;
+    const bool hasConfigChanged
+        = m_config.doubleClickAction != validated.doubleClickAction
+       || m_config.middleClickAction != validated.middleClickAction || m_config.sendPlayback != validated.sendPlayback
+       || m_config.playlistEnabled != validated.playlistEnabled || m_config.autoSwitch != validated.autoSwitch
+       || m_config.keepAlive != validated.keepAlive || m_config.playlistName != validated.playlistName
+       || m_config.rowHeight != validated.rowHeight || m_config.iconSize != validated.iconSize
+       || m_config.iconHorizontalGap != validated.iconHorizontalGap
+       || m_config.iconVerticalGap != validated.iconVerticalGap;
 
     m_config = validated;
 
@@ -552,7 +559,7 @@ void FilterWidget::applyConfig(const ConfigData& config)
     m_view->changeIconSize(m_config.iconSize);
     QMetaObject::invokeMethod(m_view->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
 
-    if(sendPlaybackChanged) {
+    if(hasConfigChanged) {
         Q_EMIT configChanged();
     }
 }
@@ -624,7 +631,7 @@ void FilterWidget::saveConfigToLayout(const ConfigData& config, QJsonObject& lay
 
 void FilterWidget::openConfigDialog()
 {
-    showConfigDialog(new FilterConfigDialog(this, m_columnRegistry, this));
+    showConfigDialog(new FilterConfigDialog(this, m_columnRegistry, this), Qt::NonModal);
 }
 
 void FilterWidget::finalise()
@@ -791,6 +798,7 @@ void FilterWidget::setupConnections()
             m_config.iconSize = size;
             m_model->setIconSize(size);
             scheduleVisibleCoverPinUpdate();
+            Q_EMIT configChanged();
         }
     });
     QObject::connect(m_view->verticalScrollBar(), &QScrollBar::valueChanged, this,

--- a/src/plugins/gme/gmesettings.cpp
+++ b/src/plugins/gme/gmesettings.cpp
@@ -45,7 +45,6 @@ GmeSettings::GmeSettings(QWidget* parent)
     , m_fadeNonLoopingTracks{new QCheckBox(tr("Fade non-looping tracks"), this)}
 {
     setWindowTitle(tr("GME Settings"));
-    setModal(true);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     QObject::connect(buttons, &QDialogButtonBox::accepted, this, &GmeSettings::accept);

--- a/src/plugins/lyrics/lyricsconfigwidget.cpp
+++ b/src/plugins/lyrics/lyricsconfigwidget.cpp
@@ -261,6 +261,8 @@ LyricsConfigDialog::LyricsConfigDialog(LyricsWidget* lyricsWidget, GuiStyleProvi
         m_edgeFadeSize->setEnabled(enabled);
     });
 
+    QObject::connect(lyricsWidget, &LyricsWidget::configChanged, this, &LyricsConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -379,6 +381,21 @@ void LyricsConfigDialog::setConfig(const LyricsWidget::ConfigData& config)
     loadFont(m_lineFontBtn, config.lineFont, Lyrics::defaultLineFont(*m_styleProvider));
     loadFont(m_wordLineFontBtn, config.wordLineFont, Lyrics::defaultWordLineFont(*m_styleProvider));
     loadFont(m_wordFontBtn, config.wordFont, Lyrics::defaultWordFont(*m_styleProvider));
+}
+
+void LyricsConfigDialog::mergeExternalConfig(const LyricsWidget::ConfigData& previous,
+                                             const LyricsWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &LyricsWidget::ConfigData::seekOnClick,
+                        &LyricsWidget::ConfigData::noLyricsScript, &LyricsWidget::ConfigData::scrollDuration,
+                        &LyricsWidget::ConfigData::scrollMode, &LyricsWidget::ConfigData::edgeFadeMode,
+                        &LyricsWidget::ConfigData::edgeFadeSize, &LyricsWidget::ConfigData::showScrollbar,
+                        &LyricsWidget::ConfigData::alignment, &LyricsWidget::ConfigData::lineSpacing,
+                        &LyricsWidget::ConfigData::centreFirstSyncedLine,
+                        &LyricsWidget::ConfigData::centreLastSyncedLine, &LyricsWidget::ConfigData::progressMode,
+                        &LyricsWidget::ConfigData::margins, &LyricsWidget::ConfigData::colours,
+                        &LyricsWidget::ConfigData::baseFont, &LyricsWidget::ConfigData::lineFont,
+                        &LyricsWidget::ConfigData::wordLineFont, &LyricsWidget::ConfigData::wordFont);
 }
 
 ScrollMode LyricsConfigDialog::scrollMode() const

--- a/src/plugins/lyrics/lyricsconfigwidget.h
+++ b/src/plugins/lyrics/lyricsconfigwidget.h
@@ -47,6 +47,8 @@ public:
 protected:
     [[nodiscard]] LyricsWidget::ConfigData config() const override;
     void setConfig(const LyricsWidget::ConfigData& config) override;
+    void mergeExternalConfig(const LyricsWidget::ConfigData& previous,
+                             const LyricsWidget::ConfigData& current) override;
 
 private:
     [[nodiscard]] ScrollMode scrollMode() const;

--- a/src/plugins/lyrics/lyricswidget.cpp
+++ b/src/plugins/lyrics/lyricswidget.cpp
@@ -479,6 +479,8 @@ void LyricsWidget::applyConfig(const ConfigData& config)
     if(!m_currentLyrics.isValid() && m_currentTrack.isValid()) {
         m_lyricsView->setDisplayString(noLyricsDisplayText(m_currentTrack));
     }
+
+    Q_EMIT configChanged();
 }
 
 void LyricsWidget::timerEvent(QTimerEvent* event)
@@ -600,7 +602,7 @@ void LyricsWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void LyricsWidget::openConfigDialog()
 {
-    showConfigDialog(new LyricsConfigDialog(this, m_styleProvider, this));
+    showConfigDialog(new LyricsConfigDialog(this, m_styleProvider, this), Qt::NonModal);
 }
 
 void LyricsWidget::loadLyrics(const Lyrics& lyrics)

--- a/src/plugins/lyrics/lyricswidget.h
+++ b/src/plugins/lyrics/lyricswidget.h
@@ -97,6 +97,9 @@ public:
     void clearSavedDefaults() const;
     void applyConfig(const ConfigData& config);
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void timerEvent(QTimerEvent* event) override;
     void contextMenuEvent(QContextMenuEvent* event) override;

--- a/src/plugins/openmpt/openmptsettings.cpp
+++ b/src/plugins/openmpt/openmptsettings.cpp
@@ -48,7 +48,6 @@ OpenMptSettings::OpenMptSettings(SettingsManager* settings, QWidget* parent)
     , m_loopCount{new QSpinBox(this)}
 {
     setWindowTitle(tr("OpenMPT Settings"));
-    setModal(true);
 
     auto* buttons
         = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Reset, this);

--- a/src/plugins/oscilloscope/oscilloscopeconfigwidget.cpp
+++ b/src/plugins/oscilloscope/oscilloscopeconfigwidget.cpp
@@ -105,6 +105,9 @@ OscilloscopeConfigDialog::OscilloscopeConfigDialog(OscilloscopeWidget* oscillosc
     layout->addWidget(m_colourGroup, 0, 1);
     layout->setRowStretch(layout->rowCount(), 1);
 
+    QObject::connect(oscilloscope, &OscilloscopeWidget::configChanged, this,
+                     &OscilloscopeConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -178,6 +181,15 @@ void OscilloscopeConfigDialog::setConfig(const OscilloscopeWidget::ConfigData& c
     m_waveformColour->setColour(colours.colour(Colours::Type::Waveform, widget()->palette()));
     m_zeroLineColour->setChecked(colours.hasOverride(Colours::Type::ZeroLine));
     m_zeroLineColour->setColour(colours.colour(Colours::Type::ZeroLine, widget()->palette()));
+}
+
+void OscilloscopeConfigDialog::mergeExternalConfig(const OscilloscopeWidget::ConfigData& previous,
+                                                   const OscilloscopeWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &OscilloscopeWidget::ConfigData::curveDurationMs,
+                        &OscilloscopeWidget::ConfigData::zoomPercent, &OscilloscopeWidget::ConfigData::updateFps,
+                        &OscilloscopeWidget::ConfigData::downmixMode, &OscilloscopeWidget::ConfigData::showZeroLine,
+                        &OscilloscopeWidget::ConfigData::colours);
 }
 } // namespace Fooyin::Oscilloscope
 

--- a/src/plugins/oscilloscope/oscilloscopeconfigwidget.h
+++ b/src/plugins/oscilloscope/oscilloscopeconfigwidget.h
@@ -41,6 +41,8 @@ public:
 protected:
     [[nodiscard]] OscilloscopeWidget::ConfigData config() const override;
     void setConfig(const OscilloscopeWidget::ConfigData& config) override;
+    void mergeExternalConfig(const OscilloscopeWidget::ConfigData& previous,
+                             const OscilloscopeWidget::ConfigData& current) override;
 
 private:
     QComboBox* m_curveDurationMs;

--- a/src/plugins/oscilloscope/oscilloscopewidget.cpp
+++ b/src/plugins/oscilloscope/oscilloscopewidget.cpp
@@ -172,6 +172,8 @@ void OscilloscopeWidget::applyConfig(const ConfigData& config)
     m_config = validated;
     updateSessionConfig();
     update();
+
+    Q_EMIT configChanged();
 }
 
 QSize OscilloscopeWidget::minimumSizeHint() const
@@ -266,7 +268,7 @@ void OscilloscopeWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void OscilloscopeWidget::openConfigDialog()
 {
-    showConfigDialog(new OscilloscopeConfigDialog(this, this));
+    showConfigDialog(new OscilloscopeConfigDialog(this, this), Qt::NonModal);
 }
 
 void OscilloscopeWidget::handlePlayStateChanged(Player::PlayState state)

--- a/src/plugins/oscilloscope/oscilloscopewidget.h
+++ b/src/plugins/oscilloscope/oscilloscopewidget.h
@@ -89,6 +89,9 @@ public:
 
     [[nodiscard]] QSize minimumSizeHint() const override;
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void timerEvent(QTimerEvent* event) override;

--- a/src/plugins/projectm/projectmconfigdialog.cpp
+++ b/src/plugins/projectm/projectmconfigdialog.cpp
@@ -192,6 +192,8 @@ ProjectMConfigDialog::ProjectMConfigDialog(ProjectMWidget* widget, QWidget* pare
     QObject::connect(m_hardCutsEnabled, &QCheckBox::toggled, m_beatSensitivity, &QWidget::setEnabled);
     QObject::connect(m_presetDir, &QLineEdit::editingFinished, this, &ProjectMConfigDialog::updateSummary);
 
+    QObject::connect(widget, &ProjectMWidget::configChanged, this, &ProjectMConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -230,6 +232,20 @@ void ProjectMConfigDialog::setConfig(const ProjectMWidget::ConfigData& config)
     m_hardCutSensitivity->setEnabled(config.settings.hardCutsEnabled);
     m_beatSensitivity->setEnabled(config.settings.hardCutsEnabled);
     updateSummary();
+}
+
+void ProjectMConfigDialog::mergeExternalConfig(const ProjectMWidget::ConfigData& previous,
+                                               const ProjectMWidget::ConfigData& current)
+{
+    auto draft{config()};
+    mergeExternalFieldValues(previous, current, draft, &ProjectMWidget::ConfigData::presetDir);
+    mergeExternalFieldValues(previous.settings, current.settings, draft.settings, &ProjectMSettings::scanRecursive,
+                             &ProjectMSettings::maxFps, &ProjectMSettings::meshWidth, &ProjectMSettings::meshHeight,
+                             &ProjectMSettings::aspectCorrection, &ProjectMSettings::presetDuration,
+                             &ProjectMSettings::softCutDuration, &ProjectMSettings::hardCutsEnabled,
+                             &ProjectMSettings::hardCutDuration, &ProjectMSettings::hardCutSensitivity,
+                             &ProjectMSettings::beatSensitivity);
+    setConfig(draft);
 }
 
 void ProjectMConfigDialog::browsePresetDir()

--- a/src/plugins/projectm/projectmconfigdialog.h
+++ b/src/plugins/projectm/projectmconfigdialog.h
@@ -42,6 +42,8 @@ public:
 protected:
     [[nodiscard]] ProjectMWidget::ConfigData config() const override;
     void setConfig(const ProjectMWidget::ConfigData& config) override;
+    void mergeExternalConfig(const ProjectMWidget::ConfigData& previous,
+                             const ProjectMWidget::ConfigData& current) override;
 
 private:
     void browsePresetDir();

--- a/src/plugins/projectm/projectmwidget.cpp
+++ b/src/plugins/projectm/projectmwidget.cpp
@@ -315,6 +315,8 @@ void ProjectMWidget::loadLayoutData(const QJsonObject& layout)
     }
 
     updateActionState();
+
+    Q_EMIT configChanged();
 }
 
 ProjectMWidget::ConfigData ProjectMWidget::factoryConfig() const
@@ -368,6 +370,8 @@ void ProjectMWidget::applyConfig(const ConfigData& config)
     scanPresetLibrary();
     m_view->setPresetDirs(presetDirs(m_config));
     m_view->applySettings(m_config.settings);
+
+    Q_EMIT configChanged();
 }
 
 void ProjectMWidget::saveDefaults(const ConfigData& config) const
@@ -492,7 +496,8 @@ void ProjectMWidget::closeEvent(QCloseEvent* event)
 
 void ProjectMWidget::openConfigDialog()
 {
-    showConfigDialog(new ProjectMConfigDialog(this, m_fullScreenWindow ? m_fullScreenWindow.data() : this));
+    showConfigDialog(new ProjectMConfigDialog(this, m_fullScreenWindow ? m_fullScreenWindow.data() : this),
+                     Qt::NonModal);
 }
 
 void ProjectMWidget::setupActions()
@@ -783,6 +788,8 @@ void ProjectMWidget::setPresetDuration(int seconds)
     m_config                         = normaliseConfig(m_config);
     m_view->applySettings(m_config.settings);
     updateActionState();
+
+    Q_EMIT configChanged();
 }
 
 void ProjectMWidget::installSplitterEventFilters()

--- a/src/plugins/projectm/projectmwidget.h
+++ b/src/plugins/projectm/projectmwidget.h
@@ -82,6 +82,9 @@ public:
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void showEvent(QShowEvent* event) override;

--- a/src/plugins/radiobrowser/radiobrowserconfigdialog.cpp
+++ b/src/plugins/radiobrowser/radiobrowserconfigdialog.cpp
@@ -162,6 +162,11 @@ RadioBrowserConfigDialog::RadioBrowserConfigDialog(RadioBrowserWidget* radioBrow
 
     QObject::connect(m_overrideRowHeight, &QCheckBox::toggled, m_rowHeight, &QWidget::setEnabled);
 
+    m_sendClicks->setChecked(radioBrowser->sendClicks());
+    QObject::connect(radioBrowser, &RadioBrowserWidget::configChanged, this,
+                     &RadioBrowserConfigDialog::syncCurrentConfig);
+    QObject::connect(radioBrowser, &RadioBrowserWidget::sendClicksChanged, m_sendClicks, &QCheckBox::setChecked);
+
     loadCurrentConfig();
 }
 
@@ -200,7 +205,6 @@ void RadioBrowserConfigDialog::setConfig(const RadioBrowserWidget::ConfigData& c
 
     m_playbackOnSend->setChecked(config.playbackOnSend);
     m_hideBroken->setChecked(config.hideBroken);
-    m_sendClicks->setChecked(widget()->sendClicks());
     m_rowHeight->setEnabled(config.view.rowHeight > 0);
     m_overrideRowHeight->setChecked(config.view.rowHeight > 0);
     m_rowHeight->setValue(config.view.rowHeight);
@@ -214,5 +218,31 @@ void RadioBrowserConfigDialog::setConfig(const RadioBrowserWidget::ConfigData& c
     m_useIconGapsForSideCaptions->setChecked(config.view.useIconGapsForSideCaptions);
     m_iconItemBorder->setValue(config.view.iconItemBorderWidth);
     m_uniformStationIcons->setChecked(config.view.uniformStationIcons);
+}
+
+void RadioBrowserConfigDialog::mergeExternalConfig(const RadioBrowserWidget::ConfigData& previous,
+                                                   const RadioBrowserWidget::ConfigData& current)
+{
+    auto draft{config()};
+    mergeExternalFieldValues(previous, current, draft, &RadioBrowserWidget::ConfigData::doubleClickAction,
+                             &RadioBrowserWidget::ConfigData::middleClickAction,
+                             &RadioBrowserWidget::ConfigData::playbackOnSend,
+                             &RadioBrowserWidget::ConfigData::hideBroken);
+    mergeExternalFieldValues(
+        previous.view, current.view, draft.view, &RadioBrowserWidget::ConfigData::ViewConfig::viewMode,
+        &RadioBrowserWidget::ConfigData::ViewConfig::captions, &RadioBrowserWidget::ConfigData::ViewConfig::showHeader,
+        &RadioBrowserWidget::ConfigData::ViewConfig::showScrollbar,
+        &RadioBrowserWidget::ConfigData::ViewConfig::alternatingRows,
+        &RadioBrowserWidget::ConfigData::ViewConfig::showIcons,
+        &RadioBrowserWidget::ConfigData::ViewConfig::showSavedStationIcons,
+        &RadioBrowserWidget::ConfigData::ViewConfig::showToolTips,
+        &RadioBrowserWidget::ConfigData::ViewConfig::separateSavedStationsViewState,
+        &RadioBrowserWidget::ConfigData::ViewConfig::rowHeight, &RadioBrowserWidget::ConfigData::ViewConfig::iconSize,
+        &RadioBrowserWidget::ConfigData::ViewConfig::iconHorizontalGap,
+        &RadioBrowserWidget::ConfigData::ViewConfig::iconVerticalGap,
+        &RadioBrowserWidget::ConfigData::ViewConfig::useIconGapsForSideCaptions,
+        &RadioBrowserWidget::ConfigData::ViewConfig::iconItemBorderWidth,
+        &RadioBrowserWidget::ConfigData::ViewConfig::uniformStationIcons);
+    setConfig(draft);
 }
 } // namespace Fooyin::RadioBrowser

--- a/src/plugins/radiobrowser/radiobrowserconfigdialog.h
+++ b/src/plugins/radiobrowser/radiobrowserconfigdialog.h
@@ -40,6 +40,8 @@ public:
 protected:
     [[nodiscard]] RadioBrowserWidget::ConfigData config() const override;
     void setConfig(const RadioBrowserWidget::ConfigData& config) override;
+    void mergeExternalConfig(const RadioBrowserWidget::ConfigData& previous,
+                             const RadioBrowserWidget::ConfigData& current) override;
 
 private:
     QComboBox* m_middleClick;

--- a/src/plugins/radiobrowser/radiobrowserwidget.cpp
+++ b/src/plugins/radiobrowser/radiobrowserwidget.cpp
@@ -698,6 +698,8 @@ void RadioBrowserWidget::clearSavedDefaults() const
 
 void RadioBrowserWidget::applyConfig(const ConfigData& config)
 {
+    const ConfigData previousConfig{m_config};
+
     const bool searchConfigChanged = m_hideBroken != config.hideBroken;
 
     m_config.doubleClickAction = config.doubleClickAction;
@@ -710,10 +712,14 @@ void RadioBrowserWidget::applyConfig(const ConfigData& config)
     m_hideBroken               = config.hideBroken;
 
     m_controller->setHideBroken(m_hideBroken);
-    setViewConfig(config.view);
+    setViewConfig(config.view, false);
 
     if(searchConfigChanged && !m_loadingLayout) {
         applyFilterSearch();
+    }
+
+    if(previousConfig != m_config) {
+        Q_EMIT configChanged();
     }
 }
 
@@ -724,9 +730,13 @@ bool RadioBrowserWidget::sendClicks() const
 
 void RadioBrowserWidget::setSendClicks(const bool enabled)
 {
-    m_sendClicks = enabled;
+    if(std::exchange(m_sendClicks, enabled) == enabled) {
+        return;
+    }
+
     m_settings->fileSet(SendClicksKey, enabled);
     m_controller->setSendClicks(enabled);
+    Q_EMIT sendClicksChanged(enabled);
 }
 
 bool RadioBrowserWidget::separateSavedStationsViewStateAllowed() const
@@ -755,7 +765,7 @@ void RadioBrowserWidget::showEvent(QShowEvent* event)
 
 void RadioBrowserWidget::openConfigDialog()
 {
-    showConfigDialog(new RadioBrowserConfigDialog(this, this));
+    showConfigDialog(new RadioBrowserConfigDialog(this, this), Qt::NonModal);
 }
 
 void RadioBrowserWidget::handleIconSizeChanged(const QSize& size)
@@ -1076,6 +1086,8 @@ RadioSearchRequest RadioBrowserWidget::currentFilterRequest() const
 
 void RadioBrowserWidget::setFilterRequest(const RadioSearchRequest& request)
 {
+    const bool hideBrokenChanged = m_config.hideBroken != request.hideBroken;
+
     m_filterRequest = request;
 
     if(m_filterBar) {
@@ -1086,6 +1098,10 @@ void RadioBrowserWidget::setFilterRequest(const RadioSearchRequest& request)
     m_config.hideBroken = m_hideBroken;
     m_controller->setHideBroken(m_hideBroken);
     updateSavedSearchState();
+
+    if(hideBrokenChanged) {
+        Q_EMIT configChanged();
+    }
 }
 
 void RadioBrowserWidget::updateSavedSearchState()
@@ -1898,8 +1914,9 @@ void RadioBrowserWidget::applyActiveViewState()
     updateIconColumnOrder();
 }
 
-void RadioBrowserWidget::setViewConfig(const ConfigData::ViewConfig& config)
+void RadioBrowserWidget::setViewConfig(const ConfigData::ViewConfig& config, const bool notify)
 {
+    const ConfigData::ViewConfig previousConfig{m_config.view};
     const bool separateViewStateWasEnabled = m_config.view.separateSavedStationsViewState;
 
     ConfigData::ViewConfig requestedConfig{config};
@@ -1998,6 +2015,10 @@ void RadioBrowserWidget::setViewConfig(const ConfigData::ViewConfig& config)
     }
 
     QMetaObject::invokeMethod(m_resultsView->itemDelegate(), "sizeHintChanged", Q_ARG(QModelIndex, {}));
+
+    if(notify && previousConfig != m_config.view) {
+        Q_EMIT configChanged();
+    }
 }
 
 void RadioBrowserWidget::updateIconColumnOrder()

--- a/src/plugins/radiobrowser/radiobrowserwidget.h
+++ b/src/plugins/radiobrowser/radiobrowserwidget.h
@@ -97,6 +97,8 @@ public:
             bool useIconGapsForSideCaptions{true};
             int iconItemBorderWidth{2};
             bool uniformStationIcons{true};
+
+            bool operator==(const ViewConfig&) const = default;
         };
 
         ViewConfig view;
@@ -104,6 +106,8 @@ public:
         int middleClickAction{0};
         bool playbackOnSend{true};
         bool hideBroken{true};
+
+        bool operator==(const ConfigData&) const = default;
     };
 
     [[nodiscard]] ConfigData factoryConfig() const;
@@ -116,6 +120,10 @@ public:
     void setSendClicks(bool enabled);
     [[nodiscard]] bool separateSavedStationsViewStateAllowed() const;
     void setSeparateSavedStationsViewStateAllowed(bool allowed);
+
+Q_SIGNALS:
+    void configChanged();
+    void sendClicksChanged(bool enabled);
 
 protected:
     void showEvent(QShowEvent* event) override;
@@ -188,7 +196,7 @@ private:
 
     void saveCurrentViewState();
     void applyActiveViewState();
-    void setViewConfig(const ConfigData::ViewConfig& config);
+    void setViewConfig(const ConfigData::ViewConfig& config, bool notify = true);
     void updateIconColumnOrder();
     void disconnectFilterBar();
     void updateFilterBarCategories();

--- a/src/plugins/radiobrowser/radioguidewidget.cpp
+++ b/src/plugins/radiobrowser/radioguidewidget.cpp
@@ -310,7 +310,7 @@ void RadioGuideWidget::applyConfig(const ConfigData& config)
 
 void RadioGuideWidget::openConfigDialog()
 {
-    showConfigDialog(new RadioGuideConfigDialog(this, this));
+    showConfigDialog(new RadioGuideConfigDialog(this, this), Qt::NonModal);
 }
 
 void RadioGuideWidget::initialiseModel()

--- a/src/plugins/scrobbler/settings/scrobblerpage.cpp
+++ b/src/plugins/scrobbler/settings/scrobblerpage.cpp
@@ -149,6 +149,11 @@ ScrobblerPageWidget::ScrobblerPageWidget(SettingsManager* settings)
     QObject::connect(m_scrobblingEnabled, &QCheckBox::toggled, this, &ScrobblerPageWidget::updateWidgetState);
     QObject::connect(m_filterScrobbles, &QCheckBox::toggled, this, &ScrobblerPageWidget::updateWidgetState);
     QObject::connect(m_sendAlbumArtist, &QCheckBox::toggled, this, &ScrobblerPageWidget::updateWidgetState);
+
+    m_settings->subscribe<Settings::Scrobbler::ScrobblingEnabled>(this, [this](const bool enabled) {
+        m_scrobblingEnabled->setChecked(enabled);
+        updateWidgetState();
+    });
 }
 
 void ScrobblerPageWidget::load()

--- a/src/plugins/sleepinhibitor/sleepinhibitorsettings.cpp
+++ b/src/plugins/sleepinhibitor/sleepinhibitorsettings.cpp
@@ -36,7 +36,6 @@ SleepInhibitorSettings::SleepInhibitorSettings(QWidget* parent)
     namespace Settings = SleepInhibitor::Settings;
 
     setWindowTitle(tr("Sleep Inhibitor Settings"));
-    setModal(true);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     QObject::connect(buttons, &QDialogButtonBox::accepted, this, &SleepInhibitorSettings::accept);

--- a/src/plugins/spectrogram/spectrogramconfigwidget.cpp
+++ b/src/plugins/spectrogram/spectrogramconfigwidget.cpp
@@ -125,6 +125,8 @@ SpectrogramConfigDialog::SpectrogramConfigDialog(SpectrogramWidget* widget, QWid
     layout->addWidget(tabs, 0, 0);
     layout->setRowStretch(0, 1);
 
+    QObject::connect(widget, &SpectrogramWidget::configChanged, this, &SpectrogramConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -178,5 +180,16 @@ void SpectrogramConfigDialog::setConfig(const SpectrogramWidget::ConfigData& con
     m_minDb->setValue(config.minDb);
     m_maxDb->setValue(config.maxDb);
     m_colours->setColours(config.colours);
+}
+
+void SpectrogramConfigDialog::mergeExternalConfig(const SpectrogramWidget::ConfigData& previous,
+                                                  const SpectrogramWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &SpectrogramWidget::ConfigData::channelMode,
+                        &SpectrogramWidget::ConfigData::presentationMode, &SpectrogramWidget::ConfigData::logFrequency,
+                        &SpectrogramWidget::ConfigData::clearOnTrackChange,
+                        &SpectrogramWidget::ConfigData::channelSpacing, &SpectrogramWidget::ConfigData::fftSize,
+                        &SpectrogramWidget::ConfigData::minDb, &SpectrogramWidget::ConfigData::maxDb,
+                        &SpectrogramWidget::ConfigData::windowFunction, &SpectrogramWidget::ConfigData::colours);
 }
 } // namespace Fooyin::Spectrogram

--- a/src/plugins/spectrogram/spectrogramconfigwidget.h
+++ b/src/plugins/spectrogram/spectrogramconfigwidget.h
@@ -41,6 +41,8 @@ public:
 protected:
     [[nodiscard]] SpectrogramWidget::ConfigData config() const override;
     void setConfig(const SpectrogramWidget::ConfigData& config) override;
+    void mergeExternalConfig(const SpectrogramWidget::ConfigData& previous,
+                             const SpectrogramWidget::ConfigData& current) override;
 
 private:
     QCheckBox* m_logFrequency;

--- a/src/plugins/spectrogram/spectrogramwidget.cpp
+++ b/src/plugins/spectrogram/spectrogramwidget.cpp
@@ -429,6 +429,8 @@ void SpectrogramWidget::applyConfig(const ConfigData& config)
     updateTimerState();
     renderFrame();
     update();
+
+    Q_EMIT configChanged();
 }
 
 QSize SpectrogramWidget::minimumSizeHint() const
@@ -611,7 +613,7 @@ void SpectrogramWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void SpectrogramWidget::openConfigDialog()
 {
-    showConfigDialog(new SpectrogramConfigDialog(this, this));
+    showConfigDialog(new SpectrogramConfigDialog(this, this), Qt::NonModal);
 }
 
 SpectrogramWidget::ConfigData SpectrogramWidget::configFromLayout(const QJsonObject& layout) const

--- a/src/plugins/spectrogram/spectrogramwidget.h
+++ b/src/plugins/spectrogram/spectrogramwidget.h
@@ -101,6 +101,9 @@ public:
     [[nodiscard]] QSize minimumSizeHint() const override;
     [[nodiscard]] QSize sizeHint() const override;
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void showEvent(QShowEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;

--- a/src/plugins/spectrum/spectrumconfigwidget.cpp
+++ b/src/plugins/spectrum/spectrumconfigwidget.cpp
@@ -480,6 +480,8 @@ SpectrumConfigDialog::SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* pa
     layout->addWidget(tabs, 0, 0);
     layout->setColumnStretch(0, 1);
 
+    QObject::connect(spectrum, &SpectrumWidget::configChanged, this, &SpectrumConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -649,6 +651,30 @@ void SpectrumConfigDialog::setConfig(const SpectrumWidget::ConfigData& config)
     loadColour(m_octaveGridColour, Colours::Type::OctaveGrid);
     loadColour(m_whiteKeyColour, Colours::Type::WhiteKey);
     loadColour(m_blackKeyColour, Colours::Type::BlackKey);
+}
+
+void SpectrumConfigDialog::mergeExternalConfig(const SpectrumWidget::ConfigData& previous,
+                                               const SpectrumWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &SpectrumWidget::ConfigData::bandCount,
+                        &SpectrumWidget::ConfigData::barSpacing, &SpectrumWidget::ConfigData::barSections,
+                        &SpectrumWidget::ConfigData::sectionSpacing, &SpectrumWidget::ConfigData::minFrequencyHz,
+                        &SpectrumWidget::ConfigData::maxFrequencyHz, &SpectrumWidget::ConfigData::minNote,
+                        &SpectrumWidget::ConfigData::maxNote, &SpectrumWidget::ConfigData::pitchHz,
+                        &SpectrumWidget::ConfigData::transpose, &SpectrumWidget::ConfigData::amplitudeMinDb,
+                        &SpectrumWidget::ConfigData::amplitudeMaxDb, &SpectrumWidget::ConfigData::amplitudesEnabled,
+                        &SpectrumWidget::ConfigData::amplitudeHoldTimeMs, &SpectrumWidget::ConfigData::amplitudeGravity,
+                        &SpectrumWidget::ConfigData::peaksEnabled, &SpectrumWidget::ConfigData::peakHoldTimeMs,
+                        &SpectrumWidget::ConfigData::peakGravity, &SpectrumWidget::ConfigData::updateFps,
+                        &SpectrumWidget::ConfigData::fftSize, &SpectrumWidget::ConfigData::windowFunction,
+                        &SpectrumWidget::ConfigData::gradientOrientation, &SpectrumWidget::ConfigData::labelMode,
+                        &SpectrumWidget::ConfigData::drawStyle, &SpectrumWidget::ConfigData::showTopLabels,
+                        &SpectrumWidget::ConfigData::showBottomLabels, &SpectrumWidget::ConfigData::showLeftLabels,
+                        &SpectrumWidget::ConfigData::showRightLabels, &SpectrumWidget::ConfigData::showHorizontalGrid,
+                        &SpectrumWidget::ConfigData::showVerticalGrid, &SpectrumWidget::ConfigData::showWhiteKeys,
+                        &SpectrumWidget::ConfigData::showBlackKeys, &SpectrumWidget::ConfigData::showTooltip,
+                        &SpectrumWidget::ConfigData::fillSpectrum, &SpectrumWidget::ConfigData::interpolate,
+                        &SpectrumWidget::ConfigData::axisFont, &SpectrumWidget::ConfigData::colours);
 }
 } // namespace Fooyin::Spectrum
 

--- a/src/plugins/spectrum/spectrumconfigwidget.h
+++ b/src/plugins/spectrum/spectrumconfigwidget.h
@@ -41,10 +41,13 @@ class SpectrumConfigDialog : public WidgetConfigDialog<SpectrumWidget, SpectrumW
 public:
     explicit SpectrumConfigDialog(SpectrumWidget* spectrum, QWidget* parent = nullptr);
 
-private:
+protected:
     [[nodiscard]] SpectrumWidget::ConfigData config() const override;
     void setConfig(const SpectrumWidget::ConfigData& config) override;
+    void mergeExternalConfig(const SpectrumWidget::ConfigData& previous,
+                             const SpectrumWidget::ConfigData& current) override;
 
+private:
     QSpinBox* m_bandCount;
     QSpinBox* m_barSpacing;
     QSpinBox* m_barSections;

--- a/src/plugins/spectrum/spectrumwidget.cpp
+++ b/src/plugins/spectrum/spectrumwidget.cpp
@@ -351,6 +351,8 @@ void SpectrumWidget::applyConfig(const ConfigData& config)
 
     m_config = validated;
     m_view->setConfig(m_config);
+
+    Q_EMIT configChanged();
 }
 
 QSize SpectrumWidget::minimumSizeHint() const
@@ -370,7 +372,7 @@ void SpectrumWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void SpectrumWidget::openConfigDialog()
 {
-    showConfigDialog(new SpectrumConfigDialog(this, this));
+    showConfigDialog(new SpectrumConfigDialog(this, this), Qt::NonModal);
 }
 
 SpectrumWidget::ConfigData SpectrumWidget::configFromLayout(const QJsonObject& layout) const

--- a/src/plugins/spectrum/spectrumwidget.h
+++ b/src/plugins/spectrum/spectrumwidget.h
@@ -99,6 +99,9 @@ public:
     [[nodiscard]] QSize minimumSizeHint() const override;
     [[nodiscard]] QSize sizeHint() const override;
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void openConfigDialog() override;

--- a/src/plugins/vumeter/vumeterconfigwidget.cpp
+++ b/src/plugins/vumeter/vumeterconfigwidget.cpp
@@ -165,6 +165,8 @@ VuMeterConfigDialog::VuMeterConfigDialog(VuMeter::VuMeterWidget* vuMeter, QWidge
     layout->addWidget(tabs, 0, 0);
     layout->setRowStretch(0, 1);
 
+    QObject::connect(vuMeter, &VuMeterWidget::configChanged, this, &VuMeterConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
 }
 
@@ -240,5 +242,17 @@ void VuMeterConfigDialog::setConfig(const VuMeterWidget::ConfigData& config)
     m_barGradient->setColours(colours.gradient(palette()));
     m_barGradient->setEnabled(m_barGradientEnabled->isChecked());
     m_barGradient->setOrientation(widget()->orientation());
+}
+
+void VuMeterConfigDialog::mergeExternalConfig(const VuMeterWidget::ConfigData& previous,
+                                              const VuMeterWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &VuMeterWidget::ConfigData::peakHoldTimeMs,
+                        &VuMeterWidget::ConfigData::falloffTime, &VuMeterWidget::ConfigData::peakFalloffTime,
+                        &VuMeterWidget::ConfigData::showPeaks, &VuMeterWidget::ConfigData::showLegend,
+                        &VuMeterWidget::ConfigData::updateFps, &VuMeterWidget::ConfigData::channelSpacing,
+                        &VuMeterWidget::ConfigData::barSize, &VuMeterWidget::ConfigData::barSpacing,
+                        &VuMeterWidget::ConfigData::barSections, &VuMeterWidget::ConfigData::sectionSpacing,
+                        &VuMeterWidget::ConfigData::meterColours);
 }
 } // namespace Fooyin::VuMeter

--- a/src/plugins/vumeter/vumeterconfigwidget.h
+++ b/src/plugins/vumeter/vumeterconfigwidget.h
@@ -40,10 +40,13 @@ class VuMeterConfigDialog : public WidgetConfigDialog<VuMeterWidget, VuMeterWidg
 public:
     explicit VuMeterConfigDialog(VuMeterWidget* vuMeter, QWidget* parent = nullptr);
 
-private:
+protected:
     [[nodiscard]] VuMeterWidget::ConfigData config() const override;
     void setConfig(const VuMeterWidget::ConfigData& config) override;
+    void mergeExternalConfig(const VuMeterWidget::ConfigData& previous,
+                             const VuMeterWidget::ConfigData& current) override;
 
+private:
     QSpinBox* m_peakHold;
     QSpinBox* m_falloff;
     QSpinBox* m_peakFalloff;

--- a/src/plugins/vumeter/vumeterwidget.cpp
+++ b/src/plugins/vumeter/vumeterwidget.cpp
@@ -945,6 +945,8 @@ void VuMeterWidget::applyConfig(const ConfigData& config)
 
     p->updateSize();
     update();
+
+    Q_EMIT configChanged();
 }
 
 VuMeterWidget::ConfigData VuMeterWidget::configFromLayout(const QJsonObject& layout) const
@@ -1159,6 +1161,8 @@ void VuMeterWidget::setShowLegend(bool show)
     m_config.showLegend = show;
     p->updateSize();
     update();
+
+    Q_EMIT configChanged();
 }
 
 void VuMeterWidget::setChannelSpacing(int size)
@@ -1198,7 +1202,7 @@ void VuMeterWidget::setSectionSpacing(int size)
 
 void VuMeterWidget::openConfigDialog()
 {
-    showConfigDialog(new VuMeterConfigDialog(this, this));
+    showConfigDialog(new VuMeterConfigDialog(this, this), Qt::NonModal);
 }
 
 QSize VuMeterWidget::minimumSizeHint() const
@@ -1278,6 +1282,8 @@ void VuMeterWidget::contextMenuEvent(QContextMenuEvent* event)
         p->m_showPeaks     = checked;
         m_config.showPeaks = checked;
         update();
+
+        Q_EMIT configChanged();
     });
 
     auto* showLegend = new QAction(tr("Show legend"), menu);

--- a/src/plugins/vumeter/vumeterwidget.h
+++ b/src/plugins/vumeter/vumeterwidget.h
@@ -90,6 +90,9 @@ public:
     void clearSavedDefaults() const;
     void applyConfig(const ConfigData& config);
 
+Q_SIGNALS:
+    void configChanged();
+
 protected:
     void showEvent(QShowEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;

--- a/src/plugins/wavebar/wavebarconfigwidget.cpp
+++ b/src/plugins/wavebar/wavebarconfigwidget.cpp
@@ -280,6 +280,8 @@ WaveBarConfigDialog::WaveBarConfigDialog(WaveBarWidget* waveBar, QWidget* parent
         updateCacheSize();
     });
 
+    QObject::connect(waveBar, &WaveBarWidget::configChanged, this, &WaveBarConfigDialog::syncCurrentConfig);
+
     loadCurrentConfig();
     setGlobalCacheConfig(widget()->globalNumSamples());
     updateCacheSize();
@@ -409,6 +411,20 @@ void WaveBarConfigDialog::setConfig(const WaveBarWidget::ConfigData& config)
     loadColour(m_rmsMinBorder, Colours::Type::RmsMinBorder);
     loadColour(m_cursorColour, Colours::Type::Cursor);
     loadColour(m_seekingCursorColour, Colours::Type::SeekingCursor);
+}
+
+void WaveBarConfigDialog::mergeExternalConfig(const WaveBarWidget::ConfigData& previous,
+                                              const WaveBarWidget::ConfigData& current)
+{
+    mergeExternalFields(previous, current, &WaveBarWidget::ConfigData::showLabels,
+                        &WaveBarWidget::ConfigData::showRemainingTime, &WaveBarWidget::ConfigData::showCursor,
+                        &WaveBarWidget::ConfigData::cursorWidth, &WaveBarWidget::ConfigData::mode,
+                        &WaveBarWidget::ConfigData::downmix, &WaveBarWidget::ConfigData::barWidth,
+                        &WaveBarWidget::ConfigData::barGap, &WaveBarWidget::ConfigData::supersampleFactor,
+                        &WaveBarWidget::ConfigData::peakDisplayMode, &WaveBarWidget::ConfigData::normaliseToPeak,
+                        &WaveBarWidget::ConfigData::decibelScale, &WaveBarWidget::ConfigData::maxScale,
+                        &WaveBarWidget::ConfigData::centreGap, &WaveBarWidget::ConfigData::channelScale,
+                        &WaveBarWidget::ConfigData::colourOptions);
 }
 
 void WaveBarConfigDialog::apply()

--- a/src/plugins/wavebar/wavebarconfigwidget.h
+++ b/src/plugins/wavebar/wavebarconfigwidget.h
@@ -52,6 +52,8 @@ public:
 protected:
     [[nodiscard]] WaveBarWidget::ConfigData config() const override;
     void setConfig(const WaveBarWidget::ConfigData& config) override;
+    void mergeExternalConfig(const WaveBarWidget::ConfigData& previous,
+                             const WaveBarWidget::ConfigData& current) override;
 
 private:
     void setGlobalCacheConfig(int numSamples);

--- a/src/plugins/wavebar/wavebarwidget.cpp
+++ b/src/plugins/wavebar/wavebarwidget.cpp
@@ -341,6 +341,8 @@ void WaveBarWidget::applyConfig(const ConfigData& config)
     m_builder->setDecibelScale(m_config.decibelScale);
 
     QMetaObject::invokeMethod(m_container, [this]() { rescaleWaveform(); }, Qt::QueuedConnection);
+
+    Q_EMIT configChanged();
 }
 
 WaveBarWidget::ConfigData WaveBarWidget::configFromLayout(const QJsonObject& layout) const
@@ -530,7 +532,7 @@ void WaveBarWidget::resizeEvent(QResizeEvent* event)
 
 void WaveBarWidget::openConfigDialog()
 {
-    showConfigDialog(new WaveBarConfigDialog(this, this));
+    showConfigDialog(new WaveBarConfigDialog(this, this), Qt::NonModal);
 }
 
 void WaveBarWidget::contextMenuEvent(QContextMenuEvent* event)

--- a/src/plugins/wavebar/wavebarwidget.h
+++ b/src/plugins/wavebar/wavebarwidget.h
@@ -87,6 +87,7 @@ public:
     void requestClearCache();
 
 Q_SIGNALS:
+    void configChanged();
     void clearCacheRequested();
 
 protected:

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/utils/helpers.h
     ${CMAKE_SOURCE_DIR}/include/utils/id.h
     ${CMAKE_SOURCE_DIR}/include/utils/itemregistry.h
+    ${CMAKE_SOURCE_DIR}/include/utils/jsonutils.h
     ${CMAKE_SOURCE_DIR}/include/utils/lockfreeringbuffer.h
     ${CMAKE_SOURCE_DIR}/include/utils/logging/messagehandler.h
     ${CMAKE_SOURCE_DIR}/include/utils/modelutils.h
@@ -69,6 +70,7 @@ set(SOURCES
     fypaths.cpp
     id.cpp
     itemregistry.cpp
+    jsonutils.cpp
     logging/logmodel.cpp
     logging/logmodel.h
     logging/logwidget.cpp

--- a/src/utils/jsonutils.cpp
+++ b/src/utils/jsonutils.cpp
@@ -1,0 +1,133 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <utils/jsonutils.h>
+
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <set>
+#include <unordered_map>
+
+namespace Fooyin::Utils {
+QJsonValue mergeJsonThreeWay(const QJsonValue& base, const QJsonValue& first, const QJsonValue& second,
+                             const JsonArrayItemIdentity& arrayItemIdentity)
+{
+    if(second == base) {
+        return first;
+    }
+    if(first == base || first == second) {
+        return second;
+    }
+
+    if(base.isObject() && first.isObject() && second.isObject()) {
+        const auto baseObject   = base.toObject();
+        const auto firstObject  = first.toObject();
+        const auto secondObject = second.toObject();
+
+        std::set<QString> keys;
+        for(auto it = baseObject.constBegin(); it != baseObject.constEnd(); ++it) {
+            keys.insert(it.key());
+        }
+        for(auto it = firstObject.constBegin(); it != firstObject.constEnd(); ++it) {
+            keys.insert(it.key());
+        }
+        for(auto it = secondObject.constBegin(); it != secondObject.constEnd(); ++it) {
+            keys.insert(it.key());
+        }
+
+        QJsonObject merged;
+        for(const auto& key : keys) {
+            const auto value = mergeJsonThreeWay(baseObject.value(key), firstObject.value(key), secondObject.value(key),
+                                                 arrayItemIdentity);
+            if(!value.isUndefined()) {
+                merged.insert(key, value);
+            }
+        }
+        return merged;
+    }
+
+    if(base.isArray() && first.isArray() && second.isArray()) {
+        const auto baseArray   = base.toArray();
+        const auto firstArray  = first.toArray();
+        const auto secondArray = second.toArray();
+
+        if(arrayItemIdentity) {
+            std::unordered_map<QString, QJsonValue> baseItems;
+            std::unordered_map<QString, QJsonValue> firstItems;
+            std::unordered_map<QString, QJsonValue> secondItems;
+            bool identified{true};
+
+            for(const auto& value : baseArray) {
+                const QString identity = arrayItemIdentity(value);
+                identified &= !identity.isEmpty() && baseItems.emplace(identity, value).second;
+            }
+            for(const auto& value : firstArray) {
+                const QString identity = arrayItemIdentity(value);
+                identified &= !identity.isEmpty() && firstItems.emplace(identity, value).second;
+            }
+            for(const auto& value : secondArray) {
+                const QString identity = arrayItemIdentity(value);
+                identified &= !identity.isEmpty() && secondItems.emplace(identity, value).second;
+            }
+
+            if(!identified) {
+                return second;
+            }
+
+            QJsonArray merged;
+            for(const auto& value : secondArray) {
+                const QString identity = arrayItemIdentity(value);
+                const auto baseItem    = baseItems.find(identity);
+                const auto firstItem   = firstItems.find(identity);
+
+                if(baseItem == baseItems.end()) {
+                    merged.append(value);
+                }
+                else if(firstItem != firstItems.end()) {
+                    merged.append(mergeJsonThreeWay(baseItem->second, firstItem->second, value, arrayItemIdentity));
+                }
+                else if(value != baseItem->second) {
+                    merged.append(value);
+                }
+            }
+
+            for(const auto& value : firstArray) {
+                const QString identity = arrayItemIdentity(value);
+                if(!baseItems.contains(identity) && !secondItems.contains(identity)) {
+                    merged.append(value);
+                }
+            }
+
+            return merged;
+        }
+
+        if(baseArray.size() == firstArray.size() && firstArray.size() == secondArray.size()) {
+            QJsonArray merged;
+            for(qsizetype i{0}; i < secondArray.size(); ++i) {
+                merged.append(
+                    mergeJsonThreeWay(baseArray.at(i), firstArray.at(i), secondArray.at(i), arrayItemIdentity));
+            }
+            return merged;
+        }
+    }
+
+    return second;
+}
+} // namespace Fooyin::Utils

--- a/src/utils/settings/settingsdialog.cpp
+++ b/src/utils/settings/settingsdialog.cpp
@@ -180,7 +180,6 @@ SettingsDialog::SettingsDialog(PageList pages, QWidget* parent)
     , m_pages{std::move(pages)}
 {
     setWindowTitle(tr("Settings"));
-    setModal(true);
 
     m_stackedLayout->setContentsMargins(0, 0, 0, 0);
 
@@ -215,7 +214,8 @@ SettingsDialog::SettingsDialog(PageList pages, QWidget* parent)
 
 void SettingsDialog::openSettings()
 {
-    open();
+    setWindowModality(Qt::NonModal);
+    show();
 }
 
 void SettingsDialog::openPage(const Id& id)

--- a/src/utils/settings/settingsdialogcontroller.cpp
+++ b/src/utils/settings/settingsdialogcontroller.cpp
@@ -29,6 +29,7 @@
 #include <QDataStream>
 #include <QIODevice>
 #include <QMainWindow>
+#include <QPointer>
 #include <QSettings>
 
 #include <unordered_map>
@@ -100,7 +101,7 @@ public:
     std::unordered_map<QString, QByteArray> pageStates;
     PageList pages;
     Id lastOpenPage;
-    bool isOpen{false};
+    QPointer<SettingsDialog> dialog;
 
     void applyPageStates() const
     {
@@ -135,13 +136,20 @@ void SettingsDialogController::open()
 
 void SettingsDialogController::openAtPage(const Id& page)
 {
-    if(p->isOpen) {
+    if(p->dialog) {
+        p->dialog->show();
+        p->dialog->raise();
+        p->dialog->activateWindow();
+        if(page.isValid()) {
+            p->dialog->openPage(page);
+        }
         return;
     }
 
     p->applyPageStates();
 
     auto* settingsDialog = new SettingsDialog{p->pages, p->mainWindow};
+    p->dialog            = settingsDialog;
 
     QObject::connect(settingsDialog, &QDialog::finished, this, [this, settingsDialog]() {
         p->updatePageStates();
@@ -149,7 +157,7 @@ void SettingsDialogController::openAtPage(const Id& page)
         p->size               = settingsDialog->size();
         p->expandedCategories = settingsDialog->saveState();
         p->lastOpenPage       = settingsDialog->currentPage();
-        p->isOpen             = false;
+        p->dialog             = nullptr;
         Q_EMIT closing();
         settingsDialog->deleteLater();
     });
@@ -164,7 +172,6 @@ void SettingsDialogController::openAtPage(const Id& page)
     }
     settingsDialog->restoreState(p->expandedCategories);
 
-    p->isOpen = true;
     Q_EMIT opening();
 
     settingsDialog->openSettings();


### PR DESCRIPTION
Makes widget, DSP, plugin, and settings dialogs non-modal. Adds live sync and draft merging where settings can also change outside their dialogs.

Closes #1402