### PR TITLE
[core] TagLib: Flush file device after saving

### DIFF
--- a/src/core/engine/input/taglibparser.cpp
+++ b/src/core/engine/input/taglibparser.cpp
@@ -3911,14 +3911,17 @@ bool TagLibReader::writeTrack(const AudioSource& source, const Track& track, Wri
         return false;
     }
 
-    if(atime.isValid() || mtime.isValid()) {
-        if(auto* fileDev = qobject_cast<QFile*>(source.device)) {
-            fileDev->setFileTime(mtime, QFileDevice::FileModificationTime);
+    if(auto* fileDev = qobject_cast<QFile*>(source.device)) {
+        fileDev->flush();
+        if(atime.isValid()) {
             fileDev->setFileTime(atime, QFileDevice::FileAccessTime);
+        }
+        if(mtime.isValid()) {
+            fileDev->setFileTime(mtime, QFileDevice::FileModificationTime);
         }
     }
 
-    return success;
+    return true;
 }
 
 bool TagLibReader::writeCover(const AudioSource& source, const Track& track, const TrackCovers& covers,
@@ -4133,13 +4136,16 @@ bool TagLibReader::writeCover(const AudioSource& source, const Track& track, con
         return false;
     }
 
-    if(atime.isValid() || mtime.isValid()) {
-        if(auto* fileDev = qobject_cast<QFile*>(source.device)) {
-            fileDev->setFileTime(mtime, QFileDevice::FileModificationTime);
+    if(auto* fileDev = qobject_cast<QFile*>(source.device)) {
+        fileDev->flush();
+        if(atime.isValid()) {
             fileDev->setFileTime(atime, QFileDevice::FileAccessTime);
+        }
+        if(mtime.isValid()) {
+            fileDev->setFileTime(mtime, QFileDevice::FileModificationTime);
         }
     }
 
-    return success;
+    return true;
 }
 } // namespace Fooyin


### PR DESCRIPTION
Problem: atime and mtime timestamps weren't being preserved on tag updates when "Preserve timestamps" was enabled on my system. This is caused by the file device being flushed too late which discards the timestamp restoration.

Fix: Call `flush()` on the file device after saving the file to force changes to be written to disk before restoring timestamps. Note that atime timestamp preservation is still broken for me, probably due to surrounding `QFileInfo` and `IODeviceStream` constructors which have to access the file. In my opinion preserving atime is overkill but I'll leave it up to you whether it should be fixed or removed.