### PR TITLE
[gui] Add MusicBrainz metadata lookup

### DIFF
--- a/include/core/track.h
+++ b/include/core/track.h
@@ -327,6 +327,9 @@ public:
     //! Sets rating on the internal 0-10 half-star scale; 0 clears the rating.
     void setRatingStars(int rating);
 
+    //! Clears metadata and extra tags while retaining ratings, ReplayGain and playback statistics.
+    void clearWritableTags();
+
     void setRGTrackGain(float gain);
     void setRGAlbumGain(float gain);
     void setRGTrackPeak(float peak);

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -100,20 +100,22 @@ constexpr auto SwitchLibrary  = "Fooyin.Menu.Library.Switch";
 constexpr auto Help           = "Fooyin.Menu.Help";
 
 namespace Context {
-constexpr auto Layout              = "Fooyin.Menu.Layout";
-constexpr auto AddWidget           = "Fooyin.Menu.Widget.Add";
-constexpr auto TrackSelection      = "Fooyin.Menu.Tracks";
-constexpr auto TrackQueue          = "Fooyin.Menu.Queue";
-constexpr auto TracksPlaylist      = "Fooyin.Menu.Tracks.Playlist";
-constexpr auto Playlist            = "Fooyin.Menu.Playlist";
-constexpr auto PlaylistAddTo       = "Fooyin.Menu.Playlist.AddTo";
-constexpr auto ReplayGain          = "Fooyin.Menu.ReplayGain";
-constexpr auto Artwork             = "Fooyin.Menu.Artwork";
-constexpr auto ArtworkAttach       = "Fooyin.Menu.Artwork.Attach";
-constexpr auto Tagging             = "Fooyin.Menu.Tagging";
-constexpr auto TrackFinalSeparator = "Fooyin.Menu.Track.FinalSeparator";
-constexpr auto Utilities           = "Fooyin.Menu.Utilities";
-constexpr auto Convert             = "Fooyin.Menu.Convert";
+constexpr auto Layout                 = "Fooyin.Menu.Layout";
+constexpr auto AddWidget              = "Fooyin.Menu.Widget.Add";
+constexpr auto TrackSelection         = "Fooyin.Menu.Tracks";
+constexpr auto TrackQueue             = "Fooyin.Menu.Queue";
+constexpr auto TracksPlaylist         = "Fooyin.Menu.Tracks.Playlist";
+constexpr auto Playlist               = "Fooyin.Menu.Playlist";
+constexpr auto PlaylistAddTo          = "Fooyin.Menu.Playlist.AddTo";
+constexpr auto ReplayGain             = "Fooyin.Menu.ReplayGain";
+constexpr auto Artwork                = "Fooyin.Menu.Artwork";
+constexpr auto ArtworkAttach          = "Fooyin.Menu.Artwork.Attach";
+constexpr auto Tagging                = "Fooyin.Menu.Tagging";
+constexpr auto TaggingLookupSeparator = "Fooyin.Menu.Tagging.LookupSeparator";
+constexpr auto TaggingReloadSeparator = "Fooyin.Menu.Tagging.ReloadSeparator";
+constexpr auto TrackFinalSeparator    = "Fooyin.Menu.Track.FinalSeparator";
+constexpr auto Utilities              = "Fooyin.Menu.Utilities";
+constexpr auto Convert                = "Fooyin.Menu.Convert";
 } // namespace Context
 } // namespace Menus
 
@@ -233,6 +235,8 @@ constexpr auto TogglePropertiesTrackList = "Tracks.Properties.ToggleTrackList";
 constexpr auto PropertiesPreviousTrack   = "Tracks.Properties.PreviousTrack";
 constexpr auto PropertiesNextTrack       = "Tracks.Properties.NextTrack";
 constexpr auto ToggleMenubar             = "View.ToggleMenubar";
+constexpr auto LookupMetadata            = "Tracks.LookupMetadata";
+constexpr auto LookupMetadataById        = "Tracks.LookupMetadataById";
 } // namespace Actions
 
 namespace Mime {

--- a/include/gui/trackselectioncontroller.h
+++ b/include/gui/trackselectioncontroller.h
@@ -147,6 +147,8 @@ public:
     bool registerTrackContextAction(QObject* owner, TrackContextMenuArea area, const Id& parentId, const Id& id,
                                     const QString& title, const TrackContextMenuRenderer& renderer,
                                     const Id& beforeId = {});
+    bool registerTrackContextSeparator(QObject* owner, TrackContextMenuArea area, const Id& parentId, const Id& id,
+                                       const Id& beforeId = {});
     bool registerTrackContextDynamicSubmenu(QObject* owner, TrackContextMenuArea area, const Id& parentId, const Id& id,
                                             const QString& title, const TrackContextMenuRenderer& renderer,
                                             const Id& beforeId = {});

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -1811,6 +1811,24 @@ void Track::setRatingStars(int rating)
     }
 }
 
+void Track::clearWritableTags()
+{
+    setTitle({});
+    setArtists({});
+    setAlbum({});
+    setAlbumArtists({});
+    setTrackNumber({});
+    setTrackTotal({});
+    setDiscNumber({});
+    setDiscTotal({});
+    setGenres({});
+    setComposers({});
+    setPerformers({});
+    setComment({});
+    setDate({});
+    clearExtraTags();
+}
+
 void Track::setRGTrackGain(float gain)
 {
     p->rgTrackGain = std::isfinite(gain) ? gain : Constants::InvalidGain;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -237,6 +237,25 @@ set(SOURCES
     menubar/playbackmenu.h
     menubar/viewmenu.cpp
     menubar/viewmenu.h
+    metadatalookup/lookupresultsmodel.cpp
+    metadatalookup/lookupresultsmodel.h
+    metadatalookup/metadataapply.cpp
+    metadatalookup/metadataapply.h
+    metadatalookup/metadatachangesdialog.cpp
+    metadatalookup/metadatachangesdialog.h
+    metadatalookup/metadatalookupdialog.cpp
+    metadatalookup/metadatalookupdialog.h
+    metadatalookup/metadatalookupregistry.cpp
+    metadatalookup/metadatalookupregistry.h
+    metadatalookup/metadatamatcher.cpp
+    metadatalookup/metadatamatcher.h
+    metadatalookup/metadatatypes.h
+    metadatalookup/trackmatchmodel.cpp
+    metadatalookup/trackmatchmodel.h
+    metadatalookup/sources/metadatalookupsource.cpp
+    metadatalookup/sources/metadatalookupsource.h
+    metadatalookup/sources/musicbrainzmetadata.cpp
+    metadatalookup/sources/musicbrainzmetadata.h
     sortactionhandler.cpp
     sortactionhandler.h
     nowplayingoutput/nowplayingoutputservice.cpp

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -37,6 +37,7 @@
 #include "menubar/mainmenubar.h"
 #include "menubar/playbackmenu.h"
 #include "menubar/viewmenu.h"
+#include "metadatalookup/metadatalookupdialog.h"
 #include "playlist/manager/playlistmanagerwidget.h"
 #include "playlist/playlistcontroller.h"
 #include "playlist/playlistinteractor.h"
@@ -50,7 +51,6 @@
 #include "search/searchwidget.h"
 #include "systemtrayicon.h"
 #include "widgets.h"
-#include <gui/playlist/currentplaylistcontroller.h>
 
 #include <core/application.h>
 #include <core/corepaths.h>
@@ -78,6 +78,7 @@
 #include <gui/guiutils.h>
 #include <gui/iconloader.h>
 #include <gui/layoutprovider.h>
+#include <gui/playlist/currentplaylistcontroller.h>
 #include <gui/plugins/dspguiplugin.h>
 #include <gui/plugins/guiplugin.h>
 #include <gui/plugins/guiplugincontext.h>
@@ -129,6 +130,8 @@
 #include <QTimer>
 #include <QUrl>
 
+#include <optional>
+
 Q_LOGGING_CATEGORY(GUI_APP, "fy.gui")
 
 using namespace std::chrono_literals;
@@ -138,6 +141,31 @@ constexpr auto ThemeUpdateDelayMs = 50;
 
 namespace Fooyin {
 namespace {
+QString commonMetadataValue(const TrackList& tracks, const QString& field)
+{
+    if(tracks.empty()) {
+        return {};
+    }
+
+    const QString value = tracks.front().metaValue(field);
+    return !value.isEmpty()
+                && std::ranges::all_of(tracks,
+                                       [&field, &value](const Track& track) { return track.metaValue(field) == value; })
+             ? value
+             : QString{};
+}
+
+std::optional<LookupMode> musicBrainzLookupMode(const TrackList& tracks)
+{
+    if(!commonMetadataValue(tracks, u"MUSICBRAINZ_ALBUMID"_s).isEmpty()) {
+        return LookupMode::ReleaseId;
+    }
+    if(!commonMetadataValue(tracks, u"MUSICBRAINZ_RELEASEGROUPID"_s).isEmpty()) {
+        return LookupMode::ReleaseGroupId;
+    }
+    return {};
+}
+
 QString pluginIdentifierForRoot(const PluginManager& pluginManager, const QObject* root)
 {
     if(!root) {
@@ -261,6 +289,8 @@ GuiApplication::GuiApplication(Application* core)
     , m_defaultConversionCommand{nullptr}
     , m_lastUsedConversionAction{nullptr}
     , m_lastUsedConversionCommand{nullptr}
+    , m_lookupArtistAlbumAction{nullptr}
+    , m_lookupIdAction{nullptr}
     , m_coverProvider{m_coverRepository}
     , m_themeUpdatePending{false}
     , m_refreshSystemBaseline{false}
@@ -1104,6 +1134,44 @@ void GuiApplication::registerActions()
                      [this](bool visible) { m_settings->set<Settings::Gui::ShowMenuBar>(visible); });
     m_settings->subscribe<Settings::Gui::ShowMenuBar>(
         toggleMenubar, [toggleMenubar](bool visible) { toggleMenubar->setChecked(visible); });
+
+    m_lookupArtistAlbumAction = new QAction(tr("Lookup metadata by artist and album…"), this);
+    m_lookupArtistAlbumAction->setStatusTip(tr("Look up metadata using the selected tracks' artist and album"));
+    QObject::connect(m_lookupArtistAlbumAction, &QAction::triggered, this,
+                     [this] { showMetadataLookupDialog(LookupMode::ArtistAlbum); });
+    Command* artistAlbumCommand
+        = m_actionManager->registerAction(m_lookupArtistAlbumAction, Constants::Actions::LookupMetadata);
+    artistAlbumCommand->setDescription(tr("Look up metadata by artist and album"));
+    artistAlbumCommand->setCategories({tr("Tagging")});
+
+    m_lookupIdAction = new QAction(tr("Lookup metadata by MusicBrainz ID…"), this);
+    m_lookupIdAction->setStatusTip(tr("Look up metadata using a MusicBrainz release identifier"));
+    QObject::connect(m_lookupIdAction, &QAction::triggered, this, &GuiApplication::showMetadataLookupById);
+    Command* idCommand = m_actionManager->registerAction(m_lookupIdAction, Constants::Actions::LookupMetadataById);
+    idCommand->setDescription(tr("Look up metadata by MusicBrainz ID"));
+    idCommand->setCategories({tr("Tagging")});
+
+    m_selectionController->registerTrackContextSubmenu(this, TrackContextMenuArea::Track,
+                                                       Fooyin::Constants::Menus::Context::TrackSelection,
+                                                       Fooyin::Constants::Menus::Context::Tagging, tr("Tagging"),
+                                                       Fooyin::Constants::Menus::Context::TrackFinalSeparator);
+    m_selectionController->registerTrackContextAction(
+        this, TrackContextMenuArea::Track, Fooyin::Constants::Menus::Context::Tagging,
+        Constants::Actions::LookupMetadata, m_lookupArtistAlbumAction->text(),
+        [this](QMenu* menu, const TrackSelection& selection) {
+            m_lookupArtistAlbumAction->setEnabled(!selection.tracks.empty());
+            menu->addAction(m_lookupArtistAlbumAction);
+        });
+    m_selectionController->registerTrackContextAction(
+        this, TrackContextMenuArea::Track, Fooyin::Constants::Menus::Context::Tagging,
+        Constants::Actions::LookupMetadataById, m_lookupIdAction->text(),
+        [this](QMenu* menu, const TrackSelection& selection) {
+            m_lookupIdAction->setEnabled(musicBrainzLookupMode(selection.tracks).has_value());
+            menu->addAction(m_lookupIdAction);
+        });
+    m_selectionController->registerTrackContextSeparator(this, TrackContextMenuArea::Track,
+                                                         Constants::Menus::Context::Tagging,
+                                                         Constants::Menus::Context::TaggingLookupSeparator);
 }
 
 void GuiApplication::rescanTracks(const TrackList& tracks, bool onlyModified) const
@@ -1179,6 +1247,9 @@ void GuiApplication::setupScanMenu()
             rescanChangedAction->setEnabled(m_selectionController->hasTracks());
             menu->addAction(rescanChangedAction);
         });
+    m_selectionController->registerTrackContextSeparator(this, TrackContextMenuArea::Track,
+                                                         Constants::Menus::Context::Tagging,
+                                                         Constants::Menus::Context::TaggingReloadSeparator);
 }
 
 void GuiApplication::setupRatingMenu()
@@ -1811,6 +1882,48 @@ void GuiApplication::showTrackNotFoundMessage(const Track& track) const
 void GuiApplication::showTrackUnreableMessage(const Track& track) const
 {
     showMessage(tr("No Decoder Available"), track);
+}
+
+void GuiApplication::showMetadataLookupDialog(LookupMode mode)
+{
+    const auto* selection = m_selectionController->selectedSelection();
+    if(!selection || selection->tracks.empty()) {
+        return;
+    }
+
+    if(m_metadataLookupDialog) {
+        // Start new lookup if same tracks
+        if(m_metadataLookupDialog->hasSameTracks(selection->tracks)) {
+            m_metadataLookupDialog->startLookup(mode);
+            m_metadataLookupDialog->raise();
+            m_metadataLookupDialog->activateWindow();
+            return;
+        }
+
+        if(!m_metadataLookupDialog->close()) {
+            m_metadataLookupDialog->raise();
+            m_metadataLookupDialog->activateWindow();
+            return;
+        }
+    }
+
+    m_metadataLookupDialog
+        = new MetadataLookupDialog(selection->tracks, m_library, m_core->audioLoader(), m_core->networkManager(),
+                                   m_settings, mode, Utils::getMainWindow());
+    m_metadataLookupDialog->show();
+    m_metadataLookupDialog->raise();
+}
+
+void GuiApplication::showMetadataLookupById()
+{
+    const auto* selection = m_selectionController->selectedSelection();
+    if(!selection) {
+        return;
+    }
+
+    if(const auto mode = musicBrainzLookupMode(selection->tracks)) {
+        showMetadataLookupDialog(*mode);
+    }
 }
 
 void GuiApplication::createNewPlaylist() const

--- a/src/gui/guiapplication.h
+++ b/src/gui/guiapplication.h
@@ -61,6 +61,8 @@ class LibraryMenu;
 class LogWidget;
 class MainMenuBar;
 class MainWindow;
+class MetadataLookupDialog;
+enum class LookupMode : uint8_t;
 class Playlist;
 class PlaylistController;
 class PlaylistManagerWidget;
@@ -181,6 +183,9 @@ private:
     void showTrackNotFoundMessage(const Track& track) const;
     void showTrackUnreableMessage(const Track& track) const;
 
+    void showMetadataLookupDialog(LookupMode mode);
+    void showMetadataLookupById();
+
     void createNewPlaylist() const;
     void createNewAutoPlaylist();
 
@@ -250,6 +255,10 @@ private:
     QAction* m_lastUsedConversionAction;
     Command* m_lastUsedConversionCommand;
     std::vector<ConversionPresetAction> m_conversionPresetActions;
+
+    QAction* m_lookupArtistAlbumAction;
+    QAction* m_lookupIdAction;
+    QPointer<MetadataLookupDialog> m_metadataLookupDialog;
 
     ScriptParser m_scriptParser;
     CoverProvider m_coverProvider;

--- a/src/gui/metadatalookup/lookupresultsmodel.cpp
+++ b/src/gui/metadatalookup/lookupresultsmodel.cpp
@@ -1,0 +1,103 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "lookupresultsmodel.h"
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+QVariant LookupResultsModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    if(role == Qt::TextAlignmentRole) {
+        return Qt::AlignCenter;
+    }
+
+    if(role != Qt::DisplayRole) {
+        return {};
+    }
+
+    switch(section) {
+        case 0:
+            return tr("Release");
+        case 1:
+            return tr("Artist");
+        case 2:
+            return tr("Date/Country");
+        case 3:
+            return tr("Format");
+        case 4:
+            return tr("Discs");
+        default:
+            return {};
+    }
+}
+
+QVariant LookupResultsModel::data(const QModelIndex& index, int role) const
+{
+    if(!index.isValid() || role != Qt::DisplayRole || std::cmp_greater_equal(index.row(), m_results.size())) {
+        return {};
+    }
+
+    const ReleaseSummary& release = m_results.at(index.row());
+
+    switch(index.column()) {
+        case 0:
+            return release.title;
+        case 1:
+            return artistCreditText(release.artistCredit);
+        case 2:
+            if(release.date.isEmpty()) {
+                return release.country;
+            }
+            return release.country.isEmpty() ? release.date : u"%1/%2"_s.arg(release.date, release.country);
+        case 3:
+            return release.formats.join(u", "_s);
+        case 4:
+            return release.discCount > 0 ? QVariant{release.discCount} : QVariant{};
+        default:
+            return {};
+    }
+}
+
+int LookupResultsModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_results.size());
+}
+
+int LookupResultsModel::columnCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : 5;
+}
+
+void LookupResultsModel::setResults(std::vector<ReleaseSummary> results)
+{
+    beginResetModel();
+    m_results = std::move(results);
+    endResetModel();
+}
+
+const ReleaseSummary* LookupResultsModel::releaseAt(int row) const
+{
+    return row >= 0 && std::cmp_less(row, m_results.size()) ? &m_results.at(row) : nullptr;
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/lookupresultsmodel.h
+++ b/src/gui/metadatalookup/lookupresultsmodel.h
@@ -1,0 +1,46 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "metadatatypes.h"
+
+#include <QAbstractTableModel>
+
+namespace Fooyin {
+class LookupResultsModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    using QAbstractTableModel::QAbstractTableModel;
+
+    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
+                                      int role = Qt::DisplayRole) const override;
+
+    void setResults(std::vector<ReleaseSummary> results);
+    [[nodiscard]] const ReleaseSummary* releaseAt(int row) const;
+
+private:
+    std::vector<ReleaseSummary> m_results;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadataapply.cpp
+++ b/src/gui/metadatalookup/metadataapply.cpp
@@ -1,0 +1,181 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadataapply.h"
+
+#include <QMap>
+
+#include <functional>
+#include <ranges>
+#include <set>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+QMap<QString, QString> displayMetadata(const Track& track)
+{
+    QMap<QString, QString> result = track.metadata();
+    for(const auto& [key, values] : track.extraTags()) {
+        result.insert(key, values.join(u"; "_s));
+    }
+    return result;
+}
+
+template <typename Value, typename Getter, typename Setter>
+void setBuiltIn(Track& track, const Value& value, ExistingMetadataPolicy policy, Getter getter, Setter setter)
+{
+    if(value.isEmpty() || (policy == ExistingMetadataPolicy::FillMissing && !std::invoke(getter, track).isEmpty())) {
+        return;
+    }
+    setter(track, value);
+}
+
+void setExtra(Track& track, const QString& tag, const QStringList& values, ExistingMetadataPolicy policy)
+{
+    if(values.empty() || (policy == ExistingMetadataPolicy::FillMissing && track.hasExtraTag(tag))) {
+        return;
+    }
+    track.replaceExtraTag(tag, values);
+}
+
+void setExtra(Track& track, const QString& tag, const QString& value, ExistingMetadataPolicy policy)
+{
+    setExtra(track, tag, value.isEmpty() ? QStringList{} : QStringList{value}, policy);
+}
+
+void setIdentifiers(Track& track, const std::unordered_map<QString, QStringList>& identifiers,
+                    ExistingMetadataPolicy policy)
+{
+    for(const auto& [tag, value] : identifiers) {
+        setExtra(track, tag, value, policy);
+    }
+}
+
+QString mediumFormat(const Release& release, int position)
+{
+    const auto it = std::ranges::find(release.media, position, &ReleaseMedium::position);
+    return it != release.media.cend() ? it->format : QString{};
+}
+
+QString mediumTitle(const Release& release, int position)
+{
+    const auto it = std::ranges::find(release.media, position, &ReleaseMedium::position);
+    return it != release.media.cend() ? it->title : QString{};
+}
+} // namespace
+
+MetadataApplyResult applyReleaseMetadata(const TrackList& localTracks, const Release& release,
+                                         const std::vector<TrackMatch>& matches, const MetadataApplyOptions& options)
+{
+    MetadataApplyResult result;
+
+    const auto remoteTracks = flattenedTracks(release);
+    const auto albumArtists = artistCreditNames(release.summary.artistCredit);
+    const QString date      = options.useOriginalReleaseDate && !release.summary.originalDate.isEmpty()
+                                ? release.summary.originalDate
+                                : release.summary.date;
+
+    for(const TrackMatch& match : matches) {
+        if(match.localIndex >= localTracks.size() || !match.remoteIndex || *match.remoteIndex >= remoteTracks.size()) {
+            continue;
+        }
+
+        const Track& original       = localTracks.at(match.localIndex);
+        const ReleaseTrack& remote  = *remoteTracks.at(*match.remoteIndex);
+        const auto originalMetadata = displayMetadata(original);
+        Track updated{original};
+
+        if(options.policy == ExistingMetadataPolicy::WipeWritableTags) {
+            updated.clearWritableTags();
+        }
+
+        setBuiltIn(updated, remote.title, options.policy, &Track::title,
+                   [](Track& track, const QString& value) { track.setTitle(value); });
+        setBuiltIn(updated, artistCreditNames(remote.artistCredit), options.policy, &Track::artists,
+                   [](Track& track, const QStringList& value) { track.setArtists(value); });
+        setBuiltIn(updated, release.summary.title, options.policy, &Track::album,
+                   [](Track& track, const QString& value) { track.setAlbum(value); });
+        setBuiltIn(updated, albumArtists, options.policy, &Track::albumArtists,
+                   [](Track& track, const QStringList& value) { track.setAlbumArtists(value); });
+        setBuiltIn(updated, remote.number.isEmpty() ? QString::number(remote.position) : remote.number, options.policy,
+                   &Track::trackNumber, [](Track& track, const QString& value) { track.setTrackNumber(value); });
+        setBuiltIn(updated, QString::number(remote.total), options.policy, &Track::trackTotal,
+                   [](Track& track, const QString& value) { track.setTrackTotal(value); });
+        setBuiltIn(updated, QString::number(remote.mediumPosition), options.policy, &Track::discNumber,
+                   [](Track& track, const QString& value) { track.setDiscNumber(value); });
+
+        const int discTotal
+            = release.summary.discCount > 0 ? release.summary.discCount : static_cast<int>(release.media.size());
+        setBuiltIn(updated, QString::number(discTotal), options.policy, &Track::discTotal,
+                   [](Track& track, const QString& value) { track.setDiscTotal(value); });
+
+        setBuiltIn(updated, date, options.policy, &Track::date,
+                   [](Track& track, const QString& value) { track.setDate(value); });
+
+        if(options.writeGenres) {
+            const QStringList genres = !remote.genres.empty() ? remote.genres : release.genres;
+            setBuiltIn(updated, genres, options.policy, &Track::genres,
+                       [](Track& track, const QStringList& value) { track.setGenres(value); });
+        }
+
+        if(options.writeReleaseIds) {
+            setIdentifiers(updated, release.summary.identifiers, options.policy);
+            setIdentifiers(updated, remote.identifiers, options.policy);
+        }
+
+        setExtra(updated, u"RELEASECOUNTRY"_s, release.summary.country, options.policy);
+        setExtra(updated, u"RELEASESTATUS"_s, release.summary.status, options.policy);
+        setExtra(updated, u"RELEASETYPE"_s, release.summary.releaseTypes, options.policy);
+        setExtra(updated, u"ORIGINALDATE"_s, release.summary.originalDate, options.policy);
+        setExtra(updated, u"LABEL"_s, release.summary.labels, options.policy);
+        setExtra(updated, u"CATALOGNUMBER"_s, release.summary.catalogNumbers, options.policy);
+        setExtra(updated, u"BARCODE"_s, release.summary.barcode, options.policy);
+        setExtra(updated, u"ISRC"_s, remote.isrcs, options.policy);
+        setExtra(updated, u"MEDIA"_s, mediumFormat(release, remote.mediumPosition), options.policy);
+        setExtra(updated, u"DISCSUBTITLE"_s, mediumTitle(release, remote.mediumPosition), options.policy);
+
+        const auto updatedMetadata = displayMetadata(updated);
+        std::set<QString> fields;
+        for(auto it = originalMetadata.cbegin(); it != originalMetadata.cend(); ++it) {
+            fields.insert(it.key());
+        }
+        for(auto it = updatedMetadata.cbegin(); it != updatedMetadata.cend(); ++it) {
+            fields.insert(it.key());
+        }
+
+        bool changed{false};
+        for(const QString& field : fields) {
+            const QString before = originalMetadata.value(field);
+            const QString after  = updatedMetadata.value(field);
+            if(before != after) {
+                result.changes.push_back(
+                    {.localIndex = match.localIndex, .field = field, .before = before, .after = after});
+                changed = true;
+            }
+        }
+        if(changed) {
+            result.trackIndices.push_back(match.localIndex);
+            result.tracks.push_back(std::move(updated));
+        }
+    }
+
+    return result;
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadataapply.h
+++ b/src/gui/metadatalookup/metadataapply.h
@@ -1,0 +1,61 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include "metadatamatcher.h"
+
+namespace Fooyin {
+enum class ExistingMetadataPolicy : uint8_t
+{
+    FillMissing = 0,
+    ReplaceLookupFields,
+    WipeWritableTags,
+};
+
+struct MetadataApplyOptions
+{
+    ExistingMetadataPolicy policy{ExistingMetadataPolicy::ReplaceLookupFields};
+    bool writeGenres{true};
+    bool writeReleaseIds{true};
+    bool useOriginalReleaseDate{false};
+};
+
+struct FieldChange
+{
+    size_t localIndex{0};
+    QString field;
+    QString before;
+    QString after;
+};
+
+struct MetadataApplyResult
+{
+    TrackList tracks;
+    //! Original track index corresponding to each entry in tracks
+    std::vector<size_t> trackIndices;
+    std::vector<FieldChange> changes;
+};
+
+FYGUI_EXPORT MetadataApplyResult applyReleaseMetadata(const TrackList& localTracks, const Release& release,
+                                                      const std::vector<TrackMatch>& matches,
+                                                      const MetadataApplyOptions& options);
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatachangesdialog.cpp
+++ b/src/gui/metadatalookup/metadatachangesdialog.cpp
@@ -1,0 +1,157 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadatachangesdialog.h"
+
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QSplitter>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+namespace Fooyin {
+MetadataChangesDialog::MetadataChangesDialog(TrackList tracks, std::vector<FieldChange> changes, QWidget* parent)
+    : QDialog{parent}
+    , m_tracks{std::move(tracks)}
+    , m_changes{std::move(changes)}
+    , m_files{new QTableWidget(this)}
+    , m_changesTable{new QTableWidget(this)}
+{
+    setWindowTitle(tr("Metadata Changes"));
+    resize(1050, 560);
+
+    std::vector<size_t> trackIndexes;
+    for(const auto& change : m_changes) {
+        if(change.localIndex < m_tracks.size()
+           && std::ranges::find(trackIndexes, change.localIndex) == trackIndexes.cend()) {
+            trackIndexes.push_back(change.localIndex);
+        }
+    }
+
+    const QString changeSummary = tr("%Ln metadata change(s)", nullptr, static_cast<int>(m_changes.size()));
+    const QString fileSummary   = tr("%Ln file(s)", nullptr, static_cast<int>(trackIndexes.size()));
+    auto* summary               = new QLabel(tr("%1 across %2.").arg(changeSummary, fileSummary), this);
+
+    m_files->setColumnCount(2);
+    m_files->setRowCount(static_cast<int>(trackIndexes.size()));
+    m_files->setHorizontalHeaderLabels({tr("File"), tr("Changes")});
+    m_files->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_files->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_files->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_files->setAlternatingRowColors(true);
+    m_files->verticalHeader()->hide();
+    m_files->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_files->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+
+    for(size_t row{0}; row < trackIndexes.size(); ++row) {
+        const size_t trackIndex = trackIndexes.at(row);
+        const Track& track      = m_tracks.at(trackIndex);
+        const auto changeCount  = std::ranges::count(m_changes, trackIndex, &FieldChange::localIndex);
+
+        auto* fileItem = new QTableWidgetItem(track.filenameExt());
+        fileItem->setToolTip(track.filepath());
+        fileItem->setData(Qt::UserRole, QVariant::fromValue<qulonglong>(trackIndex));
+        m_files->setItem(static_cast<int>(row), 0, fileItem);
+
+        auto* countItem = new QTableWidgetItem(QString::number(changeCount));
+        countItem->setTextAlignment(Qt::AlignCenter);
+        m_files->setItem(static_cast<int>(row), 1, countItem);
+    }
+
+    m_changesTable->setColumnCount(4);
+    m_changesTable->setHorizontalHeaderLabels({tr("Change"), tr("Tag"), tr("Current value"), tr("New value")});
+    m_changesTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_changesTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_changesTable->setAlternatingRowColors(true);
+    m_changesTable->setWordWrap(false);
+    m_changesTable->setTextElideMode(Qt::ElideRight);
+    m_changesTable->verticalHeader()->hide();
+    m_changesTable->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+    m_changesTable->verticalHeader()->setDefaultSectionSize(m_changesTable->fontMetrics().height() + 8);
+    m_changesTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_changesTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_changesTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_changesTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+
+    QObject::connect(m_files, &QTableWidget::currentCellChanged, this,
+                     [this](int currentRow, int, int, int) { populateChanges(currentRow); });
+
+    auto* splitter = new QSplitter(Qt::Horizontal, this);
+    splitter->addWidget(m_files);
+    splitter->addWidget(m_changesTable);
+    splitter->setChildrenCollapsible(false);
+    splitter->setStretchFactor(0, 1);
+    splitter->setStretchFactor(1, 3);
+    splitter->setSizes({260, 790});
+
+    if(!trackIndexes.empty()) {
+        m_files->selectRow(0);
+        populateChanges(0);
+    }
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(summary);
+    layout->addWidget(splitter, 1);
+    layout->addWidget(buttons);
+}
+
+void MetadataChangesDialog::populateChanges(int row)
+{
+    const auto* fileItem = m_files->item(row, 0);
+    if(!fileItem) {
+        m_changesTable->setRowCount(0);
+        return;
+    }
+
+    const size_t trackIndex = fileItem->data(Qt::UserRole).toULongLong();
+    std::vector<const FieldChange*> trackChanges;
+    for(const auto& change : m_changes) {
+        if(change.localIndex == trackIndex) {
+            trackChanges.push_back(&change);
+        }
+    }
+
+    m_changesTable->setRowCount(static_cast<int>(trackChanges.size()));
+    for(int rowIndex{0}; std::cmp_less(rowIndex, trackChanges.size()); ++rowIndex) {
+        const auto& change   = *trackChanges.at(rowIndex);
+        const QString status = change.before.isEmpty() ? tr("Added")
+                             : change.after.isEmpty()  ? tr("Removed")
+                                                       : tr("Modified");
+
+        auto* statusItem = new QTableWidgetItem(status);
+        statusItem->setTextAlignment(Qt::AlignCenter);
+        m_changesTable->setItem(rowIndex, 0, statusItem);
+        m_changesTable->setItem(rowIndex, 1, new QTableWidgetItem(change.field));
+
+        auto* before = new QTableWidgetItem(change.before.isEmpty() ? tr("(empty)") : change.before.simplified());
+        before->setToolTip(change.before);
+        m_changesTable->setItem(rowIndex, 2, before);
+
+        auto* after = new QTableWidgetItem(change.after.isEmpty() ? tr("(empty)") : change.after.simplified());
+        after->setToolTip(change.after);
+        m_changesTable->setItem(rowIndex, 3, after);
+    }
+}
+} // namespace Fooyin
+
+#include "moc_metadatachangesdialog.cpp"

--- a/src/gui/metadatalookup/metadatachangesdialog.h
+++ b/src/gui/metadatalookup/metadatachangesdialog.h
@@ -1,0 +1,47 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "metadataapply.h"
+
+#include <QDialog>
+
+#include <vector>
+
+class QTableWidget;
+
+namespace Fooyin {
+class MetadataChangesDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    MetadataChangesDialog(TrackList tracks, std::vector<FieldChange> changes, QWidget* parent = nullptr);
+
+private:
+    void populateChanges(int row);
+
+    TrackList m_tracks;
+    std::vector<FieldChange> m_changes;
+
+    QTableWidget* m_files;
+    QTableWidget* m_changesTable;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatalookupdialog.cpp
+++ b/src/gui/metadatalookup/metadatalookupdialog.cpp
@@ -1,0 +1,1042 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadatalookupdialog.h"
+
+#include "lookupresultsmodel.h"
+#include "metadatachangesdialog.h"
+#include "metadatalookupregistry.h"
+#include "sources/metadatalookupsource.h"
+#include "trackmatchmodel.h"
+
+#include <core/engine/audioloader.h>
+#include <core/library/musiclibrary.h>
+#include <core/network/networkaccessmanager.h>
+#include <gui/guiutils.h>
+#include <gui/widgets/elapsedprogressdialog.h>
+#include <utils/settings/settingsmanager.h>
+#include <utils/stringutils.h>
+
+#include <QCheckBox>
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPushButton>
+#include <QScrollBar>
+#include <QSignalBlocker>
+#include <QSplitter>
+#include <QStackedWidget>
+#include <QTableView>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+using namespace std::chrono_literals;
+
+constexpr auto Geometry             = "MetadataLookup/DialogGeometry";
+constexpr auto SplitterState        = "MetadataLookup/SplitterState";
+constexpr auto ResultsSplitterState = "MetadataLookup/ResultsSplitterState";
+constexpr auto MatchSplitterState   = "MetadataLookup/MatchSplitterState2";
+constexpr auto LocalHeaderState     = "MetadataLookup/LocalHeaderState4";
+constexpr auto RemoteHeaderState    = "MetadataLookup/RemoteHeaderState2";
+constexpr auto ExistingPolicy       = "MetadataLookup/ExistingMetadataPolicy";
+constexpr auto WriteGenres          = "MetadataLookup/WriteGenres";
+constexpr auto WriteReleaseIds      = "MetadataLookup/WriteReleaseIds";
+constexpr auto UseOriginalDate      = "MetadataLookup/UseOriginalReleaseDate";
+constexpr auto Source               = "MetadataLookup/Source";
+constexpr auto LookupModeSetting    = "MetadataLookup/LookupMode";
+
+namespace Fooyin {
+namespace {
+QString commonValue(const TrackList& tracks, const std::function<QString(const Track&)>& getter)
+{
+    if(tracks.empty()) {
+        return {};
+    }
+
+    const QString first = getter(tracks.front());
+    return std::ranges::all_of(tracks, [&getter, &first](const Track& track) { return getter(track) == first; })
+             ? first
+             : QString{};
+}
+
+bool isDbOnlyMetadataTrack(const Track& track)
+{
+    return track.isRemote() && track.isInDatabase();
+}
+
+bool isIdentifierMode(LookupMode mode)
+{
+    return mode == LookupMode::ReleaseId || mode == LookupMode::ReleaseGroupId;
+}
+
+class EmptyStateTableView : public QTableView
+{
+public:
+    explicit EmptyStateTableView(QString emptyText, QWidget* parent = nullptr)
+        : QTableView{parent}
+        , m_emptyText{std::move(emptyText)}
+    { }
+
+protected:
+    void paintEvent(QPaintEvent* event) override
+    {
+        QTableView::paintEvent(event);
+
+        if(model()->rowCount(rootIndex()) > 0) {
+            return;
+        }
+
+        QPainter painter{viewport()};
+        painter.setPen(palette().color(QPalette::PlaceholderText));
+        painter.drawText(viewport()->rect().adjusted(24, 24, -24, -24), Qt::AlignCenter | Qt::TextWordWrap,
+                         m_emptyText);
+    }
+
+private:
+    QString m_emptyText;
+};
+} // namespace
+
+MetadataLookupDialog::MetadataLookupDialog(TrackList tracks, MusicLibrary* library,
+                                           std::shared_ptr<AudioLoader> audioLoader,
+                                           std::shared_ptr<NetworkAccessManager> network, SettingsManager* settings,
+                                           LookupMode mode, QWidget* parent)
+    : MetadataLookupDialog{std::move(tracks),   library,  std::move(audioLoader),
+                           std::move(network),  settings, mode,
+                           Purpose::WriteFiles, {},       parent}
+{ }
+
+MetadataLookupDialog::MetadataLookupDialog(TrackList tracks, std::shared_ptr<NetworkAccessManager> network,
+                                           SettingsManager* settings, const LookupQuery& initialQuery, QWidget* parent)
+    : MetadataLookupDialog{std::move(tracks),     nullptr,      {},    std::move(network), settings, initialQuery.mode,
+                           Purpose::ReturnTracks, initialQuery, parent}
+{ }
+
+MetadataLookupDialog::MetadataLookupDialog(TrackList tracks, MusicLibrary* library,
+                                           std::shared_ptr<AudioLoader> audioLoader,
+                                           std::shared_ptr<NetworkAccessManager> network, SettingsManager* settings,
+                                           LookupMode mode, Purpose purpose,
+                                           const std::optional<LookupQuery>& initialQuery, QWidget* parent)
+    : QDialog{parent}
+    , m_tracks{std::move(tracks)}
+    , m_library{library}
+    , m_audioLoader{std::move(audioLoader)}
+    , m_network{std::move(network)}
+    , m_settings{settings}
+    , m_purpose{purpose}
+    , m_registry{std::make_unique<MetadataLookupRegistry>(m_network.get())}
+    , m_client{nullptr}
+    , m_resultsModel{new LookupResultsModel(this)}
+    , m_retrievedModel{new RetrievedTrackModel(this)}
+    , m_matchModel{new TrackMatchModel(m_tracks, this)}
+    , m_releaseLoaded{false}
+    , m_busy{false}
+    , m_writeInProgress{false}
+    , m_writeCompleted{false}
+    , m_syncingTrackScrollbars{false}
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(tr("Metadata Lookup"));
+
+    setMinimumSize(780, 520);
+    resize(1050, 700);
+
+    buildUi();
+
+    for(auto* source : m_registry->sources()) {
+        connectSource(source);
+    }
+
+    restoreState();
+    if(initialQuery) {
+        setLookupQuery(*initialQuery);
+    }
+    else {
+        setLookupMode(mode);
+    }
+
+    QObject::connect(m_resultsView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+                     [this](const QModelIndex& current) { selectRelease(current); });
+    QObject::connect(m_matchView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+                     [this](const QModelIndex& current) { selectMatchingRow(current.row()); });
+    QObject::connect(m_retrievedView->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
+                     [this](const QModelIndex& current) { selectMatchingRow(current.row()); });
+    QObject::connect(m_matchModel, &TrackMatchModel::mappingsChanged, this, &MetadataLookupDialog::updatePreview);
+    QObject::connect(m_source, &QComboBox::currentIndexChanged, this,
+                     [this] { setSource(m_source->currentData().toString()); });
+    QObject::connect(m_lookupMode, &QComboBox::currentIndexChanged, this, &MetadataLookupDialog::updateLookupEditor);
+    QObject::connect(m_idType, &QComboBox::currentIndexChanged, this, &MetadataLookupDialog::updateLookupEditor);
+    QObject::connect(m_changesButton, &QPushButton::clicked, this, &MetadataLookupDialog::showChanges);
+    QObject::connect(m_search, &QPushButton::clicked, this, &MetadataLookupDialog::startSearch);
+    QObject::connect(m_updateFiles, &QPushButton::clicked, this, &MetadataLookupDialog::applyMetadata);
+    QObject::connect(m_close, &QPushButton::clicked, this, &QDialog::close);
+    QObject::connect(m_policy, &QComboBox::currentIndexChanged, this, [this] { updatePreview(); });
+    QObject::connect(m_allowUnresolved, &QCheckBox::toggled, this, [this] { updateActions(); });
+    QObject::connect(m_writeGenres, &QCheckBox::toggled, this, [this] { updatePreview(); });
+    QObject::connect(m_writeIds, &QCheckBox::toggled, this, [this] { updatePreview(); });
+    QObject::connect(m_originalDate, &QCheckBox::toggled, this, [this] { updatePreview(); });
+    QObject::connect(m_retrievedView->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        if(m_syncingTrackScrollbars) {
+            return;
+        }
+        m_syncingTrackScrollbars = true;
+        m_matchView->verticalScrollBar()->setValue(value);
+        m_syncingTrackScrollbars = false;
+    });
+    QObject::connect(m_matchView->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
+        if(m_syncingTrackScrollbars) {
+            return;
+        }
+        m_syncingTrackScrollbars = true;
+        m_retrievedView->verticalScrollBar()->setValue(value);
+        m_syncingTrackScrollbars = false;
+    });
+
+    updateActions();
+    m_search->click();
+}
+
+MetadataLookupDialog::~MetadataLookupDialog()
+{
+    saveState();
+    if(m_client) {
+        m_client->cancel();
+    }
+    if(m_cancelWrite) {
+        m_cancelWrite();
+    }
+}
+
+bool MetadataLookupDialog::hasSameTracks(const TrackList& tracks) const
+{
+    return std::ranges::equal(m_tracks, tracks,
+                              [](const Track& lhs, const Track& rhs) { return lhs.sameIdentityAs(rhs); });
+}
+
+void MetadataLookupDialog::startLookup(LookupMode mode)
+{
+    setLookupMode(mode);
+    startSearch();
+}
+
+void MetadataLookupDialog::closeEvent(QCloseEvent* event)
+{
+    if(m_writeInProgress) {
+        event->ignore();
+        return;
+    }
+    QDialog::closeEvent(event);
+}
+
+void MetadataLookupDialog::buildUi()
+{
+    m_source = new QComboBox(this);
+    for(const auto* source : m_registry->sources()) {
+        m_source->addItem(source->name(), source->id());
+    }
+
+    m_lookupMode = new QComboBox(this);
+
+    m_artist
+        = new QLineEdit(commonValue(m_tracks, [](const Track& track) { return track.effectiveAlbumArtist(); }), this);
+    m_album = new QLineEdit(commonValue(m_tracks, [](const Track& track) { return track.album(); }), this);
+
+    m_discToc
+        = new QLineEdit(commonValue(m_tracks, [](const Track& track) { return track.metaValue(u"DISCTOC"_s); }), this);
+    m_discToc->setPlaceholderText(tr("First track, last track, lead-out sector, then track offsets"));
+
+    m_releaseId = new QLineEdit(
+        commonValue(m_tracks, [](const Track& track) { return track.metaValue(u"MUSICBRAINZ_ALBUMID"_s); }), this);
+    m_releaseGroupId = new QLineEdit(
+        commonValue(m_tracks, [](const Track& track) { return track.metaValue(u"MUSICBRAINZ_RELEASEGROUPID"_s); }),
+        this);
+    m_idType = new QComboBox(this);
+
+    m_search = new QPushButton(tr("Search"), this);
+    m_search->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+
+    for(auto* editor : {m_artist, m_album, m_discToc, m_releaseId, m_releaseGroupId}) {
+        editor->setClearButtonEnabled(true);
+        QObject::connect(editor, &QLineEdit::returnPressed, m_search, &QPushButton::click);
+    }
+
+    auto* artistAlbumPage   = new QWidget(this);
+    auto* artistAlbumLayout = new QHBoxLayout(artistAlbumPage);
+    artistAlbumLayout->setContentsMargins({});
+    artistAlbumLayout->addWidget(new QLabel(tr("Artist") + u":"_s, artistAlbumPage));
+    artistAlbumLayout->addWidget(m_artist, 1);
+    artistAlbumLayout->addWidget(new QLabel(tr("Album") + u":"_s, artistAlbumPage));
+    artistAlbumLayout->addWidget(m_album, 1);
+
+    auto* discTocPage   = new QWidget(this);
+    auto* discTocLayout = new QHBoxLayout(discTocPage);
+    discTocLayout->setContentsMargins({});
+    discTocLayout->addWidget(new QLabel(tr("TOC") + u":"_s, discTocPage));
+    discTocLayout->addWidget(m_discToc, 1);
+
+    m_identifierEditor = new QStackedWidget(this);
+    m_identifierEditor->addWidget(m_releaseId);
+    m_identifierEditor->addWidget(m_releaseGroupId);
+
+    auto* identifierPage   = new QWidget(this);
+    auto* identifierLayout = new QHBoxLayout(identifierPage);
+    identifierLayout->setContentsMargins({});
+    identifierLayout->addWidget(new QLabel(tr("Type") + u":"_s, identifierPage));
+    identifierLayout->addWidget(m_idType);
+    identifierLayout->addWidget(new QLabel(tr("ID") + u":"_s, identifierPage));
+    identifierLayout->addWidget(m_identifierEditor, 1);
+
+    m_lookupEditor = new QStackedWidget(this);
+    m_lookupEditor->addWidget(artistAlbumPage);
+    m_lookupEditor->addWidget(discTocPage);
+    m_lookupEditor->addWidget(identifierPage);
+
+    auto* searchBox    = new QWidget(this);
+    auto* searchLayout = new QGridLayout(searchBox);
+    searchLayout->setContentsMargins({});
+    searchLayout->addWidget(new QLabel(tr("Source") + u":"_s, searchBox), 0, 0);
+    searchLayout->addWidget(m_source, 0, 1);
+    searchLayout->addWidget(new QLabel(tr("Lookup by") + u":"_s, searchBox), 0, 2);
+    searchLayout->addWidget(m_lookupMode, 0, 3);
+    searchLayout->addWidget(m_search, 0, 5, 2, 1);
+    searchLayout->addWidget(m_lookupEditor, 1, 0, 1, 5);
+    searchLayout->setColumnStretch(4, 1);
+
+    m_resultsView = new EmptyStateTableView(tr("Search for a release to see matching results"), this);
+    m_resultsView->setModel(m_resultsModel);
+    m_resultsView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_resultsView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_resultsView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_resultsView->setAlternatingRowColors(true);
+    m_resultsView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_resultsView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_resultsView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_resultsView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+    m_resultsView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+    m_resultsView->verticalHeader()->hide();
+
+    auto* releaseInfo       = new QGroupBox(tr("Release information"), this);
+    auto* releaseInfoLayout = new QFormLayout(releaseInfo);
+    releaseInfoLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+
+    const auto addReleaseField = [releaseInfo, releaseInfoLayout](const QString& name) {
+        auto* label = new QLabel(name + u":"_s, releaseInfo);
+        label->setForegroundRole(QPalette::PlaceholderText);
+
+        auto* value = new QLabel(releaseInfo);
+        value->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        value->setWordWrap(true);
+        releaseInfoLayout->addRow(label, value);
+        return value;
+    };
+
+    m_releaseArtist         = addReleaseField(tr("Artist"));
+    m_releaseAlbum          = addReleaseField(tr("Album"));
+    m_releaseDate           = addReleaseField(tr("Date"));
+    m_releaseOriginalDate   = addReleaseField(tr("Original release date"));
+    m_releaseCountry        = addReleaseField(tr("Country"));
+    m_releaseLabel          = addReleaseField(tr("Label"));
+    m_releaseCatalogNumber  = addReleaseField(tr("Catalogue number"));
+    m_releaseBarcode        = addReleaseField(tr("Barcode"));
+    m_releaseFormat         = addReleaseField(tr("Format"));
+    m_releaseType           = addReleaseField(tr("Type"));
+    m_releaseStatus         = addReleaseField(tr("Status"));
+    m_releaseDisambiguation = addReleaseField(tr("Comment"));
+
+    auto* resultsPage   = new QWidget(this);
+    auto* resultsLayout = new QVBoxLayout(resultsPage);
+    resultsLayout->setContentsMargins({});
+    resultsLayout->addWidget(Gui::createSectionHeader(tr("Releases"), resultsPage));
+    resultsLayout->addWidget(m_resultsView);
+
+    m_resultsSplitter = new QSplitter(Qt::Horizontal, this);
+    m_resultsSplitter->addWidget(resultsPage);
+    m_resultsSplitter->addWidget(releaseInfo);
+    m_resultsSplitter->setStretchFactor(0, 2);
+    m_resultsSplitter->setStretchFactor(1, 1);
+    m_resultsSplitter->setSizes({700, 350});
+
+    m_retrievedView = new EmptyStateTableView(tr("Select a release above to load its tracks"), this);
+    m_retrievedView->setModel(m_retrievedModel);
+    m_retrievedView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_retrievedView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_retrievedView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_retrievedView->setAlternatingRowColors(true);
+    m_retrievedView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_retrievedView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_retrievedView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_retrievedView->verticalHeader()->hide();
+
+    m_matchView = new EmptyStateTableView(tr("No local tracks were selected"), this);
+    m_matchView->setModel(m_matchModel);
+    m_matchView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_matchView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_matchView->setDragDropMode(QAbstractItemView::InternalMove);
+    m_matchView->setDragDropOverwriteMode(false);
+    m_matchView->setDefaultDropAction(Qt::MoveAction);
+    m_matchView->setDragEnabled(true);
+    m_matchView->setDropIndicatorShown(true);
+    m_matchView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_matchView->setAlternatingRowColors(true);
+    m_matchView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_matchView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_matchView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_matchView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+    m_matchView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
+    m_matchView->verticalHeader()->hide();
+
+    auto* retrievedPage   = new QWidget(this);
+    auto* retrievedLayout = new QVBoxLayout(retrievedPage);
+    retrievedLayout->setContentsMargins({});
+    retrievedLayout->addWidget(Gui::createSectionHeader(tr("Retrieved tracks"), retrievedPage));
+    retrievedLayout->addWidget(m_retrievedView);
+
+    auto* matchingPage   = new QWidget(this);
+    auto* matchingLayout = new QVBoxLayout(matchingPage);
+    matchingLayout->setContentsMargins({});
+
+    auto* matchingHeader       = new QWidget(matchingPage);
+    auto* matchingHeaderLayout = new QHBoxLayout(matchingHeader);
+    matchingHeaderLayout->setContentsMargins({});
+
+    auto* dragHint = new QLabel(tr("Drag rows to align tracks"), matchingHeader);
+    dragHint->setForegroundRole(QPalette::PlaceholderText);
+
+    matchingHeaderLayout->addWidget(Gui::createSectionHeader(tr("Local tracks"), matchingHeader));
+    matchingHeaderLayout->addStretch();
+    matchingHeaderLayout->addWidget(dragHint);
+    matchingLayout->addWidget(matchingHeader);
+    matchingLayout->addWidget(m_matchView);
+
+    m_matchSplitter = new QSplitter(Qt::Horizontal, this);
+    m_matchSplitter->addWidget(retrievedPage);
+    m_matchSplitter->addWidget(matchingPage);
+    m_matchSplitter->setStretchFactor(0, 1);
+    m_matchSplitter->setStretchFactor(1, 1);
+    m_matchSplitter->setSizes({500, 500});
+
+    m_splitter = new QSplitter(Qt::Vertical, this);
+    m_splitter->addWidget(m_resultsSplitter);
+    m_splitter->addWidget(m_matchSplitter);
+    m_splitter->setStretchFactor(0, 1);
+    m_splitter->setStretchFactor(1, 3);
+    m_splitter->setSizes({280, 360});
+
+    m_policy = new QComboBox(this);
+    m_policy->addItem(tr("Fill missing metadata"), static_cast<int>(ExistingMetadataPolicy::FillMissing));
+    m_policy->addItem(tr("Replace lookup fields"), static_cast<int>(ExistingMetadataPolicy::ReplaceLookupFields));
+    m_policy->addItem(tr("Wipe writable tags, then apply"), static_cast<int>(ExistingMetadataPolicy::WipeWritableTags));
+    m_policy->setToolTip(tr("Choose how retrieved metadata is combined with the track's existing tags."));
+
+    m_allowUnresolved = new QCheckBox(m_purpose == Purpose::ReturnTracks ? tr("Allow applying unresolved tracks")
+                                                                         : tr("Allow updating unresolved tracks"),
+                                      this);
+    m_writeGenres     = new QCheckBox(tr("Write genres"), this);
+    m_writeIds        = new QCheckBox(tr("Write provider IDs"), this);
+
+    m_originalDate = new QCheckBox(tr("Use original date for Date"), this);
+    m_allowUnresolved->setToolTip(
+        m_purpose == Purpose::ReturnTracks
+            ? tr("Allow applying metadata when local tracks are unmatched or have an ambiguous match.")
+            : tr("Allow writing when local tracks are unmatched or have an ambiguous match."));
+    m_writeGenres->setToolTip(tr("Write genres supplied by the selected metadata provider when available."));
+    m_writeIds->setToolTip(tr("Write identifiers supplied by the selected metadata provider."));
+    m_originalDate->setToolTip(
+        tr("Use the original release date for the Date tag instead of this specific release's date."));
+
+    m_allowUnresolved->hide();
+    m_writeGenres->setChecked(true);
+    m_writeIds->setChecked(true);
+
+    auto* options       = new QGroupBox(tr("Metadata options"), this);
+    auto* optionsLayout = new QGridLayout(options);
+    options->setFlat(true);
+    optionsLayout->addWidget(new QLabel(tr("Existing metadata") + u":"_s, options), 0, 0);
+    optionsLayout->addWidget(m_policy, 0, 1);
+    optionsLayout->addWidget(m_writeGenres, 0, 2);
+    optionsLayout->addWidget(m_writeIds, 0, 3);
+    optionsLayout->addWidget(m_originalDate, 0, 4);
+    optionsLayout->setColumnStretch(1, 1);
+
+    m_changesButton = new QPushButton(tr("Changes…"), this);
+    m_changesButton->setEnabled(false);
+
+    m_status = new QLabel(tr("Ready."), this);
+    m_status->setWordWrap(true);
+
+    m_buttons = new QDialogButtonBox(this);
+    m_buttons->addButton(m_changesButton, QDialogButtonBox::ActionRole);
+    m_updateFiles = m_buttons->addButton(m_purpose == Purpose::ReturnTracks ? tr("Apply") : tr("Update files"),
+                                         QDialogButtonBox::AcceptRole);
+    m_close       = m_buttons->addButton(QDialogButtonBox::Close);
+    m_updateFiles->setDefault(true);
+
+    auto* footer = new QGridLayout();
+    footer->addWidget(options, 0, 0, 1, 3);
+    footer->addWidget(m_status, 1, 0);
+    footer->addWidget(m_allowUnresolved, 1, 1);
+    footer->addWidget(m_buttons, 1, 2);
+    footer->setColumnStretch(0, 1);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(searchBox);
+    layout->addWidget(m_splitter, 1);
+    layout->addLayout(footer);
+}
+
+void MetadataLookupDialog::connectSource(MetadataLookupSource* source)
+{
+    QObject::connect(source, &MetadataLookupSource::searchFinished, this, [this, source](const auto& results) {
+        if(source != m_client) {
+            return;
+        }
+        m_resultsModel->setResults(results);
+        m_status->setText(results.empty() ? tr("No matching releases found.")
+                                          : tr("Found %Ln release(s).", nullptr, static_cast<int>(results.size())));
+        if(!results.empty()) {
+            m_resultsView->selectRow(0);
+        }
+    });
+    QObject::connect(source, &MetadataLookupSource::releaseFetched, this, [this, source](const Release& release) {
+        if(source == m_client) {
+            setRelease(release);
+        }
+    });
+    QObject::connect(source, &MetadataLookupSource::failed, this, [this, source](const QString& error) {
+        if(source == m_client) {
+            m_status->setText(error);
+        }
+    });
+    QObject::connect(source, &MetadataLookupSource::busyChanged, this, [this, source](bool busy) {
+        if(source != m_client) {
+            return;
+        }
+        m_busy = busy;
+        if(busy) {
+            m_status->setText(tr("Contacting %1...").arg(source->name()));
+        }
+        updateActions();
+    });
+}
+
+void MetadataLookupDialog::setSource(const QString& sourceId)
+{
+    MetadataLookupSource* source = m_registry->source(sourceId);
+    if(m_client == source) {
+        return;
+    }
+
+    if(m_client) {
+        m_client->cancel();
+    }
+
+    m_client        = source;
+    m_busy          = false;
+    m_releaseLoaded = false;
+
+    updateLookupModes();
+    m_resultsModel->setResults({});
+    m_retrievedModel->setRelease({});
+    m_matchModel->setRelease({});
+    updateReleaseInformation({});
+    m_applyResult = {};
+
+    m_changesButton->setText(tr("Changes…"));
+    m_status->setText(tr("Ready."));
+    updateActions();
+}
+
+void MetadataLookupDialog::updateLookupModes()
+{
+    const LookupMode previousMode = m_lookupMode->currentIndex() >= 0 ? query().mode : LookupMode::ArtistAlbum;
+    const QSignalBlocker modeBlocker{m_lookupMode};
+    const QSignalBlocker idBlocker{m_idType};
+
+    m_lookupMode->clear();
+    m_idType->clear();
+
+    if(m_client) {
+        const auto modes    = m_client->supportedModes();
+        const auto supports = [&modes](LookupMode mode) {
+            return std::ranges::find(modes, mode) != modes.cend();
+        };
+
+        if(supports(LookupMode::ArtistAlbum)) {
+            m_lookupMode->addItem(tr("Artist and album"), static_cast<int>(LookupMode::ArtistAlbum));
+        }
+        if(supports(LookupMode::DiscToc)) {
+            m_lookupMode->addItem(tr("Disc TOC"), static_cast<int>(LookupMode::DiscToc));
+        }
+        if(supports(LookupMode::ReleaseId)) {
+            m_idType->addItem(tr("Release"), static_cast<int>(LookupMode::ReleaseId));
+        }
+        if(supports(LookupMode::ReleaseGroupId)) {
+            m_idType->addItem(tr("Release group"), static_cast<int>(LookupMode::ReleaseGroupId));
+        }
+        if(m_idType->count() > 0) {
+            m_lookupMode->addItem(tr("%1 ID").arg(m_client->name()), m_idType->itemData(0));
+        }
+    }
+
+    setLookupMode(previousMode);
+    m_lookupMode->setEnabled(m_lookupMode->count() > 1);
+}
+
+void MetadataLookupDialog::setLookupMode(LookupMode mode)
+{
+    int index = m_lookupMode->findData(static_cast<int>(mode));
+    if(index < 0 && isIdentifierMode(mode)) {
+        for(int i{0}; i < m_lookupMode->count(); ++i) {
+            if(isIdentifierMode(static_cast<LookupMode>(m_lookupMode->itemData(i).toInt()))) {
+                index = i;
+                break;
+            }
+        }
+    }
+    m_lookupMode->setCurrentIndex(index >= 0 ? index : (m_lookupMode->count() > 0 ? 0 : -1));
+
+    const int idIndex = m_idType->findData(static_cast<int>(mode));
+    if(idIndex >= 0) {
+        m_idType->setCurrentIndex(idIndex);
+    }
+    updateLookupEditor();
+}
+
+void MetadataLookupDialog::setLookupQuery(const LookupQuery& query)
+{
+    m_artist->setText(query.artist);
+    m_album->setText(query.album);
+    m_discToc->setText(query.discToc);
+    m_discId = query.discId;
+
+    if(query.mode == LookupMode::ReleaseGroupId) {
+        m_releaseGroupId->setText(query.identifier);
+    }
+    else if(query.mode == LookupMode::ReleaseId) {
+        m_releaseId->setText(query.identifier);
+    }
+
+    setLookupMode(query.mode);
+}
+
+void MetadataLookupDialog::updateLookupEditor()
+{
+    if(m_lookupMode->currentIndex() < 0) {
+        m_lookupEditor->setEnabled(false);
+        return;
+    }
+
+    m_lookupEditor->setEnabled(true);
+
+    LookupMode mode = static_cast<LookupMode>(m_lookupMode->currentData().toInt());
+    if(isIdentifierMode(mode) && m_idType->currentIndex() >= 0) {
+        mode = static_cast<LookupMode>(m_idType->currentData().toInt());
+    }
+
+    m_lookupEditor->setCurrentIndex(mode == LookupMode::ArtistAlbum ? 0 : mode == LookupMode::DiscToc ? 1 : 2);
+    if(isIdentifierMode(mode)) {
+        m_identifierEditor->setCurrentIndex(mode == LookupMode::ReleaseId ? 0 : 1);
+    }
+}
+
+void MetadataLookupDialog::saveState()
+{
+    m_settings->fileSet(Geometry, saveGeometry());
+    m_settings->fileSet(SplitterState, m_splitter->saveState());
+    m_settings->fileSet(ResultsSplitterState, m_resultsSplitter->saveState());
+    m_settings->fileSet(MatchSplitterState, m_matchSplitter->saveState());
+    m_settings->fileSet(LocalHeaderState, m_matchView->horizontalHeader()->saveState());
+    m_settings->fileSet(RemoteHeaderState, m_retrievedView->horizontalHeader()->saveState());
+    m_settings->fileSet(ExistingPolicy, m_policy->currentData().toInt());
+    m_settings->fileSet(WriteGenres, m_writeGenres->isChecked());
+    m_settings->fileSet(WriteReleaseIds, m_writeIds->isChecked());
+    m_settings->fileSet(UseOriginalDate, m_originalDate->isChecked());
+    m_settings->fileSet(Source, m_source->currentData().toString());
+    m_settings->fileSet(LookupModeSetting, static_cast<int>(query().mode));
+}
+
+void MetadataLookupDialog::restoreState()
+{
+    const QByteArray geometry = m_settings->fileValue(Geometry).toByteArray();
+    if(!geometry.isEmpty()) {
+        restoreGeometry(geometry);
+    }
+    const QByteArray splitter = m_settings->fileValue(SplitterState).toByteArray();
+    if(!splitter.isEmpty()) {
+        m_splitter->restoreState(splitter);
+    }
+    const QByteArray resultsSplitter = m_settings->fileValue(ResultsSplitterState).toByteArray();
+    if(!resultsSplitter.isEmpty()) {
+        m_resultsSplitter->restoreState(resultsSplitter);
+    }
+    const QByteArray matchSplitter = m_settings->fileValue(MatchSplitterState).toByteArray();
+    if(!matchSplitter.isEmpty()) {
+        m_matchSplitter->restoreState(matchSplitter);
+    }
+    const QByteArray localHeader = m_settings->fileValue(LocalHeaderState).toByteArray();
+    if(!localHeader.isEmpty()) {
+        m_matchView->horizontalHeader()->restoreState(localHeader);
+    }
+    const QByteArray remoteHeader = m_settings->fileValue(RemoteHeaderState).toByteArray();
+    if(!remoteHeader.isEmpty()) {
+        m_retrievedView->horizontalHeader()->restoreState(remoteHeader);
+    }
+
+    const int policy
+        = m_settings->fileValue(ExistingPolicy, static_cast<int>(ExistingMetadataPolicy::ReplaceLookupFields)).toInt();
+    m_policy->setCurrentIndex(std::max(0, m_policy->findData(policy)));
+
+    m_writeGenres->setChecked(m_settings->fileValue(WriteGenres, true).toBool());
+    m_writeIds->setChecked(m_settings->fileValue(WriteReleaseIds, true).toBool());
+    m_originalDate->setChecked(m_settings->fileValue(UseOriginalDate, false).toBool());
+
+    const QString sourceId = m_settings->fileValue(Source).toString();
+    const int sourceIndex  = m_source->findData(sourceId);
+    m_source->setCurrentIndex(sourceIndex >= 0 ? sourceIndex : (m_source->count() > 0 ? 0 : -1));
+    setSource(m_source->currentData().toString());
+
+    setLookupMode(static_cast<LookupMode>(
+        m_settings->fileValue(LookupModeSetting, static_cast<int>(LookupMode::ArtistAlbum)).toInt()));
+}
+
+void MetadataLookupDialog::startSearch()
+{
+    if(!m_client) {
+        return;
+    }
+
+    m_releaseLoaded = false;
+    m_resultsModel->setResults({});
+    m_retrievedModel->setRelease({});
+    m_matchModel->setRelease({});
+    updateReleaseInformation({});
+    m_applyResult = {};
+
+    m_changesButton->setText(tr("Changes…"));
+    m_client->search(query());
+}
+
+void MetadataLookupDialog::selectRelease(const QModelIndex& current)
+{
+    if(const auto* release = m_resultsModel->releaseAt(current.row())) {
+        m_releaseLoaded = false;
+        updateReleaseInformation(*release);
+        updateActions();
+        m_client->fetchRelease(release->id);
+    }
+}
+
+void MetadataLookupDialog::setRelease(const Release& release)
+{
+    const QSignalBlocker unresolvedBlocker{m_allowUnresolved};
+
+    Release selectedRelease{release};
+    const LookupQuery lookupQuery = query();
+    bool matchByPosition{false};
+
+    // A TOC identifies one physical disc, so restrict multi-disc releases to the matching medium and align its tracks
+    // by position
+    if(lookupQuery.mode == LookupMode::DiscToc && !lookupQuery.discId.isEmpty()) {
+        const auto medium     = std::ranges::find_if(release.media, [&lookupQuery](const ReleaseMedium& candidate) {
+            return candidate.discIds.contains(lookupQuery.discId);
+        });
+        const bool hasDiscIds = std::ranges::any_of(
+            release.media, [](const ReleaseMedium& candidate) { return !candidate.discIds.isEmpty(); });
+
+        if(medium != release.media.cend()) {
+            selectedRelease.media = {*medium};
+            matchByPosition       = true;
+        }
+        else if(hasDiscIds) {
+            m_releaseLoaded = false;
+            m_retrievedModel->setRelease({});
+            m_matchModel->setRelease({});
+            m_applyResult = {};
+            m_changesButton->setText(tr("Changes…"));
+            m_status->setText(tr("The selected release does not contain the queried disc."));
+            updateActions();
+            return;
+        }
+        else if(release.media.size() == 1) {
+            matchByPosition = true;
+        }
+    }
+
+    m_allowUnresolved->setChecked(false);
+    m_releaseLoaded = true;
+    m_retrievedModel->setRelease(selectedRelease);
+    m_matchModel->setRelease(selectedRelease, matchByPosition);
+    updateReleaseInformation(selectedRelease.summary);
+
+    if(m_matchModel->rowCount() > 0) {
+        m_matchView->selectRow(0);
+    }
+    updatePreview();
+}
+
+void MetadataLookupDialog::updateReleaseInformation(const ReleaseSummary& release)
+{
+    const auto setValue = [](QLabel* label, const QString& value) {
+        label->setText(value.isEmpty() ? u"—"_s : value);
+    };
+
+    setValue(m_releaseArtist, artistCreditText(release.artistCredit));
+    setValue(m_releaseAlbum, release.title);
+    setValue(m_releaseDate, release.date);
+    setValue(m_releaseOriginalDate, release.originalDate);
+    setValue(m_releaseCountry, release.country);
+    setValue(m_releaseLabel, release.labels.join(u", "_s));
+    setValue(m_releaseCatalogNumber, release.catalogNumbers.join(u", "_s));
+    setValue(m_releaseBarcode, release.barcode);
+    setValue(m_releaseFormat, release.formats.join(u", "_s));
+    setValue(m_releaseType, release.releaseTypes.join(u", "_s));
+    setValue(m_releaseStatus, release.status);
+    setValue(m_releaseDisambiguation, release.disambiguation);
+}
+
+void MetadataLookupDialog::selectMatchingRow(int row)
+{
+    if(row < 0) {
+        return;
+    }
+
+    const QSignalBlocker localBlocker{m_matchView->selectionModel()};
+    const QSignalBlocker remoteBlocker{m_retrievedView->selectionModel()};
+
+    if(row < m_matchModel->rowCount()) {
+        m_matchView->selectRow(row);
+    }
+    if(row < m_retrievedModel->rowCount()) {
+        m_retrievedView->selectRow(row);
+    }
+    else {
+        m_retrievedView->selectionModel()->setCurrentIndex({}, QItemSelectionModel::Clear);
+    }
+}
+
+void MetadataLookupDialog::updatePreview()
+{
+    if(!m_releaseLoaded) {
+        m_applyResult = {};
+        m_changesButton->setText(tr("Changes…"));
+        updateActions();
+        return;
+    }
+
+    m_applyResult = applyReleaseMetadata(m_tracks, m_matchModel->release(), m_matchModel->matches(), applyOptions());
+    m_changesButton->setText(tr("Changes (%1)…").arg(m_applyResult.changes.size()));
+    updateActions();
+}
+
+void MetadataLookupDialog::showChanges()
+{
+    if(m_applyResult.changes.empty()) {
+        return;
+    }
+
+    auto* dialog = new MetadataChangesDialog(m_tracks, m_applyResult.changes, this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setModal(true);
+    dialog->show();
+}
+
+void MetadataLookupDialog::updateActions()
+{
+    m_search->setEnabled(m_client && m_lookupMode->currentIndex() >= 0 && !m_busy && !m_writeInProgress);
+    m_source->setEnabled(!m_busy && !m_writeInProgress);
+
+    const bool canReorder = m_releaseLoaded && !m_busy && !m_writeInProgress;
+    m_matchView->setDragEnabled(canReorder);
+    m_matchView->viewport()->setCursor(canReorder ? Qt::OpenHandCursor : Qt::ArrowCursor);
+
+    m_changesButton->setEnabled(!m_busy && !m_writeInProgress && !m_applyResult.changes.empty());
+    m_close->setEnabled(!m_writeInProgress);
+
+    const bool hasUnresolved = m_releaseLoaded && m_matchModel->hasUnresolved();
+    m_allowUnresolved->setVisible(hasUnresolved);
+    m_allowUnresolved->setEnabled(!m_busy && !m_writeInProgress);
+
+    if(m_writeCompleted) {
+        m_updateFiles->setEnabled(false);
+        return;
+    }
+
+    const bool unresolvedAllowed = !m_matchModel->hasUnresolved() || m_allowUnresolved->isChecked();
+    const bool canApply          = m_purpose == Purpose::ReturnTracks || canWriteAllTracks();
+    const bool valid             = m_releaseLoaded && !m_busy && !m_writeInProgress && unresolvedAllowed
+                                && !m_applyResult.tracks.empty() && canApply;
+    m_updateFiles->setEnabled(valid);
+
+    if(m_releaseLoaded && !canApply) {
+        m_status->setText(tr("One or more selected tracks cannot be updated."));
+    }
+    else if(m_releaseLoaded && m_matchModel->hasUnresolved() && !m_allowUnresolved->isChecked()) {
+        m_status->setText(m_purpose == Purpose::ReturnTracks
+                              ? tr("Review unmatched or ambiguous tracks before applying metadata.")
+                              : tr("Review unmatched or ambiguous tracks before updating files."));
+    }
+    else if(m_releaseLoaded && m_applyResult.tracks.empty()) {
+        m_status->setText(tr("The selected release produces no metadata changes."));
+    }
+    else if(m_releaseLoaded && !m_busy) {
+        m_status->setText(m_purpose == Purpose::ReturnTracks ? tr("Metadata will be applied to %Ln track(s).", nullptr,
+                                                                  static_cast<int>(m_applyResult.tracks.size()))
+                                                             : tr("%Ln track(s) will be updated.", nullptr,
+                                                                  static_cast<int>(m_applyResult.tracks.size())));
+    }
+}
+
+void MetadataLookupDialog::applyMetadata()
+{
+    updatePreview();
+
+    if(!m_updateFiles->isEnabled() || !confirmMetadataWipe()) {
+        return;
+    }
+
+    if(m_purpose == Purpose::WriteFiles) {
+        writeMetadata();
+        return;
+    }
+
+    TrackList tracks{m_tracks};
+
+    Q_ASSERT(m_applyResult.tracks.size() == m_applyResult.trackIndices.size());
+
+    for(size_t i{0}; i < m_applyResult.tracks.size(); ++i) {
+        const size_t localIndex = m_applyResult.trackIndices.at(i);
+        if(localIndex < tracks.size()) {
+            tracks.at(localIndex) = m_applyResult.tracks.at(i);
+        }
+    }
+
+    Q_EMIT tracksApplied(tracks);
+    accept();
+}
+
+void MetadataLookupDialog::writeMetadata()
+{
+    WriteRequest request = m_library->writeTrackMetadata(m_applyResult.tracks);
+
+    m_writeInProgress = true;
+    m_cancelWrite     = request.cancel;
+
+    m_progressDialog = new ElapsedProgressDialog(tr("Writing metadata…"), tr("Abort"), 0, 1, this);
+    m_progressDialog->setAttribute(Qt::WA_DeleteOnClose);
+    m_progressDialog->setModal(true);
+    m_progressDialog->setMinimumDuration(500ms);
+    m_progressDialog->setBusy(true);
+    m_progressDialog->setShowRemaining(false);
+    m_progressDialog->setWindowTitle(tr("Writing Metadata"));
+    m_progressDialog->setText(
+        tr("Writing metadata to %Ln track(s)…", nullptr, static_cast<int>(m_applyResult.tracks.size())));
+    m_progressDialog->startTimer();
+
+    QObject::connect(m_progressDialog, &ElapsedProgressDialog::cancelled, this, [this] {
+        if(m_cancelWrite) {
+            m_cancelWrite();
+        }
+    });
+
+    updateActions();
+
+    request.finished.then(this, [this](const WriteResult& result) {
+        if(m_progressDialog) {
+            m_progressDialog->close();
+        }
+
+        m_writeInProgress = false;
+        m_cancelWrite     = {};
+        updateActions();
+
+        if(result.state == WriteState::Cancelled) {
+            const QString succeeded = tr("%Ln succeeded", nullptr, result.succeeded);
+            const QString failed    = tr("%Ln failed", nullptr, result.failed);
+            m_status->setText(tr("Metadata writing was cancelled.") + u" %1; %2."_s.arg(succeeded, failed));
+        }
+        else if(result.failed > 0) {
+            const QString succeeded = tr("%Ln succeeded", nullptr, result.succeeded);
+            const QString failed    = tr("%Ln failed", nullptr, result.failed);
+            m_status->setText(tr("Metadata writing finished:") + u" %1; %2."_s.arg(succeeded, failed));
+        }
+        else {
+            m_writeCompleted = true;
+            m_status->setText(tr("Metadata was updated in %Ln track(s).", nullptr, result.succeeded));
+            m_updateFiles->setEnabled(false);
+        }
+    });
+}
+
+bool MetadataLookupDialog::confirmMetadataWipe()
+{
+    return applyOptions().policy != ExistingMetadataPolicy::WipeWritableTags
+        || QMessageBox::warning(this, tr("Wipe existing tags?"),
+                                tr("Existing metadata and custom tags will be removed before applying the selected "
+                                   "release. Ratings, ReplayGain, technical information, playback statistics, and "
+                                   "artwork will be preserved."),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+               == QMessageBox::Yes;
+}
+
+LookupQuery MetadataLookupDialog::query() const
+{
+    LookupMode mode = m_lookupMode->currentIndex() >= 0 ? static_cast<LookupMode>(m_lookupMode->currentData().toInt())
+                                                        : LookupMode::ArtistAlbum;
+    if(isIdentifierMode(mode) && m_idType->currentIndex() >= 0) {
+        mode = static_cast<LookupMode>(m_idType->currentData().toInt());
+    }
+
+    return {.mode       = mode,
+            .artist     = m_artist->text().simplified(),
+            .album      = m_album->text().simplified(),
+            .discToc    = m_discToc->text().simplified(),
+            .discId     = mode == LookupMode::DiscToc ? m_discId : QString{},
+            .identifier = mode == LookupMode::ReleaseGroupId ? m_releaseGroupId->text().simplified()
+                                                             : m_releaseId->text().simplified()};
+}
+
+MetadataApplyOptions MetadataLookupDialog::applyOptions() const
+{
+    return {.policy                 = static_cast<ExistingMetadataPolicy>(m_policy->currentData().toInt()),
+            .writeGenres            = m_writeGenres->isChecked(),
+            .writeReleaseIds        = m_writeIds->isChecked(),
+            .useOriginalReleaseDate = m_originalDate->isChecked()};
+}
+
+bool MetadataLookupDialog::canWriteAllTracks() const
+{
+    return !m_tracks.empty() && std::ranges::all_of(m_tracks, [this](const Track& track) {
+        return !track.hasCue() && !track.isInArchive()
+            && (isDbOnlyMetadataTrack(track) || m_audioLoader->canWriteMetadata(track));
+    });
+}
+} // namespace Fooyin
+
+#include "moc_metadatalookupdialog.cpp"

--- a/src/gui/metadatalookup/metadatalookupdialog.h
+++ b/src/gui/metadatalookup/metadatalookupdialog.h
@@ -1,0 +1,178 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "metadataapply.h"
+
+#include <QDialog>
+#include <QPointer>
+
+#include <functional>
+#include <optional>
+
+class QCheckBox;
+class QCloseEvent;
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QSplitter;
+class QStackedWidget;
+class QTableView;
+class QWidget;
+
+namespace Fooyin {
+class AudioLoader;
+class ElapsedProgressDialog;
+class MusicLibrary;
+class NetworkAccessManager;
+class SettingsManager;
+
+class LookupResultsModel;
+class MetadataLookupRegistry;
+class MetadataLookupSource;
+class RetrievedTrackModel;
+class TrackMatchModel;
+
+class FYGUI_EXPORT MetadataLookupDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    MetadataLookupDialog(TrackList tracks, MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
+                         std::shared_ptr<NetworkAccessManager> network, SettingsManager* settings, LookupMode mode,
+                         QWidget* parent = nullptr);
+    MetadataLookupDialog(TrackList tracks, std::shared_ptr<NetworkAccessManager> network, SettingsManager* settings,
+                         const LookupQuery& initialQuery, QWidget* parent = nullptr);
+    ~MetadataLookupDialog() override;
+
+    [[nodiscard]] bool hasSameTracks(const TrackList& tracks) const;
+    void startLookup(LookupMode mode);
+
+Q_SIGNALS:
+    void tracksApplied(const Fooyin::TrackList& tracks);
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
+private:
+    enum class Purpose : uint8_t
+    {
+        WriteFiles = 0,
+        ReturnTracks,
+    };
+
+    MetadataLookupDialog(TrackList tracks, MusicLibrary* library, std::shared_ptr<AudioLoader> audioLoader,
+                         std::shared_ptr<NetworkAccessManager> network, SettingsManager* settings, LookupMode mode,
+                         Purpose purpose, const std::optional<LookupQuery>& initialQuery, QWidget* parent);
+
+    void buildUi();
+    void connectSource(MetadataLookupSource* source);
+    void setSource(const QString& sourceId);
+
+    void updateLookupModes();
+    void setLookupMode(LookupMode mode);
+    void setLookupQuery(const LookupQuery& query);
+    void updateLookupEditor();
+    void saveState();
+    void restoreState();
+
+    void startSearch();
+    void selectRelease(const QModelIndex& current);
+    void setRelease(const Release& release);
+    void updateReleaseInformation(const ReleaseSummary& release);
+    void selectMatchingRow(int row);
+
+    void updatePreview();
+    void showChanges();
+    void updateActions();
+    void applyMetadata();
+    void writeMetadata();
+    [[nodiscard]] bool confirmMetadataWipe();
+
+    [[nodiscard]] LookupQuery query() const;
+    [[nodiscard]] MetadataApplyOptions applyOptions() const;
+    [[nodiscard]] bool canWriteAllTracks() const;
+
+    TrackList m_tracks;
+    MusicLibrary* m_library;
+    std::shared_ptr<AudioLoader> m_audioLoader;
+    std::shared_ptr<NetworkAccessManager> m_network;
+    SettingsManager* m_settings;
+    Purpose m_purpose;
+    QString m_discId;
+
+    std::unique_ptr<MetadataLookupRegistry> m_registry;
+    MetadataLookupSource* m_client;
+    LookupResultsModel* m_resultsModel;
+    RetrievedTrackModel* m_retrievedModel;
+    TrackMatchModel* m_matchModel;
+
+    QComboBox* m_source;
+    QComboBox* m_lookupMode;
+    QComboBox* m_idType;
+    QStackedWidget* m_lookupEditor;
+    QStackedWidget* m_identifierEditor;
+    QLineEdit* m_artist;
+    QLineEdit* m_album;
+    QLineEdit* m_discToc;
+    QLineEdit* m_releaseId;
+    QLineEdit* m_releaseGroupId;
+    QPushButton* m_search;
+    QLabel* m_status;
+    QLabel* m_releaseArtist;
+    QLabel* m_releaseAlbum;
+    QLabel* m_releaseDate;
+    QLabel* m_releaseOriginalDate;
+    QLabel* m_releaseCountry;
+    QLabel* m_releaseLabel;
+    QLabel* m_releaseCatalogNumber;
+    QLabel* m_releaseBarcode;
+    QLabel* m_releaseFormat;
+    QLabel* m_releaseType;
+    QLabel* m_releaseStatus;
+    QLabel* m_releaseDisambiguation;
+    QTableView* m_resultsView;
+    QTableView* m_retrievedView;
+    QTableView* m_matchView;
+    QComboBox* m_policy;
+    QCheckBox* m_allowUnresolved;
+    QCheckBox* m_writeGenres;
+    QCheckBox* m_writeIds;
+    QCheckBox* m_originalDate;
+    QPushButton* m_changesButton;
+    QSplitter* m_splitter;
+    QSplitter* m_resultsSplitter;
+    QSplitter* m_matchSplitter;
+    QDialogButtonBox* m_buttons;
+    QPushButton* m_updateFiles;
+    QPushButton* m_close;
+
+    MetadataApplyResult m_applyResult;
+    bool m_releaseLoaded;
+    bool m_busy;
+    bool m_writeInProgress;
+    bool m_writeCompleted;
+    bool m_syncingTrackScrollbars;
+    std::function<void()> m_cancelWrite;
+    QPointer<ElapsedProgressDialog> m_progressDialog;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatalookupregistry.cpp
+++ b/src/gui/metadatalookup/metadatalookupregistry.cpp
@@ -1,0 +1,60 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadatalookupregistry.h"
+
+#include "sources/musicbrainzmetadata.h"
+
+namespace Fooyin {
+MetadataLookupRegistry::MetadataLookupRegistry(QNetworkAccessManager* network)
+{
+    addSource(std::make_unique<MusicBrainzMetadata>(network));
+}
+
+MetadataLookupRegistry::~MetadataLookupRegistry() = default;
+
+std::vector<MetadataLookupSource*> MetadataLookupRegistry::sources() const
+{
+    std::vector<MetadataLookupSource*> result;
+    result.reserve(m_sources.size());
+
+    for(const auto& registeredSource : m_sources) {
+        result.push_back(registeredSource.get());
+    }
+
+    return result;
+}
+
+MetadataLookupSource* MetadataLookupRegistry::source(const QString& id) const
+{
+    const auto it = std::ranges::find(m_sources, id, &MetadataLookupSource::id);
+    return it != m_sources.cend() ? it->get() : nullptr;
+}
+
+MetadataLookupSource* MetadataLookupRegistry::addSource(std::unique_ptr<MetadataLookupSource> source)
+{
+    if(!source || source->id().isEmpty() || this->source(source->id())) {
+        return nullptr;
+    }
+
+    auto* result = source.get();
+    m_sources.push_back(std::move(source));
+    return result;
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatalookupregistry.h
+++ b/src/gui/metadatalookup/metadatalookupregistry.h
@@ -1,0 +1,50 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include <QString>
+#include <memory>
+#include <vector>
+
+class QNetworkAccessManager;
+
+namespace Fooyin {
+class MetadataLookupSource;
+
+class FYGUI_EXPORT MetadataLookupRegistry
+{
+public:
+    explicit MetadataLookupRegistry(QNetworkAccessManager* network);
+    ~MetadataLookupRegistry();
+
+    MetadataLookupRegistry(const MetadataLookupRegistry&)            = delete;
+    MetadataLookupRegistry& operator=(const MetadataLookupRegistry&) = delete;
+
+    [[nodiscard]] std::vector<MetadataLookupSource*> sources() const;
+    [[nodiscard]] MetadataLookupSource* source(const QString& id) const;
+
+    MetadataLookupSource* addSource(std::unique_ptr<MetadataLookupSource> source);
+
+private:
+    std::vector<std::unique_ptr<MetadataLookupSource>> m_sources;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatamatcher.cpp
+++ b/src/gui/metadatalookup/metadatamatcher.cpp
@@ -1,0 +1,190 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadatamatcher.h"
+
+#include <utils/stringutils.h>
+
+#include <QRegularExpression>
+
+#include <cmath>
+#include <set>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin {
+namespace {
+int leadingNumber(const QString& value)
+{
+    static const QRegularExpression expression{uR"(^\s*(\d+))"_s};
+    const auto match = expression.match(value);
+    return match.hasMatch() ? match.captured(1).toInt() : 0;
+}
+
+int candidateScore(const Track& local, const ReleaseTrack& remote, size_t localIndex, size_t remoteIndex,
+                   size_t localCount, size_t remoteCount)
+{
+    int score{0};
+
+    const QString localTitle  = normaliseMatchText(local.effectiveTitle());
+    const QString remoteTitle = normaliseMatchText(remote.title);
+    if(!localTitle.isEmpty() && !remoteTitle.isEmpty()) {
+        score += (Utils::similarityRatio(localTitle, remoteTitle, Qt::CaseInsensitive) * 55) / 100;
+    }
+
+    if(local.duration() > 0 && remote.durationMs > 0) {
+        const auto difference = std::llabs(static_cast<int64_t>(local.duration()) - remote.durationMs);
+        if(difference <= 2000) {
+            score += 25;
+        }
+        else if(difference <= 10000) {
+            score += static_cast<int>(25 - ((difference - 2000) * 15 / 8000));
+        }
+        else if(difference <= 30000) {
+            score += 5;
+        }
+    }
+
+    const int localTrack = leadingNumber(local.trackNumber());
+    const int localDisc  = leadingNumber(local.discNumber());
+    if(localTrack > 0 && localTrack == remote.position) {
+        score += 15;
+    }
+    if(localDisc > 0 && localDisc == remote.mediumPosition) {
+        score += 10;
+    }
+    if(localTrack > 0 && localDisc > 0 && (localTrack != remote.position || localDisc != remote.mediumPosition)) {
+        score -= 25;
+    }
+
+    if(localCount > 1 && remoteCount > 1) {
+        const double localPosition  = static_cast<double>(localIndex) / static_cast<double>(localCount - 1);
+        const double remotePosition = static_cast<double>(remoteIndex) / static_cast<double>(remoteCount - 1);
+        score += std::max(0, 10 - static_cast<int>(std::abs(localPosition - remotePosition) * 25.0));
+    }
+
+    return std::clamp(score, 0, 100);
+}
+
+struct Candidate
+{
+    size_t local{0};
+    size_t remote{0};
+    int score{0};
+};
+} // namespace
+
+QString normaliseMatchText(const QString& text)
+{
+    QString result = text.normalized(QString::NormalizationForm_C).toCaseFolded();
+    result.replace(QRegularExpression{uR"([^\p{L}\p{N}]+)"_s}, u" "_s);
+    return result.simplified();
+}
+
+std::vector<TrackMatch> matchTracks(const TrackList& localTracks, const Release& release)
+{
+    const auto remoteTracks = flattenedTracks(release);
+
+    std::vector<TrackMatch> matches(localTracks.size());
+    for(size_t i{0}; i < matches.size(); ++i) {
+        matches.at(i).localIndex = i;
+    }
+
+    if(localTracks.empty() || remoteTracks.empty()) {
+        return matches;
+    }
+
+    std::vector<Candidate> candidates;
+    candidates.reserve(localTracks.size() * remoteTracks.size());
+
+    std::vector scores(localTracks.size(), std::vector<int>(remoteTracks.size()));
+    for(size_t local{0}; local < localTracks.size(); ++local) {
+        for(size_t remote{0}; remote < remoteTracks.size(); ++remote) {
+            const int score             = candidateScore(localTracks.at(local), *remoteTracks.at(remote), local, remote,
+                                                         localTracks.size(), remoteTracks.size());
+            scores.at(local).at(remote) = score;
+            candidates.emplace_back(local, remote, score);
+        }
+    }
+
+    std::ranges::sort(candidates, [](const Candidate& lhs, const Candidate& rhs) {
+        if(lhs.score != rhs.score) {
+            return lhs.score > rhs.score;
+        }
+        if(lhs.local != rhs.local) {
+            return lhs.local < rhs.local;
+        }
+        return lhs.remote < rhs.remote;
+    });
+
+    std::set<size_t> assignedLocal;
+    std::set<size_t> assignedRemote;
+
+    for(const Candidate& candidate : candidates) {
+        if(candidate.score < 35 || assignedLocal.contains(candidate.local)
+           || assignedRemote.contains(candidate.remote)) {
+            continue;
+        }
+
+        TrackMatch& match = matches.at(candidate.local);
+        match.remoteIndex = candidate.remote;
+        match.confidence  = candidate.score;
+
+        int secondBest{0};
+        for(size_t other{0}; other < remoteTracks.size(); ++other) {
+            if(other != candidate.remote) {
+                secondBest = std::max(secondBest, scores.at(candidate.local).at(other));
+            }
+        }
+
+        match.ambiguous = candidate.score < 55 || candidate.score - secondBest < 8;
+        assignedLocal.emplace(candidate.local);
+        assignedRemote.emplace(candidate.remote);
+    }
+
+    return matches;
+}
+
+std::vector<TrackMatch> matchTracksByPosition(const TrackList& localTracks, const Release& release)
+{
+    const auto remoteTracks = flattenedTracks(release);
+
+    std::vector<TrackMatch> matches(localTracks.size());
+
+    for(size_t localIndex{0}; localIndex < localTracks.size(); ++localIndex) {
+        TrackMatch& match = matches.at(localIndex);
+        match.localIndex  = localIndex;
+
+        const int trackNumber = leadingNumber(localTracks.at(localIndex).trackNumber());
+        if(trackNumber <= 0) {
+            continue;
+        }
+
+        const auto remote = std::ranges::find(remoteTracks, trackNumber, &ReleaseTrack::position);
+        if(remote == remoteTracks.cend()) {
+            continue;
+        }
+
+        match.remoteIndex = static_cast<size_t>(std::distance(remoteTracks.cbegin(), remote));
+        match.confidence  = 100;
+    }
+
+    return matches;
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatamatcher.h
+++ b/src/gui/metadatalookup/metadatamatcher.h
@@ -1,0 +1,41 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include "metadatatypes.h"
+
+#include <core/track.h>
+
+namespace Fooyin {
+struct TrackMatch
+{
+    size_t localIndex{0};
+    std::optional<size_t> remoteIndex;
+    int confidence{0};
+    bool ambiguous{false};
+    bool manual{false};
+};
+
+FYGUI_EXPORT QString normaliseMatchText(const QString& text);
+FYGUI_EXPORT std::vector<TrackMatch> matchTracks(const TrackList& localTracks, const Release& release);
+FYGUI_EXPORT std::vector<TrackMatch> matchTracksByPosition(const TrackList& localTracks, const Release& release);
+} // namespace Fooyin

--- a/src/gui/metadatalookup/metadatatypes.h
+++ b/src/gui/metadatalookup/metadatatypes.h
@@ -1,0 +1,160 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+#include <QStringList>
+
+#include <unordered_map>
+#include <vector>
+
+namespace Fooyin {
+enum class LookupMode : uint8_t
+{
+    ArtistAlbum,
+    DiscToc,
+    ReleaseId,
+    ReleaseGroupId,
+};
+
+struct LookupQuery
+{
+    LookupMode mode{LookupMode::ArtistAlbum};
+    QString artist;
+    QString album;
+    QString discToc;
+    QString discId;
+    QString identifier;
+};
+
+struct ArtistCredit
+{
+    QString name;
+    QString joinPhrase;
+    QString id;
+
+    bool operator==(const ArtistCredit&) const = default;
+};
+
+struct ReleaseSummary
+{
+    QString sourceId;
+    QString id;
+    QString title;
+    std::vector<ArtistCredit> artistCredit;
+    QString date;
+    QString originalDate;
+    QString country;
+    QString status;
+    QString disambiguation;
+    QString barcode;
+    QStringList labels;
+    QStringList catalogNumbers;
+    QStringList formats;
+    QStringList releaseTypes;
+    std::unordered_map<QString, QStringList> identifiers;
+    int discCount{0};
+};
+
+struct ReleaseTrack
+{
+    QString title;
+    std::vector<ArtistCredit> artistCredit;
+    QStringList isrcs;
+    QStringList genres;
+    std::unordered_map<QString, QStringList> identifiers;
+    int mediumPosition{0};
+    int position{0};
+    QString number;
+    int total{0};
+    int64_t durationMs{-1};
+};
+
+struct ReleaseMedium
+{
+    int position{0};
+    QString title;
+    QString format;
+    QStringList discIds;
+    std::vector<ReleaseTrack> tracks;
+};
+
+struct Release
+{
+    ReleaseSummary summary;
+    std::vector<ReleaseMedium> media;
+    QStringList genres;
+};
+
+[[nodiscard]] inline QString artistCreditText(const std::vector<ArtistCredit>& credits)
+{
+    QString result;
+
+    for(const auto& credit : credits) {
+        result += credit.name;
+        result += credit.joinPhrase;
+    }
+
+    return result;
+}
+
+[[nodiscard]] inline QStringList artistCreditNames(const std::vector<ArtistCredit>& credits)
+{
+    QStringList result;
+
+    for(const auto& credit : credits) {
+        if(!credit.name.isEmpty()) {
+            result.push_back(credit.name);
+        }
+    }
+
+    return result;
+}
+
+[[nodiscard]] inline QStringList artistCreditIds(const std::vector<ArtistCredit>& credits)
+{
+    QStringList result;
+
+    for(const auto& credit : credits) {
+        if(!credit.id.isEmpty()) {
+            result.push_back(credit.id);
+        }
+    }
+
+    return result;
+}
+
+[[nodiscard]] inline std::vector<const ReleaseTrack*> flattenedTracks(const Release& release)
+{
+    std::vector<const ReleaseTrack*> result;
+
+    for(const auto& medium : release.media) {
+        for(const auto& track : medium.tracks) {
+            result.push_back(&track);
+        }
+    }
+
+    return result;
+}
+} // namespace Fooyin
+
+Q_DECLARE_METATYPE(Fooyin::ReleaseSummary)
+Q_DECLARE_METATYPE(Fooyin::Release)

--- a/src/gui/metadatalookup/sources/metadatalookupsource.cpp
+++ b/src/gui/metadatalookup/sources/metadatalookupsource.cpp
@@ -1,0 +1,32 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "metadatalookupsource.h"
+
+namespace Fooyin {
+MetadataLookupSource::MetadataLookupSource(QNetworkAccessManager* network, QObject* parent)
+    : QObject{parent}
+    , m_network{network}
+{ }
+
+QNetworkAccessManager* MetadataLookupSource::network() const
+{
+    return m_network;
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/sources/metadatalookupsource.h
+++ b/src/gui/metadatalookup/sources/metadatalookupsource.h
@@ -1,0 +1,61 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include "gui/metadatalookup/metadatatypes.h"
+
+#include <QObject>
+
+class QNetworkAccessManager;
+
+namespace Fooyin {
+class SettingsManager;
+
+class FYGUI_EXPORT MetadataLookupSource : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit MetadataLookupSource(QNetworkAccessManager* network, QObject* parent = nullptr);
+
+    [[nodiscard]] virtual QString id() const                             = 0;
+    [[nodiscard]] virtual QString name() const                           = 0;
+    [[nodiscard]] virtual std::vector<LookupMode> supportedModes() const = 0;
+
+    virtual void search(const LookupQuery& query)       = 0;
+    virtual void fetchRelease(const QString& releaseId) = 0;
+
+    virtual void cancel() = 0;
+
+Q_SIGNALS:
+    void searchFinished(const std::vector<Fooyin::ReleaseSummary>& results);
+    void releaseFetched(const Fooyin::Release& release);
+    void failed(const QString& message);
+    void busyChanged(bool busy);
+
+protected:
+    [[nodiscard]] QNetworkAccessManager* network() const;
+
+private:
+    QNetworkAccessManager* m_network;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/sources/musicbrainzmetadata.cpp
+++ b/src/gui/metadatalookup/sources/musicbrainzmetadata.cpp
@@ -1,0 +1,599 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "musicbrainzmetadata.h"
+
+#include <core/network/networkutils.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QLoggingCategory>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QTimerEvent>
+#include <QUrlQuery>
+
+using namespace Qt::StringLiterals;
+using namespace std::chrono_literals;
+
+Q_LOGGING_CATEGORY(METADATA_LOOKUP, "fy.metadatalookup")
+
+constexpr auto ResultLimit       = "MetadataLookup/SearchResultLimit"_L1;
+constexpr auto RequestIntervalMs = 1000;
+constexpr auto MaxRetries        = 3;
+
+namespace Fooyin {
+namespace {
+QStringList stringArray(const QJsonValue& value)
+{
+    QStringList result;
+
+    const auto entries = value.toArray();
+    for(const auto& entry : entries) {
+        const QString text = entry.isObject() ? entry.toObject().value("name"_L1).toString() : entry.toString();
+        if(!text.isEmpty() && !result.contains(text)) {
+            result.push_back(text);
+        }
+    }
+
+    return result;
+}
+
+std::vector<ArtistCredit> parseArtistCredit(const QJsonValue& value)
+{
+    std::vector<ArtistCredit> result;
+
+    const auto items = value.toArray();
+    for(const auto& item : items) {
+        const QJsonObject credit = item.toObject();
+        const QJsonObject artist = credit.value("artist"_L1).toObject();
+
+        ArtistCredit parsed;
+        parsed.name       = credit.value("name"_L1).toString(artist.value("name"_L1).toString());
+        parsed.joinPhrase = credit.value("joinphrase"_L1).toString();
+        parsed.id         = artist.value("id"_L1).toString();
+
+        if(!parsed.name.isEmpty() || !parsed.id.isEmpty()) {
+            result.push_back(std::move(parsed));
+        }
+    }
+
+    return result;
+}
+
+void parseLabelInfo(const QJsonValue& value, ReleaseSummary& summary)
+{
+    const auto items = value.toArray();
+    for(const auto& item : items) {
+        const QJsonObject info = item.toObject();
+        const QString catalog  = info.value("catalog-number"_L1).toString();
+        const QString label    = info.value("label"_L1).toObject().value("name"_L1).toString();
+
+        if(!catalog.isEmpty() && !summary.catalogNumbers.contains(catalog)) {
+            summary.catalogNumbers.push_back(catalog);
+        }
+        if(!label.isEmpty() && !summary.labels.contains(label)) {
+            summary.labels.push_back(label);
+        }
+    }
+}
+
+void parseReleaseGroup(const QJsonValue& value, ReleaseSummary& summary)
+{
+    const QJsonObject group      = value.toObject();
+    const QString releaseGroupId = group.value("id"_L1).toString();
+
+    if(!releaseGroupId.isEmpty()) {
+        summary.identifiers.emplace(u"MUSICBRAINZ_RELEASEGROUPID"_s, QStringList{releaseGroupId});
+    }
+
+    summary.originalDate = group.value("first-release-date"_L1).toString();
+
+    const QString primary = group.value("primary-type"_L1).toString();
+    if(!primary.isEmpty()) {
+        summary.releaseTypes.push_back(primary);
+    }
+
+    const auto types = stringArray(group.value("secondary-types"_L1));
+    for(const QString& type : types) {
+        if(!summary.releaseTypes.contains(type)) {
+            summary.releaseTypes.push_back(type);
+        }
+    }
+}
+
+ReleaseSummary parseSummary(const QJsonObject& object)
+{
+    ReleaseSummary result;
+    result.sourceId       = u"musicbrainz"_s;
+    result.id             = object.value("id"_L1).toString();
+    result.title          = object.value("title"_L1).toString();
+    result.artistCredit   = parseArtistCredit(object.value("artist-credit"_L1));
+    result.date           = object.value("date"_L1).toString();
+    result.country        = object.value("country"_L1).toString();
+    result.status         = object.value("status"_L1).toString();
+    result.disambiguation = object.value("disambiguation"_L1).toString();
+    result.barcode        = object.value("barcode"_L1).toString();
+
+    parseLabelInfo(object.value("label-info"_L1), result);
+    parseReleaseGroup(object.value("release-group"_L1), result);
+
+    if(!result.id.isEmpty()) {
+        result.identifiers.emplace(u"MUSICBRAINZ_ALBUMID"_s, QStringList{result.id});
+    }
+
+    const QStringList albumArtistIds = artistCreditIds(result.artistCredit);
+    if(!albumArtistIds.isEmpty()) {
+        result.identifiers.emplace(u"MUSICBRAINZ_ALBUMARTISTID"_s, albumArtistIds);
+    }
+
+    const auto items = object.value("media"_L1).toArray();
+    result.discCount = static_cast<int>(items.size());
+    for(const auto& item : items) {
+        const QJsonObject medium = item.toObject();
+        const QString format     = medium.value("format"_L1).toString();
+        if(!format.isEmpty() && !result.formats.contains(format)) {
+            result.formats.push_back(format);
+        }
+    }
+
+    return result;
+}
+
+bool parseDocument(const QByteArray& data, QJsonObject& object, QString& error)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(data, &parseError);
+    if(parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        error = parseError.error != QJsonParseError::NoError ? parseError.errorString() : u"Invalid JSON object"_s;
+        return false;
+    }
+
+    object = document.object();
+
+    if(object.contains("error"_L1)) {
+        error = object.value("error"_L1).toString();
+        if(error.isEmpty()) {
+            error = object.value("message"_L1).toString(u"MusicBrainz returned an error"_s);
+        }
+        return false;
+    }
+
+    return true;
+}
+} // namespace
+
+QString escapeQueryValue(const QString& value)
+{
+    QString escaped;
+    escaped.reserve(value.size() * 2);
+
+    static const QString special = uR"(+-!(){}[]^"~*?:\/|&)"_s;
+
+    const auto chars = value.simplified();
+    for(const QChar character : chars) {
+        if(special.contains(character)) {
+            escaped += u'\\';
+        }
+        escaped += character;
+    }
+
+    return escaped;
+}
+
+MusicBrainzMetadata::MusicBrainzMetadata(QNetworkAccessManager* network, QObject* parent)
+    : MetadataLookupSource{network, parent}
+    , m_generation{0}
+    , m_busy{false}
+{ }
+
+MusicBrainzMetadata::~MusicBrainzMetadata()
+{
+    cancel();
+}
+
+QUrl buildReleaseUrl(const QString& releaseId)
+{
+    QUrl url{u"https://musicbrainz.org/ws/2/release/%1"_s.arg(releaseId)};
+
+    QUrlQuery query;
+    query.addQueryItem(u"fmt"_s, u"json"_s);
+    query.addQueryItem(u"inc"_s, u"recordings+artist-credits+release-groups+labels+discids+isrcs+genres"_s);
+    url.setQuery(query);
+
+    return url;
+}
+
+QString MusicBrainzMetadata::id() const
+{
+    return u"musicbrainz"_s;
+}
+
+QString MusicBrainzMetadata::name() const
+{
+    return tr("MusicBrainz");
+}
+
+std::vector<LookupMode> MusicBrainzMetadata::supportedModes() const
+{
+    return {LookupMode::ArtistAlbum, LookupMode::DiscToc, LookupMode::ReleaseId, LookupMode::ReleaseGroupId};
+}
+
+void MusicBrainzMetadata::search(const LookupQuery& query)
+{
+    cancel();
+
+    const bool empty = query.mode == LookupMode::ArtistAlbum
+                         ? query.artist.simplified().isEmpty() && query.album.simplified().isEmpty()
+                     : query.mode == LookupMode::DiscToc ? query.discToc.simplified().isEmpty()
+                                                         : query.identifier.simplified().isEmpty();
+    if(empty) {
+        Q_EMIT failed(query.mode == LookupMode::ArtistAlbum ? tr("Enter an artist or album.")
+                      : query.mode == LookupMode::DiscToc   ? tr("Enter a disc TOC.")
+                                                            : tr("Enter a MusicBrainz ID."));
+        return;
+    }
+
+    const int limit = std::clamp(m_settings.value(ResultLimit, 25).toInt(), 1, 100);
+    enqueue(
+        {.type = OperationType::Search, .url = buildSearchUrl(query, limit), .generation = m_generation, .retries = 0});
+}
+
+void MusicBrainzMetadata::fetchRelease(const QString& releaseId)
+{
+    cancel();
+
+    if(releaseId.isEmpty()) {
+        Q_EMIT failed(tr("The selected result has no release identifier."));
+        return;
+    }
+
+    if(const auto cached = m_releaseCache.find(releaseId); cached != m_releaseCache.cend()) {
+        Q_EMIT releaseFetched(cached->second);
+        return;
+    }
+
+    enqueue(
+        {.type = OperationType::Release, .url = buildReleaseUrl(releaseId), .generation = m_generation, .retries = 0});
+}
+
+void MusicBrainzMetadata::cancel()
+{
+    ++m_generation;
+
+    m_startTimer.stop();
+    m_queue.clear();
+    m_active.reset();
+
+    if(m_reply) {
+        QObject::disconnect(m_reply, nullptr, this, nullptr);
+        m_reply->abort();
+        m_reply->deleteLater();
+        m_reply = nullptr;
+    }
+
+    setBusy(false);
+}
+
+QString MusicBrainzMetadata::buildSearchExpression(const LookupQuery& query)
+{
+    QStringList clauses;
+
+    if(query.mode == LookupMode::ArtistAlbum) {
+        const QString album = query.album.simplified();
+        if(!album.isEmpty()) {
+            clauses.push_back(uR"(release:"%1")"_s.arg(escapeQueryValue(album)));
+        }
+        const QString artist = query.artist.simplified();
+        if(!artist.isEmpty()) {
+            clauses.push_back(uR"(artist:"%1")"_s.arg(escapeQueryValue(artist)));
+        }
+    }
+    else if((query.mode == LookupMode::ReleaseId || query.mode == LookupMode::ReleaseGroupId)
+            && !query.identifier.simplified().isEmpty()) {
+        const auto field = query.mode == LookupMode::ReleaseId ? "reid"_L1 : "rgid"_L1;
+        clauses.push_back(uR"(%1:"%2")"_s.arg(field, escapeQueryValue(query.identifier)));
+    }
+
+    return clauses.join(u" AND "_s);
+}
+
+QUrl MusicBrainzMetadata::buildSearchUrl(const LookupQuery& query, int limit)
+{
+    QUrl url{query.mode == LookupMode::DiscToc ? u"https://musicbrainz.org/ws/2/discid/-"_s
+                                               : u"https://musicbrainz.org/ws/2/release/"_s};
+
+    QUrlQuery urlQuery;
+    if(query.mode == LookupMode::DiscToc) {
+        urlQuery.addQueryItem(u"toc"_s, query.discToc.simplified());
+        urlQuery.addQueryItem(u"inc"_s, u"artists"_s);
+    }
+    else {
+        urlQuery.addQueryItem(u"query"_s, buildSearchExpression(query));
+    }
+    urlQuery.addQueryItem(u"fmt"_s, u"json"_s);
+    urlQuery.addQueryItem(u"limit"_s, QString::number(std::clamp(limit, 1, 100)));
+    url.setQuery(urlQuery);
+
+    return url;
+}
+
+bool MusicBrainzMetadata::parseSearchResponse(const QByteArray& data, std::vector<ReleaseSummary>& releases,
+                                              QString& error)
+{
+    releases.clear();
+
+    QJsonObject object;
+    if(!parseDocument(data, object, error)) {
+        return false;
+    }
+
+    const auto values = object.value("releases"_L1).toArray();
+    for(const auto& value : values) {
+        ReleaseSummary summary = parseSummary(value.toObject());
+        if(!summary.id.isEmpty()) {
+            releases.push_back(std::move(summary));
+        }
+    }
+
+    return true;
+}
+
+bool MusicBrainzMetadata::parseReleaseResponse(const QByteArray& data, Release& release, QString& error)
+{
+    QJsonObject object;
+    if(!parseDocument(data, object, error)) {
+        return false;
+    }
+
+    release         = {};
+    release.summary = parseSummary(object);
+    release.genres  = stringArray(object.value("genres"_L1));
+
+    const auto values = object.value("media"_L1).toArray();
+    for(const auto& mediumValue : values) {
+        const QJsonObject mediumObject = mediumValue.toObject();
+
+        ReleaseMedium medium;
+        medium.position = mediumObject.value("position"_L1).toInt();
+        medium.title    = mediumObject.value("title"_L1).toString();
+        medium.format   = mediumObject.value("format"_L1).toString();
+
+        const QJsonArray discs = mediumObject.value("discs"_L1).toArray();
+        for(const auto& discValue : discs) {
+            const QString discId = discValue.toObject().value("id"_L1).toString();
+            if(!discId.isEmpty() && !medium.discIds.contains(discId)) {
+                medium.discIds.push_back(discId);
+            }
+        }
+
+        const QJsonArray tracks = mediumObject.value("tracks"_L1).toArray();
+        for(const auto& trackValue : tracks) {
+            const QJsonObject trackObject     = trackValue.toObject();
+            const QJsonObject recordingObject = trackObject.value("recording"_L1).toObject();
+
+            const QString releaseTrackId = trackObject.value("id"_L1).toString();
+            const QString recordingId    = recordingObject.value("id"_L1).toString();
+
+            ReleaseTrack track;
+            track.title        = trackObject.value("title"_L1).toString(recordingObject.value("title"_L1).toString());
+            track.artistCredit = parseArtistCredit(trackObject.value("artist-credit"_L1));
+
+            if(track.artistCredit.empty()) {
+                track.artistCredit = parseArtistCredit(recordingObject.value("artist-credit"_L1));
+            }
+            if(track.artistCredit.empty()) {
+                track.artistCredit = release.summary.artistCredit;
+            }
+            if(!recordingId.isEmpty()) {
+                track.identifiers.emplace(u"MUSICBRAINZ_TRACKID"_s, QStringList{recordingId});
+            }
+            if(!releaseTrackId.isEmpty()) {
+                track.identifiers.emplace(u"MUSICBRAINZ_RELEASETRACKID"_s, QStringList{releaseTrackId});
+            }
+
+            const QStringList artistIds = artistCreditIds(track.artistCredit);
+            if(!artistIds.isEmpty()) {
+                track.identifiers.emplace(u"MUSICBRAINZ_ARTISTID"_s, artistIds);
+            }
+            track.isrcs          = stringArray(recordingObject.value("isrcs"_L1));
+            track.genres         = stringArray(recordingObject.value("genres"_L1));
+            track.mediumPosition = medium.position;
+            track.position       = trackObject.value("position"_L1).toInt();
+            track.number         = trackObject.value("number"_L1).toString();
+            track.total          = static_cast<int>(tracks.size());
+            track.durationMs     = trackObject.value("length"_L1).toInteger(-1);
+
+            if(track.durationMs <= 0) {
+                track.durationMs = recordingObject.value("length"_L1).toInteger(-1);
+            }
+            if(track.durationMs <= 0) {
+                track.durationMs = -1;
+            }
+            if(!releaseTrackId.isEmpty() || !recordingId.isEmpty()) {
+                medium.tracks.push_back(std::move(track));
+            }
+        }
+        release.media.push_back(std::move(medium));
+    }
+
+    if(release.summary.id.isEmpty()) {
+        error = u"MusicBrainz release response has no release ID"_s;
+        return false;
+    }
+
+    return true;
+}
+
+void MusicBrainzMetadata::timerEvent(QTimerEvent* event)
+{
+    if(event->timerId() == m_startTimer.timerId()) {
+        m_startTimer.stop();
+        startNext();
+    }
+    MetadataLookupSource::timerEvent(event);
+}
+
+void MusicBrainzMetadata::enqueue(Operation operation)
+{
+    m_queue.push_back(std::move(operation));
+    setBusy(true);
+    startNext();
+}
+
+void MusicBrainzMetadata::startNext()
+{
+    if(m_reply || m_active || m_startTimer.isActive() || m_queue.empty()) {
+        if(m_queue.empty() && !m_reply && !m_active) {
+            setBusy(false);
+        }
+        return;
+    }
+
+    const int elapsed = m_lastStarted.isValid() ? static_cast<int>(m_lastStarted.elapsed()) : RequestIntervalMs;
+    if(elapsed < RequestIntervalMs) {
+        m_startTimer.start(RequestIntervalMs - elapsed, this);
+        return;
+    }
+
+    const Operation operation = std::move(m_queue.front());
+    m_queue.pop_front();
+
+    if(operation.generation != m_generation) {
+        startNext();
+        return;
+    }
+
+    startOperation(operation);
+}
+
+void MusicBrainzMetadata::startOperation(const Operation& operation)
+{
+    QNetworkRequest request = makeNetworkRequest(operation.url);
+    request.setRawHeader("Accept", "application/json");
+
+    m_active = operation;
+    m_lastStarted.restart();
+
+    qCDebug(METADATA_LOOKUP) << "Starting MusicBrainz request" << static_cast<int>(operation.type) << "generation"
+                             << operation.generation;
+
+    m_reply = network()->get(request);
+    QObject::connect(m_reply, &QNetworkReply::finished, this, &MusicBrainzMetadata::handleReply);
+}
+
+void MusicBrainzMetadata::handleReply()
+{
+    if(!m_reply || !m_active) {
+        return;
+    }
+
+    QNetworkReply* reply{m_reply};
+    m_reply = nullptr;
+    const Operation operation{*m_active};
+    m_active.reset();
+    QObject::disconnect(reply, nullptr, this, nullptr);
+
+    const int status                               = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QByteArray retryAfter                    = reply->rawHeader("Retry-After");
+    const QNetworkReply::NetworkError networkError = reply->error();
+    const QString networkErrorText                 = reply->errorString();
+    const QByteArray data                          = reply->readAll();
+
+    reply->deleteLater();
+
+    if(operation.generation != m_generation) {
+        finishOperation();
+        return;
+    }
+
+    if((status == 429 || status == 503) && operation.retries < MaxRetries) {
+        retryOperation(operation, status, retryAfter);
+        return;
+    }
+
+    if(networkError != QNetworkReply::NoError) {
+        qCWarning(METADATA_LOOKUP) << "MusicBrainz request failed with HTTP" << status << networkErrorText;
+        Q_EMIT failed(tr("MusicBrainz request failed: %1").arg(networkErrorText));
+        finishOperation();
+        return;
+    }
+
+    QString error;
+
+    if(operation.type == OperationType::Search) {
+        std::vector<ReleaseSummary> releases;
+        if(parseSearchResponse(data, releases, error)) {
+            Q_EMIT searchFinished(releases);
+        }
+        else {
+            qCWarning(METADATA_LOOKUP) << "Could not parse MusicBrainz search response:" << error;
+            Q_EMIT failed(tr("Could not read the MusicBrainz search response: %1").arg(error));
+        }
+    }
+    else {
+        Release release;
+        if(parseReleaseResponse(data, release, error)) {
+            m_releaseCache.insert_or_assign(release.summary.id, release);
+            Q_EMIT releaseFetched(release);
+        }
+        else {
+            qCWarning(METADATA_LOOKUP) << "Could not parse MusicBrainz release response:" << error;
+            Q_EMIT failed(tr("Could not read the MusicBrainz release response: %1").arg(error));
+        }
+    }
+
+    finishOperation();
+}
+
+void MusicBrainzMetadata::finishOperation()
+{
+    if(m_queue.empty()) {
+        setBusy(false);
+    }
+    startNext();
+}
+
+void MusicBrainzMetadata::retryOperation(Operation operation, int statusCode, const QByteArray& retryAfter)
+{
+    ++operation.retries;
+
+    bool validRetryAfter{false};
+    const int serverDelay = retryAfter.toInt(&validRetryAfter) * 1000;
+    const int backoff
+        = validRetryAfter ? std::max(RequestIntervalMs, serverDelay) : RequestIntervalMs * (1 << operation.retries);
+    qCWarning(METADATA_LOOKUP) << "MusicBrainz request throttled with HTTP" << statusCode << "retrying in" << backoff
+                               << "ms";
+    m_queue.push_front(std::move(operation));
+    m_startTimer.start(backoff, this);
+}
+
+void MusicBrainzMetadata::setBusy(bool busy)
+{
+    if(std::exchange(m_busy, busy) != busy) {
+        Q_EMIT busyChanged(busy);
+    }
+}
+} // namespace Fooyin
+
+#include "moc_musicbrainzmetadata.cpp"

--- a/src/gui/metadatalookup/sources/musicbrainzmetadata.h
+++ b/src/gui/metadatalookup/sources/musicbrainzmetadata.h
@@ -1,0 +1,99 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "metadatalookupsource.h"
+
+#include <core/coresettings.h>
+
+#include <QBasicTimer>
+#include <QElapsedTimer>
+#include <QPointer>
+#include <QTimer>
+#include <QUrl>
+
+#include <deque>
+#include <optional>
+#include <unordered_map>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+namespace Fooyin {
+class SettingsManager;
+
+class FYGUI_EXPORT MusicBrainzMetadata : public MetadataLookupSource
+{
+    Q_OBJECT
+
+public:
+    explicit MusicBrainzMetadata(QNetworkAccessManager* network, QObject* parent = nullptr);
+    ~MusicBrainzMetadata() override;
+
+    [[nodiscard]] QString id() const override;
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] std::vector<LookupMode> supportedModes() const override;
+    void search(const LookupQuery& query) override;
+    void fetchRelease(const QString& releaseId) override;
+    void cancel() override;
+
+    static QString buildSearchExpression(const LookupQuery& query);
+    static QUrl buildSearchUrl(const LookupQuery& query, int limit);
+    static bool parseSearchResponse(const QByteArray& data, std::vector<ReleaseSummary>& releases, QString& error);
+    static bool parseReleaseResponse(const QByteArray& data, Release& release, QString& error);
+
+protected:
+    void timerEvent(QTimerEvent* event) override;
+
+private:
+    enum class OperationType : uint8_t
+    {
+        Search,
+        Release,
+    };
+
+    struct Operation
+    {
+        OperationType type;
+        QUrl url;
+        uint64_t generation{0};
+        int retries{0};
+    };
+
+    void enqueue(Operation operation);
+    void startNext();
+    void startOperation(const Operation& operation);
+    void handleReply();
+    void finishOperation();
+    void retryOperation(Operation operation, int statusCode, const QByteArray& retryAfter);
+    void setBusy(bool busy);
+
+    FySettings m_settings;
+
+    QBasicTimer m_startTimer;
+    QElapsedTimer m_lastStarted;
+    QPointer<QNetworkReply> m_reply;
+    std::unordered_map<QString, Release> m_releaseCache;
+    std::deque<Operation> m_queue;
+    std::optional<Operation> m_active;
+    uint64_t m_generation;
+    bool m_busy;
+};
+} // namespace Fooyin

--- a/src/gui/metadatalookup/trackmatchmodel.cpp
+++ b/src/gui/metadatalookup/trackmatchmodel.cpp
@@ -1,0 +1,448 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "trackmatchmodel.h"
+
+#include <utils/helpers.h>
+#include <utils/stringutils.h>
+
+#include <QDataStream>
+#include <QIODevice>
+#include <QMimeData>
+
+#include <cstdlib>
+#include <set>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto TrackRowsMimeType = "application/x-fooyin-metadata-lookup-track-rows"_L1;
+
+namespace Fooyin {
+namespace {
+QString trackNumber(const ReleaseTrack& track)
+{
+    return u"%1.%2"_s.arg(track.mediumPosition).arg(track.number);
+}
+
+QString durationDelta(const Track& local, const ReleaseTrack& release)
+{
+    if(local.duration() == 0 || release.durationMs <= 0) {
+        return {};
+    }
+
+    const int64_t difference = release.durationMs - static_cast<int64_t>(local.duration());
+    if(std::llabs(difference) < 1000) {
+        return {};
+    }
+
+    const QString sign = difference < 0 ? u"−"_s : u"+"_s;
+    QString duration   = Utils::msToString(static_cast<uint64_t>(std::llabs(difference)));
+    if(duration.startsWith(u'0')) {
+        duration.remove(0, 1);
+    }
+
+    return sign + duration;
+}
+} // namespace
+
+int RetrievedTrackModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_tracks.size());
+}
+
+int RetrievedTrackModel::columnCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : 3;
+}
+
+QVariant RetrievedTrackModel::data(const QModelIndex& index, int role) const
+{
+    if(!index.isValid() || std::cmp_greater_equal(index.row(), m_tracks.size()) || role != Qt::DisplayRole) {
+        return {};
+    }
+
+    const ReleaseTrack& track = *m_tracks.at(index.row());
+    switch(index.column()) {
+        case 0:
+            return trackNumber(track);
+        case 1:
+            return track.title;
+        case 2:
+            return track.durationMs > 0 ? Utils::msToString(static_cast<uint64_t>(track.durationMs)) : QString{};
+        default:
+            return {};
+    }
+}
+
+QVariant RetrievedTrackModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    if(role == Qt::TextAlignmentRole) {
+        return Qt::AlignCenter;
+    }
+
+    if(role != Qt::DisplayRole) {
+        return {};
+    }
+
+    switch(section) {
+        case 0:
+            return tr("#");
+        case 1:
+            return tr("Title");
+        case 2:
+            return tr("Duration");
+        default:
+            return {};
+    }
+}
+
+void RetrievedTrackModel::setRelease(const Release& release)
+{
+    beginResetModel();
+
+    m_release = release;
+    m_tracks  = flattenedTracks(m_release);
+
+    endResetModel();
+}
+
+TrackMatchModel::TrackMatchModel(TrackList tracks, QObject* parent)
+    : QAbstractTableModel{parent}
+    , m_tracks{std::move(tracks)}
+    , m_remoteCount{0}
+{
+    buildAutomaticOrder();
+}
+
+int TrackMatchModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_order.size());
+}
+
+int TrackMatchModel::columnCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : 5;
+}
+
+QVariant TrackMatchModel::data(const QModelIndex& index, int role) const
+{
+    if(!index.isValid() || std::cmp_greater_equal(index.row(), m_order.size())) {
+        return {};
+    }
+
+    const auto localIndex = m_order.at(index.row());
+    if(!localIndex) {
+        if(role == Qt::DisplayRole && std::cmp_less(index.row(), m_remoteCount)) {
+            if(index.column() == 2) {
+                return tr("No local track");
+            }
+            if(index.column() == 4) {
+                return tr("Unmatched");
+            }
+        }
+        return {};
+    }
+
+    const Track& local         = m_tracks.at(*localIndex);
+    const TrackMatch& match    = m_matches.at(*localIndex);
+    const auto remotes         = flattenedTracks(m_release);
+    const ReleaseTrack* remote = std::cmp_less(index.row(), remotes.size()) ? remotes.at(index.row()) : nullptr;
+    const bool durationDiffers = remote && local.duration() > 0 && remote->durationMs > 0
+                              && std::llabs(static_cast<int64_t>(local.duration()) - remote->durationMs) > 10000;
+
+    if(role == Qt::TextAlignmentRole && index.column() != 2) {
+        return Qt::AlignCenter;
+    }
+
+    if(role == Qt::ToolTipRole) {
+        QStringList details;
+
+        if(!match.remoteIndex) {
+            details.push_back(tr("This local track is not matched to a retrieved track."));
+        }
+        else if(match.manual) {
+            details.push_back(tr("This match was set manually."));
+        }
+        else {
+            details.push_back(tr("Automatic match confidence: %1%.").arg(match.confidence));
+        }
+
+        if(durationDiffers) {
+            details.push_back(tr("The local and retrieved durations differ by more than 10 seconds."));
+        }
+
+        if(match.ambiguous) {
+            details.push_back(tr("This automatic match is ambiguous."));
+        }
+
+        details.push_back(tr("Drag this row to match it with a retrieved track."));
+        return details.join(u"\n"_s);
+    }
+
+    if(role != Qt::DisplayRole) {
+        return {};
+    }
+
+    switch(index.column()) {
+        case 0:
+            return u"≡"_s;
+        case 1: {
+            const QString discNumber = local.discNumber();
+            return discNumber.isEmpty() ? local.trackNumber() : u"%1.%2"_s.arg(discNumber, local.trackNumber());
+        }
+        case 2:
+            return local.title().isEmpty() ? local.filenameExt() : local.title();
+        case 3:
+            return local.duration() > 0 ? Utils::msToString(local.duration()) : QString{};
+        case 4: {
+            if(!remote) {
+                return tr("Unmatched");
+            }
+            const QString matchStatus = match.manual ? tr("Manual") : tr("%1%").arg(match.confidence);
+            const QString difference  = durationDelta(local, *remote);
+            return difference.isEmpty() ? matchStatus : tr("%1 / %2").arg(matchStatus, difference);
+        }
+        default:
+            return {};
+    }
+}
+
+QVariant TrackMatchModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    if(role == Qt::TextAlignmentRole) {
+        return Qt::AlignCenter;
+    }
+
+    if(role != Qt::DisplayRole) {
+        return {};
+    }
+
+    switch(section) {
+        case 0:
+            return QString{};
+        case 1:
+            return tr("Current #");
+        case 2:
+            return tr("Title / file");
+        case 3:
+            return tr("Duration");
+        case 4:
+            return tr("Match / Δ");
+        default:
+            return {};
+    }
+}
+
+Qt::ItemFlags TrackMatchModel::flags(const QModelIndex& index) const
+{
+    Qt::ItemFlags defaultFlags = QAbstractTableModel::flags(index);
+
+    defaultFlags |= Qt::ItemIsDropEnabled;
+
+    if(index.isValid() && std::cmp_less(index.row(), m_order.size()) && m_order.at(index.row())) {
+        defaultFlags |= Qt::ItemIsDragEnabled;
+    }
+
+    return defaultFlags;
+}
+
+QStringList TrackMatchModel::mimeTypes() const
+{
+    return {TrackRowsMimeType};
+}
+
+QMimeData* TrackMatchModel::mimeData(const QModelIndexList& indexes) const
+{
+    std::set<int> rows;
+    for(const QModelIndex& index : indexes) {
+        if(index.isValid() && std::cmp_less(index.row(), m_order.size()) && m_order.at(index.row())) {
+            rows.insert(index.row());
+        }
+    }
+
+    std::vector<int> selectedRows;
+    selectedRows.reserve(rows.size());
+
+    for(const int row : rows) {
+        selectedRows.emplace_back(row);
+    }
+
+    QByteArray encoded;
+    QDataStream stream{&encoded, QIODevice::WriteOnly};
+
+    stream << selectedRows;
+
+    auto* mimeData = new QMimeData();
+    mimeData->setData(TrackRowsMimeType, encoded);
+    return mimeData;
+}
+
+bool TrackMatchModel::canDropMimeData(const QMimeData* data, Qt::DropAction action, int /*row*/, int /*column*/,
+                                      const QModelIndex& /*parent*/) const
+{
+    return action == Qt::MoveAction && data->hasFormat(TrackRowsMimeType);
+}
+
+bool TrackMatchModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int /*column*/,
+                                   const QModelIndex& parent)
+{
+    if(!canDropMimeData(data, action, row, 0, parent)) {
+        return false;
+    }
+
+    QByteArray encoded = data->data(TrackRowsMimeType);
+    QDataStream stream{&encoded, QIODevice::ReadOnly};
+    QList<int> rows;
+    stream >> rows;
+    if(rows.size() != 1) {
+        return false;
+    }
+
+    const int sourceRow = rows.constFirst();
+    const int targetRow = row < 0 ? (parent.isValid() ? parent.row() : static_cast<int>(m_order.size()))
+                                  : (row > sourceRow ? row - 1 : row);
+    return moveTrack(sourceRow, std::clamp(targetRow, 0, static_cast<int>(m_order.size()) - 1));
+}
+
+Qt::DropActions TrackMatchModel::supportedDropActions() const
+{
+    return Qt::MoveAction;
+}
+
+Qt::DropActions TrackMatchModel::supportedDragActions() const
+{
+    return Qt::MoveAction;
+}
+
+const Release& TrackMatchModel::release() const
+{
+    return m_release;
+}
+
+void TrackMatchModel::setRelease(Release release, bool matchByPosition)
+{
+    beginResetModel();
+
+    m_release         = std::move(release);
+    m_matchByPosition = matchByPosition;
+    buildAutomaticOrder();
+
+    endResetModel();
+
+    Q_EMIT mappingsChanged();
+}
+
+bool TrackMatchModel::moveTrack(int sourceRow, int targetRow)
+{
+    if(sourceRow < 0 || targetRow < 0 || std::cmp_greater_equal(sourceRow, m_order.size())
+       || std::cmp_greater_equal(targetRow, m_order.size()) || sourceRow == targetRow || !m_order.at(sourceRow)) {
+        return false;
+    }
+
+    const int destination = targetRow > sourceRow ? targetRow + 1 : targetRow;
+    if(!beginMoveRows({}, sourceRow, sourceRow, {}, destination)) {
+        return false;
+    }
+
+    Utils::move(m_order, sourceRow, targetRow);
+    endMoveRows();
+
+    applyOrderAsMatches();
+
+    Q_EMIT dataChanged(index(0, 0), index(rowCount() - 1, columnCount() - 1));
+    Q_EMIT mappingsChanged();
+
+    return true;
+}
+
+bool TrackMatchModel::hasTrackAt(int row) const
+{
+    return row >= 0 && std::cmp_less(row, m_order.size()) && m_order.at(row).has_value();
+}
+
+bool TrackMatchModel::hasUnresolved() const
+{
+    return std::ranges::any_of(m_matches,
+                               [](const TrackMatch& match) { return !match.remoteIndex || match.ambiguous; });
+}
+
+const std::vector<TrackMatch>& TrackMatchModel::matches() const
+{
+    return m_matches;
+}
+
+std::vector<const ReleaseTrack*> TrackMatchModel::remoteTracks() const
+{
+    return flattenedTracks(m_release);
+}
+
+void TrackMatchModel::buildAutomaticOrder()
+{
+    m_automaticMatches
+        = m_matchByPosition ? matchTracksByPosition(m_tracks, m_release) : matchTracks(m_tracks, m_release);
+    m_matches     = m_automaticMatches;
+    m_remoteCount = flattenedTracks(m_release).size();
+
+    const auto unmatchedCount = static_cast<size_t>(
+        std::ranges::count_if(m_matches, [](const TrackMatch& match) { return !match.remoteIndex; }));
+    m_order.assign(m_remoteCount + unmatchedCount, std::nullopt);
+
+    size_t unmatchedRow{m_remoteCount};
+    for(const TrackMatch& match : m_matches) {
+        if(match.remoteIndex && *match.remoteIndex < m_remoteCount && !m_order.at(*match.remoteIndex)) {
+            m_order.at(*match.remoteIndex) = match.localIndex;
+        }
+        else {
+            m_order.at(unmatchedRow++) = match.localIndex;
+        }
+    }
+}
+
+void TrackMatchModel::applyOrderAsMatches()
+{
+    for(size_t row{0}; row < m_order.size(); ++row) {
+        if(!m_order.at(row)) {
+            continue;
+        }
+
+        const size_t localIndex = *m_order.at(row);
+        TrackMatch& match       = m_matches.at(localIndex);
+        const auto remoteIndex  = row < m_remoteCount ? std::optional<size_t>{row} : std::nullopt;
+
+        const TrackMatch& automaticMatch = m_automaticMatches.at(localIndex);
+        if(automaticMatch.remoteIndex == remoteIndex) {
+            match = automaticMatch;
+        }
+        else if(match.remoteIndex != remoteIndex) {
+            match.remoteIndex = remoteIndex;
+            match.confidence  = remoteIndex ? 100 : 0;
+            match.ambiguous   = false;
+            match.manual      = true;
+        }
+    }
+}
+} // namespace Fooyin

--- a/src/gui/metadatalookup/trackmatchmodel.h
+++ b/src/gui/metadatalookup/trackmatchmodel.h
@@ -1,0 +1,95 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "metadatamatcher.h"
+
+#include <QAbstractTableModel>
+
+namespace Fooyin {
+class RetrievedTrackModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    using QAbstractTableModel::QAbstractTableModel;
+
+    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
+                                      int role = Qt::DisplayRole) const override;
+
+    void setRelease(const Release& release);
+
+private:
+    Release m_release;
+    std::vector<const ReleaseTrack*> m_tracks;
+};
+
+class TrackMatchModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit TrackMatchModel(TrackList tracks, QObject* parent = nullptr);
+
+    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
+                                      int role = Qt::DisplayRole) const override;
+    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
+    [[nodiscard]] QStringList mimeTypes() const override;
+    [[nodiscard]] QMimeData* mimeData(const QModelIndexList& indexes) const override;
+    [[nodiscard]] bool canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                                       const QModelIndex& parent) const override;
+    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                      const QModelIndex& parent) override;
+    [[nodiscard]] Qt::DropActions supportedDropActions() const override;
+    [[nodiscard]] Qt::DropActions supportedDragActions() const override;
+
+    [[nodiscard]] const Release& release() const;
+    void setRelease(Release release, bool matchByPosition = false);
+
+    bool moveTrack(int sourceRow, int targetRow);
+
+    [[nodiscard]] bool hasTrackAt(int row) const;
+    [[nodiscard]] bool hasUnresolved() const;
+
+    [[nodiscard]] const std::vector<TrackMatch>& matches() const;
+    [[nodiscard]] std::vector<const ReleaseTrack*> remoteTracks() const;
+
+Q_SIGNALS:
+    void mappingsChanged();
+
+private:
+    void buildAutomaticOrder();
+    void applyOrderAsMatches();
+
+    TrackList m_tracks;
+    Release m_release;
+    std::vector<TrackMatch> m_automaticMatches;
+    std::vector<TrackMatch> m_matches;
+    std::vector<std::optional<size_t>> m_order;
+    size_t m_remoteCount;
+    bool m_matchByPosition{false};
+};
+} // namespace Fooyin

--- a/src/gui/trackselectioncontroller.cpp
+++ b/src/gui/trackselectioncontroller.cpp
@@ -119,7 +119,8 @@ public:
     bool registerAction(QObject* owner, TrackContextMenuArea area, const Id& parentId, const Id& id,
                         const QString& title, const TrackSelectionController::TrackContextMenuRenderer& renderer,
                         const Id& beforeId = {});
-    bool registerSeparator(TrackContextMenuArea area, const Id& parentId, const Id& id = {}, const Id& beforeId = {});
+    bool registerSeparator(QObject* owner, TrackContextMenuArea area, const Id& parentId, const Id& id = {},
+                           const Id& beforeId = {});
 
     void renderArea(QMenu* menu, TrackContextMenuArea area, const TrackSelection& selection);
     void renderNode(QMenu* menu, const MenuNode& node, const TrackSelection& selection) const;
@@ -427,7 +428,7 @@ void TrackSelectionControllerPrivate::setupBuiltInMenus()
                    Constants::Actions::SearchArtwork, m_searchArtwork->text(),
                    [this](QMenu* menu, const TrackSelection&) { menu->addAction(m_searchArtwork); });
 
-    registerSeparator(TrackContextMenuArea::Track, Constants::Menus::Context::Artwork,
+    registerSeparator(m_self, TrackContextMenuArea::Track, Constants::Menus::Context::Artwork,
                       ContextMenuIds::TrackSelection::ArtworkSearchSeparator);
 
     m_extractArtwork->setStatusTip(
@@ -485,7 +486,7 @@ void TrackSelectionControllerPrivate::setupBuiltInMenus()
                    m_attachArtistArtwork->text(),
                    [this](QMenu* menu, const TrackSelection&) { menu->addAction(m_attachArtistArtwork); });
 
-    registerSeparator(TrackContextMenuArea::Track, Constants::Menus::Context::Artwork,
+    registerSeparator(m_self, TrackContextMenuArea::Track, Constants::Menus::Context::Artwork,
                       ContextMenuIds::TrackSelection::ArtworkAttachSeparator);
 
     m_removeArtwork->setStatusTip(tr("Remove all artwork associated with the selected tracks (embedded, directory)"));
@@ -500,7 +501,8 @@ void TrackSelectionControllerPrivate::setupBuiltInMenus()
                    Constants::Actions::RemoveArtwork, m_removeArtwork->text(),
                    [this](QMenu* menu, const TrackSelection&) { menu->addAction(m_removeArtwork); });
 
-    registerSeparator(TrackContextMenuArea::Track, m_trackRoot.id, Constants::Menus::Context::TrackFinalSeparator);
+    registerSeparator(m_self, TrackContextMenuArea::Track, m_trackRoot.id,
+                      Constants::Menus::Context::TrackFinalSeparator);
 
     m_openProperties->setStatusTip(tr("Open the properties dialog"));
     auto* openPropsCmd = m_actionManager->registerAction(m_openProperties, Constants::Actions::OpenProperties);
@@ -610,17 +612,17 @@ bool TrackSelectionControllerPrivate::registerAction(QObject* owner, TrackContex
     return true;
 }
 
-bool TrackSelectionControllerPrivate::registerSeparator(TrackContextMenuArea area, const Id& parentId, const Id& id,
-                                                        const Id& beforeId)
+bool TrackSelectionControllerPrivate::registerSeparator(QObject* owner, TrackContextMenuArea area, const Id& parentId,
+                                                        const Id& id, const Id& beforeId)
 {
-    if(!parentId.isValid() || !m_menuNodes.contains(parentId) || (id.isValid() && m_menuNodes.contains(id))) {
+    if(!owner || !parentId.isValid() || !m_menuNodes.contains(parentId) || (id.isValid() && m_menuNodes.contains(id))) {
         return false;
     }
     MenuNode* parent = m_menuNodes.at(parentId);
 
     auto node    = std::make_unique<MenuNode>();
     node->type   = MenuNodeType::Separator;
-    node->owner  = m_self;
+    node->owner  = owner;
     node->id     = id;
     node->area   = area;
     node->parent = parent;
@@ -1638,6 +1640,12 @@ bool TrackSelectionController::registerTrackContextAction(QObject* owner, TrackC
                                                           const TrackContextMenuRenderer& renderer, const Id& beforeId)
 {
     return p->registerAction(owner, area, parentId, id, title, renderer, beforeId);
+}
+
+bool TrackSelectionController::registerTrackContextSeparator(QObject* owner, TrackContextMenuArea area,
+                                                             const Id& parentId, const Id& id, const Id& beforeId)
+{
+    return p->registerSeparator(owner, area, parentId, id, beforeId);
 }
 
 bool TrackSelectionController::registerTrackContextDynamicSubmenu(QObject* owner, TrackContextMenuArea area,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,3 +129,6 @@ fooyin_add_test(
     test_lyricsparser plugins/lyrics/lyricsparsertest.cpp ${CMAKE_SOURCE_DIR}/src/plugins/lyrics/lyricsparser.cpp
 )
 target_include_directories(test_lyricsparser PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/lyrics)
+
+fooyin_add_test(test_metadatamatcher gui/metadatalookup/metadatamatchertest.cpp)
+fooyin_add_test(test_metadataapply gui/metadatalookup/metadataapplytest.cpp)

--- a/tests/gui/metadatalookup/metadataapplytest.cpp
+++ b/tests/gui/metadatalookup/metadataapplytest.cpp
@@ -1,0 +1,160 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "gui/metadatalookup/metadataapply.h"
+
+#include <gtest/gtest.h>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Testing {
+namespace {
+Release testRelease()
+{
+    Release release;
+    release.summary.id = u"release-id"_s;
+    release.summary.identifiers
+        = {{u"MUSICBRAINZ_ALBUMID"_s, {u"release-id"_s}}, {u"MUSICBRAINZ_RELEASEGROUPID"_s, {u"group-id"_s}}};
+    release.summary.title          = u"New Album"_s;
+    release.summary.artistCredit   = {{u"Album Artist"_s, {}, u"album-artist-id"_s}};
+    release.summary.date           = u"2024-06-07"_s;
+    release.summary.originalDate   = u"2024-06-01"_s;
+    release.summary.country        = u"JP"_s;
+    release.summary.status         = u"Official"_s;
+    release.summary.labels         = {u"Label"_s};
+    release.summary.catalogNumbers = {u"CAT-1"_s};
+    release.summary.barcode        = u"123456"_s;
+    release.summary.releaseTypes   = {u"Album"_s, u"Soundtrack"_s};
+    release.genres                 = {u"anime"_s};
+    ReleaseMedium medium;
+    medium.position = 1;
+    medium.title    = u"Main Disc"_s;
+    medium.format   = u"CD"_s;
+    ReleaseTrack remote;
+    remote.identifiers
+        = {{u"MUSICBRAINZ_RELEASETRACKID"_s, {u"release-track-id"_s}}, {u"MUSICBRAINZ_TRACKID"_s, {u"recording-id"_s}}};
+    remote.title          = u"New Title"_s;
+    remote.artistCredit   = {{u"Track Artist"_s, {}, u"track-artist-id"_s}};
+    remote.isrcs          = {u"JPAAA2400001"_s};
+    remote.mediumPosition = 1;
+    remote.position       = 1;
+    remote.number         = u"1"_s;
+    remote.total          = 1;
+    remote.durationMs     = 180000;
+    medium.tracks.push_back(std::move(remote));
+    release.media.push_back(std::move(medium));
+    return release;
+}
+
+Track originalTrack()
+{
+    Track track{u"/music/file.flac"_s};
+    track.setId(42);
+    track.setLibraryId(7);
+    track.setTitle(u"Old Title"_s);
+    track.setArtists({u"Old Artist"_s});
+    track.setAlbum(u"Old Album"_s);
+    track.setDuration(180000);
+    track.setPlayCount(9);
+    track.setRatingStars(8);
+    track.setRGTrackGain(-6.5F);
+    track.replaceExtraTag(u"CUSTOM"_s, u"Keep me"_s);
+    return track;
+}
+} // namespace
+
+TEST(MetadataApplyTest, ReplacesLookupFieldsAndPreservesIdentity)
+{
+    const Track original = originalTrack();
+    const auto result    = applyReleaseMetadata({original}, testRelease(), {{.localIndex = 0, .remoteIndex = 0}}, {});
+    ASSERT_EQ(result.tracks.size(), 1);
+    ASSERT_EQ(result.trackIndices, (std::vector<size_t>{0}));
+    const Track& updated = result.tracks.front();
+    EXPECT_EQ(updated.filepath(), original.filepath());
+    EXPECT_EQ(updated.id(), 42);
+    EXPECT_EQ(updated.libraryId(), 7);
+    EXPECT_EQ(updated.duration(), 180000);
+    EXPECT_EQ(updated.playCount(), 9);
+    EXPECT_EQ(updated.ratingStars(), 8);
+    EXPECT_FLOAT_EQ(updated.rgTrackGain(), -6.5F);
+    EXPECT_EQ(updated.title(), u"New Title"_s);
+    EXPECT_EQ(updated.album(), u"New Album"_s);
+    EXPECT_EQ(updated.artists(), QStringList({u"Track Artist"_s}));
+    EXPECT_EQ(updated.extraTag(u"CUSTOM"_s), QStringList({u"Keep me"_s}));
+    EXPECT_EQ(updated.extraTag(u"MUSICBRAINZ_TRACKID"_s), QStringList({u"recording-id"_s}));
+    EXPECT_EQ(updated.extraTag(u"MUSICBRAINZ_ALBUMID"_s), QStringList({u"release-id"_s}));
+    EXPECT_EQ(updated.extraTag(u"ISRC"_s), QStringList({u"JPAAA2400001"_s}));
+    EXPECT_EQ(updated.extraTag(u"MEDIA"_s), QStringList({u"CD"_s}));
+    EXPECT_FALSE(result.changes.empty());
+}
+
+TEST(MetadataApplyTest, FillMissingLeavesExistingValues)
+{
+    MetadataApplyOptions options;
+    options.policy = ExistingMetadataPolicy::FillMissing;
+
+    const auto result
+        = applyReleaseMetadata({originalTrack()}, testRelease(), {{.localIndex = 0, .remoteIndex = 0}}, options);
+    ASSERT_EQ(result.tracks.size(), 1);
+    EXPECT_EQ(result.tracks.front().title(), u"Old Title"_s);
+    EXPECT_EQ(result.tracks.front().album(), u"Old Album"_s);
+    EXPECT_EQ(result.tracks.front().extraTag(u"MUSICBRAINZ_TRACKID"_s), QStringList({u"recording-id"_s}));
+}
+
+TEST(MetadataApplyTest, WipeRemovesCustomTagsButPreservesProtectedState)
+{
+    MetadataApplyOptions options;
+    options.policy = ExistingMetadataPolicy::WipeWritableTags;
+
+    const Track original = originalTrack();
+    const auto result = applyReleaseMetadata({original}, testRelease(), {{.localIndex = 0, .remoteIndex = 0}}, options);
+    ASSERT_EQ(result.tracks.size(), 1);
+    const Track& updated = result.tracks.front();
+    EXPECT_FALSE(updated.hasExtraTag(u"CUSTOM"_s));
+    EXPECT_EQ(updated.id(), original.id());
+    EXPECT_EQ(updated.filepath(), original.filepath());
+    EXPECT_EQ(updated.duration(), original.duration());
+    EXPECT_EQ(updated.playCount(), original.playCount());
+    EXPECT_EQ(updated.ratingStars(), original.ratingStars());
+    EXPECT_FLOAT_EQ(updated.rgTrackGain(), original.rgTrackGain());
+}
+
+TEST(MetadataApplyTest, LeavesUnmatchedTracksUntouched)
+{
+    const auto result = applyReleaseMetadata({originalTrack()}, testRelease(), {TrackMatch{}}, {});
+    EXPECT_TRUE(result.tracks.empty());
+    EXPECT_TRUE(result.trackIndices.empty());
+    EXPECT_TRUE(result.changes.empty());
+}
+
+TEST(MetadataApplyTest, WritesIdentifiersSuppliedByTheActiveProvider)
+{
+    Release release             = testRelease();
+    release.summary.identifiers = {{u"PROVIDER_RELEASE_ID"_s, {u"123456"_s}}, {u"PROVIDER_GROUP_ID"_s, {u"654321"_s}}};
+    release.media.front().tracks.front().identifiers = {{u"PROVIDER_ARTIST_ID"_s, {u"300"_s}}};
+
+    const auto result = applyReleaseMetadata({originalTrack()}, release, {{.localIndex = 0, .remoteIndex = 0}}, {});
+    ASSERT_EQ(result.tracks.size(), 1);
+    const Track& updated = result.tracks.front();
+    EXPECT_EQ(updated.extraTag(u"PROVIDER_RELEASE_ID"_s), QStringList({u"123456"_s}));
+    EXPECT_EQ(updated.extraTag(u"PROVIDER_GROUP_ID"_s), QStringList({u"654321"_s}));
+    EXPECT_EQ(updated.extraTag(u"PROVIDER_ARTIST_ID"_s), QStringList({u"300"_s}));
+    EXPECT_FALSE(updated.hasExtraTag(u"MUSICBRAINZ_ALBUMID"_s));
+}
+} // namespace Fooyin::Testing

--- a/tests/gui/metadatalookup/metadatamatchertest.cpp
+++ b/tests/gui/metadatalookup/metadatamatchertest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "gui/metadatalookup/metadatamatcher.h"
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+using namespace Qt::StringLiterals;
+using namespace Fooyin;
+using namespace Fooyin;
+
+namespace Fooyin::Testing {
+namespace {
+Release testRelease()
+{
+    Release release;
+    release.summary.id = u"release"_s;
+
+    ReleaseMedium medium;
+    medium.position = 1;
+
+    for(const auto& [title, position, duration] : std::vector<std::tuple<QString, int, int64_t>>{
+            {u"First Song"_s, 1, 180000}, {u"Second Song"_s, 2, 200000}, {u"Finale"_s, 3, 240000}}) {
+        ReleaseTrack remote;
+        remote.title          = title;
+        remote.mediumPosition = 1;
+        remote.position       = position;
+        remote.number         = QString::number(position);
+        remote.total          = 3;
+        remote.durationMs     = duration;
+
+        medium.tracks.push_back(std::move(remote));
+    }
+    release.media.push_back(std::move(medium));
+
+    return release;
+}
+
+Track track(const QString& title, int number, uint64_t duration)
+{
+    Track result{u"/tmp/%1.flac"_s.arg(number)};
+    result.setTitle(title);
+    result.setTrackNumber(QString::number(number));
+    result.setDiscNumber(u"1"_s);
+    result.setDuration(duration);
+    return result;
+}
+} // namespace
+
+TEST(MetadataMatcherTest, MatchesNumberedAlbum)
+{
+    const TrackList tracks{track(u"First Song"_s, 1, 180500), track(u"Second Song"_s, 2, 199000),
+                           track(u"Finale"_s, 3, 240000)};
+
+    const auto matches = matchTracks(tracks, testRelease());
+    ASSERT_EQ(matches.size(), 3);
+
+    for(size_t i{0}; i < matches.size(); ++i) {
+        ASSERT_TRUE(matches.at(i).remoteIndex);
+        EXPECT_EQ(*matches.at(i).remoteIndex, i);
+        EXPECT_FALSE(matches.at(i).ambiguous);
+    }
+}
+
+TEST(MetadataMatcherTest, MatchesShuffledTracksByTitleAndDuration)
+{
+    Track finale = track(u"Finale"_s, 0, 240000);
+    finale.setTrackNumber({});
+    Track first = track(u"First Song"_s, 0, 180000);
+    first.setTrackNumber({});
+
+    const auto matches = matchTracks({finale, first}, testRelease());
+    ASSERT_TRUE(matches.at(0).remoteIndex);
+    ASSERT_TRUE(matches.at(1).remoteIndex);
+    EXPECT_EQ(*matches.at(0).remoteIndex, 2);
+    EXPECT_EQ(*matches.at(1).remoteIndex, 0);
+}
+
+TEST(MetadataMatcherTest, NeverAssignsRemoteTrackTwice)
+{
+    const TrackList tracks{track(u"First Song"_s, 0, 180000), track(u"First Song"_s, 0, 180000)};
+    const auto matches = matchTracks(tracks, testRelease());
+
+    ASSERT_TRUE(matches.at(0).remoteIndex);
+    if(matches.at(1).remoteIndex) {
+        EXPECT_NE(*matches.at(0).remoteIndex, *matches.at(1).remoteIndex);
+    }
+}
+
+TEST(MetadataMatcherTest, MatchesDiscTracksByPhysicalPosition)
+{
+    TrackList tracks{track(u"Track 01"_s, 1, 180500), track(u"Track 02"_s, 2, 199000), track(u"Track 03"_s, 3, 240000)};
+    for(Track& localTrack : tracks) {
+        localTrack.setDiscNumber({});
+    }
+
+    const auto matches = matchTracksByPosition(tracks, testRelease());
+    ASSERT_EQ(matches.size(), tracks.size());
+    for(size_t index{0}; index < matches.size(); ++index) {
+        ASSERT_TRUE(matches.at(index).remoteIndex);
+        EXPECT_EQ(*matches.at(index).remoteIndex, index);
+        EXPECT_EQ(matches.at(index).confidence, 100);
+        EXPECT_FALSE(matches.at(index).ambiguous);
+    }
+}
+} // namespace Fooyin::Testing


### PR DESCRIPTION
Add metadata lookup functionality supported by MusicBrainz. Releases can be searched using artist and album names, MusicBrainz release identifiers, or a CD TOC. Retrieved tracks are automatically matched with local tracks and can be manually reordered.

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/d39cbb54-fabb-4a41-be66-6528ba8fa2eb" />


Fetched release details are cached for the lifetime of the dialog to avoid repeated requests when revisiting results.