### PR TITLE
[core,gui,cdda] Add Audio CD playback and ripping

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -30,6 +30,7 @@ The following libraries are optional:
 * [Game Music Emu](https://github.com/libgme/game-music-emu) - for the GME audio input plugin
 * [libarchive](https://www.libarchive.org) - for the archive support plugin
 * [libebur128](https://github.com/jiixyj/libebur128) - for the ReplayGain scanner plugin
+* [libcdio](https://www.gnu.org/software/libcdio/) and libcdio-paranoia - for the Audio CD plugin
 * [SoundTouch](https://www.surina.net/soundtouch/) - for the SoundTouch DSP plugin
 * [SoXR (libsoxr)](https://sourceforge.net/projects/soxr/) - for the SoX resampler DSP plugin
 * [projectM](https://github.com/projectM-visualizer/projectm) (4.x) - for the projectM visualisation plugin
@@ -45,8 +46,8 @@ sudo apt install \
     libasound2-dev libtag1-dev libicu-dev libpipewire-0.3-dev libpulse-dev \
     qt6-base-dev libqt6sql6-sqlite libqt6svg6-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
     libavcodec-dev libavformat-dev libavutil-dev libavdevice-dev libswresample-dev \
-    libsndfile1-dev libopenmpt-dev libgme-dev libarchive-dev libebur128-dev libsoundtouch-dev \
-    libsoxr-dev
+    libsndfile1-dev libopenmpt-dev libgme-dev libarchive-dev libebur128-dev libcdio-dev \
+    libcdio-paranoia-dev libsoundtouch-dev libsoxr-dev
 ```
 
 ### Arch Linux
@@ -56,7 +57,7 @@ sudo pacman -Syu
 sudo pacman -S --needed \
     gcc git cmake pkgconf ninja alsa-lib pipewire libpulse icu zlib ffmpeg \
     qt6-base qt6-svg qt6-imageformats qt6-tools kdsingleapplication \
-    taglib libsndfile libopenmpt libgme libarchive libebur128 soundtouch libsoxr
+    taglib libsndfile libopenmpt libgme libarchive libebur128 libcdio libcdio-paranoia soundtouch libsoxr
 ```
 
 ### Fedora
@@ -68,8 +69,8 @@ sudo dnf install \
     alsa-lib-devel qt6-qtbase-devel qt6-qtsvg-devel qt6-qttools-devel \
     libavcodec-free-devel libavformat-free-devel libavutil-free-devel libswresample-free-devel \
     taglib-devel kdsingleapplication-qt6-devel libicu-devel pipewire-devel pulseaudio-libs-devel \
-    libsndfile-devel libopenmpt-devel game-music-emu-devel libarchive-devel libebur128-devel soundtouch-devel \
-    soxr-devel
+    libsndfile-devel libopenmpt-devel game-music-emu-devel libarchive-devel libebur128-devel libcdio-devel \
+    libcdio-paranoia-devel soundtouch-devel soxr-devel
 ```
 
 ### Windows

--- a/ci/fedora-depends.sh
+++ b/ci/fedora-depends.sh
@@ -39,6 +39,8 @@ dnf -y install --skip-broken \
      libarchive-devel \
      libsndfile-devel \
      libebur128-devel \
+     libcdio-devel \
+     libcdio-paranoia-devel \
      soundtouch-devel \
      soxr-devel \
      gtest-devel

--- a/ci/freebsd-depends.sh
+++ b/ci/freebsd-depends.sh
@@ -25,6 +25,8 @@ sudo pkg install -y \
      libopenmpt \
      libarchive \
      ebur128 \
+     libcdio \
+     libcdio-paranoia \
      soundtouch \
      libsoxr \
      googletest

--- a/ci/ubuntu-depends.sh
+++ b/ci/ubuntu-depends.sh
@@ -44,6 +44,8 @@ $SUDO apt-get install -y \
         libarchive-dev \
         libsndfile1-dev \
         libebur128-dev \
+        libcdio-dev \
+        libcdio-paranoia-dev \
         libsoundtouch-dev \
         libsoxr-dev \
         libgtest-dev

--- a/cmake/modules/FindCdio.cmake
+++ b/cmake/modules/FindCdio.cmake
@@ -1,0 +1,62 @@
+# Try to find libcdio and libcdio-paranoia
+# Once done this will define
+#
+# Cdio_FOUND - system has libcdio and libcdio-paranoia
+# Cdio::Cdio - the libcdio and libcdio-paranoia libraries
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(PC_Cdio QUIET libcdio libcdio_cdda libcdio_paranoia)
+endif()
+
+find_path(
+    Cdio_INCLUDE_DIR
+    NAMES cdio/cdio.h
+    HINTS ${PC_Cdio_INCLUDE_DIRS}
+    DOC "libcdio include directory"
+)
+
+find_library(
+    Cdio_LIBRARY
+    NAMES cdio
+    HINTS ${PC_Cdio_LIBRARY_DIRS}
+    DOC "libcdio library"
+)
+
+find_library(
+    Cdio_CDDA_LIBRARY
+    NAMES cdio_cdda
+    HINTS ${PC_Cdio_LIBRARY_DIRS}
+    DOC "libcdio CD-DA library"
+)
+
+find_library(
+    Cdio_PARANOIA_LIBRARY
+    NAMES cdio_paranoia
+    HINTS ${PC_Cdio_LIBRARY_DIRS}
+    DOC "libcdio paranoia library"
+)
+
+mark_as_advanced(Cdio_INCLUDE_DIR Cdio_LIBRARY Cdio_CDDA_LIBRARY Cdio_PARANOIA_LIBRARY)
+
+if(DEFINED PC_Cdio_libcdio_VERSION AND NOT PC_Cdio_libcdio_VERSION STREQUAL "")
+    set(Cdio_VERSION "${PC_Cdio_libcdio_VERSION}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    Cdio
+    REQUIRED_VARS Cdio_LIBRARY Cdio_CDDA_LIBRARY Cdio_PARANOIA_LIBRARY Cdio_INCLUDE_DIR
+    VERSION_VAR Cdio_VERSION
+)
+
+if(Cdio_FOUND AND NOT TARGET Cdio::Cdio)
+    add_library(Cdio::Cdio INTERFACE IMPORTED)
+    target_include_directories(Cdio::Cdio INTERFACE "${Cdio_INCLUDE_DIR}")
+    target_link_libraries(
+        Cdio::Cdio
+        INTERFACE "${Cdio_PARANOIA_LIBRARY}"
+                  "${Cdio_CDDA_LIBRARY}"
+                  "${Cdio_LIBRARY}"
+    )
+endif()

--- a/include/core/engine/audioinput.h
+++ b/include/core/engine/audioinput.h
@@ -107,6 +107,8 @@ public:
         //! Allow decoder to update `Track` metadata after `init()`.
         //! Useful when duration/fields depend on decoder options.
         UpdateTracks = 1 << 3,
+        //! Select source policies intended for offline conversion/extraction.
+        ForConversion = 1 << 4,
     };
     Q_DECLARE_FLAGS(DecoderOptions, DecoderFlag)
     Q_FLAG(DecoderOptions)
@@ -192,6 +194,12 @@ public:
      */
     [[nodiscard]] virtual QStringList preferredExtensions() const;
     /*!
+     * Returns URI schemes this decoder handles directly without a QIODevice.
+     * Scheme names are matched case-insensitively and should omit the trailing colon.
+     * Base class implementation returns an empty list.
+     */
+    [[nodiscard]] virtual QStringList supportedSchemes() const;
+    /*!
      * Returns @c true if this decoder can consume remote/network-backed sources
      * supplied by AudioLoader. Base implementation returns @c false.
      */
@@ -208,6 +216,18 @@ public:
      * @note Called only after `init()` succeeds.
      */
     [[nodiscard]] virtual bool isSeekable() const = 0;
+    /*!
+     * Returns whether this decoder may read while another decoder instance is active.
+     * Base implementation returns true.
+     */
+    [[nodiscard]] virtual bool allowsConcurrentDecoding() const;
+    /*!
+     * Returns the minimum decoded audio reserve preferred before playback starts or resumes.
+     * A value of zero selects the engine's normal low-latency behaviour.
+     */
+    [[nodiscard]] virtual int playbackPrebufferMs() const;
+    //! Drains non-fatal source diagnostics accumulated since the previous call.
+    [[nodiscard]] virtual QStringList takeWarnings();
     /*!
      * Returns which component owns repeat-track playback for this decoder.
      * Base implementation returns EngineTransition.
@@ -300,6 +320,8 @@ public:
 protected:
     //! Called on the decoder worker thread when runtime playback policy changes.
     virtual void playbackHintsChanged(PlaybackHints hints);
+    //! Interrupts a backend read after requestAbort(); may be called from another thread.
+    virtual void interruptRead();
     //! Shared cancellation token for decoder backends and blocking input devices.
     [[nodiscard]] std::stop_token abortToken() const noexcept;
 
@@ -343,6 +365,12 @@ public:
      * Base class implementation returns an empty list.
      */
     [[nodiscard]] virtual QStringList preferredExtensions() const;
+    /*!
+     * Returns URI schemes this reader handles directly without a QIODevice.
+     * Scheme names are matched case-insensitively and should omit the trailing colon.
+     * Base class implementation returns an empty list.
+     */
+    [[nodiscard]] virtual QStringList supportedSchemes() const;
     /*!
      * Returns @c true if this reader can consume remote/network-backed sources
      * supplied by AudioLoader. Base implementation returns @c false.

--- a/include/core/engine/audioloader.h
+++ b/include/core/engine/audioloader.h
@@ -83,6 +83,7 @@ public:
         int index{0};
         QString name;
         QStringList extensions;
+        QStringList schemes;
         bool enabled{true};
         bool isArchiveWrapper{false};
         T creator;

--- a/include/core/engine/conversion/conversionrunner.h
+++ b/include/core/engine/conversion/conversionrunner.h
@@ -59,6 +59,15 @@ struct ConversionProgress
     uint64_t sourceDurationMs{0};
 };
 
+class FYCORE_EXPORT ConversionInputObserver
+{
+public:
+    virtual ~ConversionInputObserver()                                       = default;
+    virtual void trackStarted(const Track& track, const AudioFormat& format) = 0;
+    virtual void sourceAudio(const Track& track, const AudioBuffer& buffer)  = 0;
+    virtual void trackFinished(const Track& track, bool complete)            = 0;
+};
+
 namespace ConversionRunner {
 using ProgressCallback     = std::function<void(const ConversionProgress&)>;
 using CancelCallback       = std::function<bool()>;
@@ -74,6 +83,7 @@ struct Request
     ProgressCallback progressCallback;
     CancelCallback cancelCallback;
     ExistingFileCallback existingFileCallback;
+    std::shared_ptr<ConversionInputObserver> sourceObserver;
 };
 
 FYCORE_EXPORT std::vector<ConversionTrackResult> run(const Request& request);

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -130,6 +130,8 @@ public:
 
     [[nodiscard]] bool isInArchive() const;
     [[nodiscard]] bool isRemote() const;
+    //! True when the track is backed by a non-file, non-HTTP(S) URI handled by a specialised input backend.
+    [[nodiscard]] bool isVirtual() const;
     [[nodiscard]] QString archivePath() const;
     [[nodiscard]] QString pathInArchive() const;
     [[nodiscard]] QString relativeArchivePath() const;
@@ -241,6 +243,8 @@ public:
     //! Archive paths use fooyin's unpack:// URL format.
     static bool isArchivePath(const QString& path);
     static bool isRemotePath(const QString& path);
+    //! True for a valid custom URI, excluding local, archive, and HTTP(S).
+    static bool isVirtualPath(const QString& path);
     //! True for built-in tags that can hold multiple values.
     static bool isMultiValueTag(const QString& tag);
     //! True when tag is not one of Track's built-in metadata fields.

--- a/include/gui/conversion/conversionservice.h
+++ b/include/gui/conversion/conversionservice.h
@@ -1,0 +1,56 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include <core/engine/conversion/conversionrunner.h>
+#include <core/track.h>
+
+#include <QString>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace Fooyin {
+struct FYGUI_EXPORT ConversionPresetInfo
+{
+    QString id;
+    QString name;
+};
+
+class FYGUI_EXPORT ConversionService
+{
+public:
+    virtual ~ConversionService() = default;
+
+    virtual void showSetup(const TrackList& tracks)                                                   = 0;
+    virtual void showSetup(const TrackList& tracks, const QString& suggestedFilenamePattern,
+                           std::shared_ptr<ConversionInputObserver> sourceObserver,
+                           std::function<void(const std::vector<ConversionTrackResult>&)> completion) = 0;
+
+    [[nodiscard]] virtual std::vector<ConversionPresetInfo> presets() const                             = 0;
+    virtual bool startPreset(const QString& presetId, const TrackList& tracks)                          = 0;
+    virtual bool startPreset(const QString& presetId, const TrackList& tracks, const QString& suggestedFilenamePattern,
+                             std::shared_ptr<ConversionInputObserver> sourceObserver,
+                             std::function<void(const std::vector<ConversionTrackResult>&)> completion) = 0;
+};
+} // namespace Fooyin

--- a/include/gui/plugins/guiplugincontext.h
+++ b/include/gui/plugins/guiplugincontext.h
@@ -25,6 +25,7 @@ namespace Fooyin {
 class ActionManager;
 class AdvancedSettingsRegistry;
 class CoverRepository;
+class ConversionService;
 class CurrentPlaylistController;
 class EditableLayout;
 class GuiStyleProvider;
@@ -79,5 +80,6 @@ struct FYGUI_EXPORT GuiPluginContext
     GuiStyleProvider* styleProvider;
     AdvancedSettingsRegistry* advancedSettingsRegistry;
     CoverRepository* coverRepository;
+    ConversionService* conversionService;
 };
 } // namespace Fooyin

--- a/src/core/engine/audioengine.cpp
+++ b/src/core/engine/audioengine.cpp
@@ -87,7 +87,7 @@ constexpr auto LiveBitrateWindowMs          = 1000;
 constexpr auto RemoteDecodedBufferMinMs     = 2000;
 constexpr auto RemotePrebufferMinMs         = 500;
 constexpr auto RemotePrebufferMaxMs         = 5000;
-constexpr auto RemoteRebufferFloorMs        = 100;
+constexpr auto InputRebufferFloorMs         = 100;
 constexpr auto RemoteCrossfadePrefillMaxMs  = 1500;
 constexpr auto MaxPendingLevelFrames        = 64;
 
@@ -1078,14 +1078,16 @@ void AudioEngine::play()
 
         m_decoder.startDecoding();
         m_pipeline.play();
-
         updatePosition();
-        m_audioClock.start();
-
         updatePlaybackState(Engine::PlaybackState::Playing);
         restoreLoadedTrackPhase();
         updateTrackStatus(Engine::TrackStatus::Buffered);
-        maybeUpdateRemoteBuffering("play");
+        maybeUpdateInputBuffering("play");
+
+        if(!m_inputBuffering.active) {
+            m_audioClock.start();
+        }
+
         return;
     }
 
@@ -1097,14 +1099,15 @@ void AudioEngine::play()
 
     m_decoder.startDecoding();
     m_pipeline.play();
-
     updatePosition();
-    m_audioClock.start();
-
     updatePlaybackState(Engine::PlaybackState::Playing);
     restoreLoadedTrackPhase();
     updateTrackStatus(Engine::TrackStatus::Buffered);
-    maybeUpdateRemoteBuffering("play");
+    maybeUpdateInputBuffering("play");
+
+    if(!m_inputBuffering.active) {
+        m_audioClock.start();
+    }
 }
 
 void AudioEngine::pause()
@@ -1142,7 +1145,7 @@ void AudioEngine::pause()
         return;
     }
 
-    clearRemoteBufferingState(false);
+    clearInputBufferingState(false);
     finalisePausedState();
 }
 
@@ -1154,7 +1157,7 @@ void AudioEngine::stop()
     // A transport fade advances only while the pipeline is rendering audio.
     // Remote rebuffering pauses that pipeline, so waiting for a fade callback
     // here would leave the decoder blocked indefinitely on the stalled input.
-    if(m_remoteBuffering.active) {
+    if(m_inputBuffering.active) {
         stopImmediate();
         return;
     }
@@ -1222,7 +1225,7 @@ void AudioEngine::stopImmediate()
 {
     clearPendingAudiblePause();
     m_pausedStreamSuspended = false;
-    clearRemoteBufferingState(false);
+    clearInputBufferingState(false);
     clearAutoCrossfadeTailFadeState();
     clearAutoBoundaryFadeState();
     m_upcomingTrackCandidate       = {};
@@ -1268,6 +1271,10 @@ void AudioEngine::restorePosition(uint64_t positionMs, bool pause)
         return;
     }
 
+    const bool initialRestoreApplied = m_initialRestore && m_initialRestore->applied
+                                    && m_initialRestore->trackId == m_currentTrack.id()
+                                    && m_initialRestore->positionMs == positionMs;
+
     if(!m_decoder.isValid() || !m_decoder.activeStream()) {
         m_transitions.queueInitialSeek(positionMs, m_currentTrack.id(), 0);
         loadTrack(currentPlaybackItem(), false);
@@ -1275,12 +1282,14 @@ void AudioEngine::restorePosition(uint64_t positionMs, bool pause)
             return;
         }
     }
-    else {
+    else if(!initialRestoreApplied) {
         performSimpleSeek(positionMs, 0);
         if(!m_decoder.isValid() || !m_decoder.activeStream()) {
             return;
         }
     }
+
+    m_initialRestore.reset();
 
     m_pipeline.pause();
     clearPendingAnalysisData();
@@ -1289,6 +1298,12 @@ void AudioEngine::restorePosition(uint64_t positionMs, bool pause)
     if(pause) {
         updatePlaybackState(Engine::PlaybackState::Paused);
     }
+}
+
+void AudioEngine::queueInitialRestore(uint64_t positionMs, int trackId)
+{
+    m_initialRestore = InitialRestoreState{.positionMs = positionMs, .trackId = trackId, .applied = false};
+    m_transitions.queueInitialSeek(positionMs, trackId, 0);
 }
 
 void AudioEngine::seek(uint64_t positionMs)
@@ -1902,6 +1917,12 @@ void AudioEngine::performSeek(uint64_t positionMs, uint64_t requestId)
 
     m_transitions.cancelPendingSeek();
 
+    // Sources with mechanical/network startup latency mustn't begin a seek crossfade with an empty replacement stream
+    if(m_decoder.playbackPrebufferMs() > 0) {
+        performSimpleSeek(positionMs, requestId);
+        return;
+    }
+
     auto currentStream = m_decoder.activeStream();
     const SeekPlanContext context{
         .decoderValid           = m_decoder.isValid(),
@@ -2135,6 +2156,7 @@ void AudioEngine::performSimpleSeek(uint64_t positionMs, uint64_t requestId, int
     if(wasPlaying) {
         m_pipeline.sendStreamCommand(stream->id(), AudioStream::Command::Play);
         m_pipeline.play();
+        maybeUpdateInputBuffering("seek");
     }
 
     if(wasDecoding || wasPlaying) {
@@ -2504,7 +2526,7 @@ void AudioEngine::suspendPausedStream()
                    << "trackId=" << m_currentTrack.id() << "itemId=" << m_currentTrackItemId
                    << "generation=" << m_trackGeneration;
 
-    clearRemoteBufferingState(false);
+    clearInputBufferingState(false);
     clearAutoCrossfadeTailFadeState();
     clearAutoBoundaryFadeState();
     clearAutoAdvanceState();
@@ -3748,9 +3770,9 @@ void AudioEngine::handleTimerTick(int timerId)
         syncDecoderBitrate();
         checkPendingSeek();
         cleanupOrphanedStream();
-        maybeUpdateRemoteBuffering("decode-timer");
+        maybeUpdateInputBuffering("decode-timer");
 
-        if(decodeResult->stopDecodeTimer && !m_remoteBuffering.active) {
+        if(decodeResult->stopDecodeTimer && !m_inputBuffering.active) {
             m_decoder.stopDecodeTimer();
         }
     }
@@ -3946,7 +3968,7 @@ void AudioEngine::handlePipelineWakeSignals(const AudioPipeline::PendingSignals&
 
     if(pendingSignals.needsData) {
         m_decoder.ensureDecodeTimerRunning();
-        maybeUpdateRemoteBuffering("pipeline-needs-data");
+        maybeUpdateInputBuffering("pipeline-needs-data");
     }
 }
 
@@ -3984,55 +4006,74 @@ int AudioEngine::remotePrebufferTargetMs(const AudioStreamPtr& stream) const
     return remotePrebufferTargetMs(capacityMs);
 }
 
-void AudioEngine::clearRemoteBufferingState(bool resumePipeline)
+int AudioEngine::inputPrebufferTargetMs(const AudioStreamPtr& stream) const
 {
-    if(!m_remoteBuffering.active) {
+    if(m_currentTrack.isRemote()) {
+        return remotePrebufferTargetMs(stream);
+    }
+
+    const int preferredMs = std::max(0, m_decoder.playbackPrebufferMs());
+    if(!stream || stream->sampleRate() <= 0 || stream->channelCount() <= 0) {
+        return preferredMs;
+    }
+
+    const auto capacityFrames
+        = stream->writer().capacity() / static_cast<uint64_t>(std::max(1, stream->channelCount()));
+    const auto capacityMs64 = (capacityFrames * 1000ULL) / static_cast<uint64_t>(stream->sampleRate());
+    const int capacityMs    = static_cast<int>(std::min<uint64_t>(capacityMs64, std::numeric_limits<int>::max()));
+    return std::clamp(preferredMs, 0, std::max(0, capacityMs));
+}
+
+void AudioEngine::clearInputBufferingState(bool resumePipeline)
+{
+    if(!m_inputBuffering.active) {
         return;
     }
 
-    qCDebug(ENGINE) << "Remote stream buffering cleared:" << "trackId=" << m_currentTrack.id()
-                    << "generation=" << m_trackGeneration << "streamId=" << m_remoteBuffering.streamId;
+    qCDebug(ENGINE) << "Input buffering cleared:" << "trackId=" << m_currentTrack.id()
+                    << "generation=" << m_trackGeneration << "streamId=" << m_inputBuffering.streamId;
 
-    m_remoteBuffering.active = false;
+    m_inputBuffering.active = false;
     if(resumePipeline) {
         m_pipeline.setBufferingPaused(false);
     }
 }
 
-void AudioEngine::maybeUpdateRemoteBuffering(const char* reason)
+void AudioEngine::maybeUpdateInputBuffering(const char* reason)
 {
-    if(!m_currentTrack.isRemote() || !m_decoder.isValid()) {
-        clearRemoteBufferingState(false);
+    if((!m_currentTrack.isRemote() && m_decoder.playbackPrebufferMs() <= 0) || !m_decoder.isValid()) {
+        clearInputBufferingState(false);
         return;
     }
 
     auto stream = m_decoder.activeStream();
     if(!stream || stream->endOfInput() || !hasPlaybackState(Engine::PlaybackState::Playing)) {
-        clearRemoteBufferingState();
+        clearInputBufferingState();
         return;
     }
 
     const uint64_t bufferedMs = stream->bufferedDurationMs();
-    const int targetMs        = remotePrebufferTargetMs(stream);
+    const int targetMs        = inputPrebufferTargetMs(stream);
 
-    if(!m_remoteBuffering.active && std::cmp_less(bufferedMs, static_cast<uint64_t>(targetMs))) {
+    if(!m_inputBuffering.active && std::cmp_less(bufferedMs, static_cast<uint64_t>(targetMs))) {
         m_decoder.requestDecodeReserveMs(targetMs);
         m_decoder.ensureDecodeTimerRunning();
     }
 
-    if(m_remoteBuffering.active) {
-        if(m_remoteBuffering.generation != m_trackGeneration || m_remoteBuffering.streamId != stream->id()) {
-            clearRemoteBufferingState();
+    if(m_inputBuffering.active) {
+        if(m_inputBuffering.generation != m_trackGeneration || m_inputBuffering.streamId != stream->id()) {
+            clearInputBufferingState();
             return;
         }
 
         if(std::cmp_greater_equal(bufferedMs, targetMs)) {
-            qCInfo(ENGINE) << "Remote stream recovered:" << "trackId=" << m_currentTrack.id()
+            qCInfo(ENGINE) << "Input stream recovered:" << "trackId=" << m_currentTrack.id()
                            << "generation=" << m_trackGeneration << "streamId=" << stream->id()
                            << "bufferedMs=" << bufferedMs << "targetMs=" << targetMs
-                           << "rebufferCount=" << m_remoteBuffering.rebufferCount;
-            clearRemoteBufferingState();
+                           << "rebufferCount=" << m_inputBuffering.rebufferCount;
+            clearInputBufferingState();
             m_audioClock.setPlaying(m_audioClock.position());
+            m_audioClock.start();
             updateTrackStatus(Engine::TrackStatus::Buffered);
         }
         else {
@@ -4042,25 +4083,24 @@ void AudioEngine::maybeUpdateRemoteBuffering(const char* reason)
         return;
     }
 
-    const bool belowCriticalFloor = std::cmp_less_equal(bufferedMs, static_cast<uint64_t>(RemoteRebufferFloorMs));
+    const bool belowCriticalFloor = std::cmp_less_equal(bufferedMs, static_cast<uint64_t>(InputRebufferFloorMs));
     if(!belowCriticalFloor) {
         return;
     }
 
-    ++m_remoteBuffering.rebufferCount;
-    m_remoteBuffering.active     = true;
-    m_remoteBuffering.generation = m_trackGeneration;
-    m_remoteBuffering.streamId   = stream->id();
+    ++m_inputBuffering.rebufferCount;
+    m_inputBuffering.active     = true;
+    m_inputBuffering.generation = m_trackGeneration;
+    m_inputBuffering.streamId   = stream->id();
 
     const bool inputNeedsMoreData = m_decoder.inputNeedsMoreData();
     const uint64_t neededMs
         = bufferedMs < static_cast<uint64_t>(targetMs) ? static_cast<uint64_t>(targetMs) - bufferedMs : 0;
 
-    qCInfo(ENGINE) << "Remote stream rebuffering:" << "reason=" << reason << "trackId=" << m_currentTrack.id()
+    qCInfo(ENGINE) << "Input stream buffering:" << "reason=" << reason << "trackId=" << m_currentTrack.id()
                    << "generation=" << m_trackGeneration << "streamId=" << stream->id() << "bufferedMs=" << bufferedMs
-                   << "neededMs=" << neededMs << "floorMs=" << RemoteRebufferFloorMs << "targetMs=" << targetMs
-                   << "inputNeedsMoreData=" << inputNeedsMoreData
-                   << "rebufferCount=" << m_remoteBuffering.rebufferCount;
+                   << "neededMs=" << neededMs << "floorMs=" << InputRebufferFloorMs << "targetMs=" << targetMs
+                   << "inputNeedsMoreData=" << inputNeedsMoreData << "rebufferCount=" << m_inputBuffering.rebufferCount;
 
     m_pipeline.setBufferingPaused(true);
     m_audioClock.setPaused();
@@ -4210,7 +4250,7 @@ void AudioEngine::setupSettings()
     m_settings->subscribe<Settings::Core::Internal::RemotePrebufferMs>(this, [this](int prebufferMs) {
         m_remotePrebufferMs = std::max(0, prebufferMs);
         if(m_currentTrack.isRemote()) {
-            maybeUpdateRemoteBuffering("prebuffer-setting-changed");
+            maybeUpdateInputBuffering("prebuffer-setting-changed");
         }
     });
     m_settings->subscribe<Settings::Core::Internal::DecodeLowWatermarkRatio>(
@@ -4557,11 +4597,20 @@ AudioEngine::evaluateAutoTransitionEligibility(const Track& track, bool isManual
         return reject("decoder-invalid");
     }
 
+    if(!m_decoder.allowsConcurrentDecoding()) {
+        return reject("current-decoder-exclusive");
+    }
+
     if(m_transitions.isSeekInProgress()) {
         return reject("seek-in-progress");
     }
 
     const bool directManualRemoteCrossfade = isManualChange && (m_currentTrack.isRemote() || track.isRemote());
+
+    if(m_preparedNext && samePlaybackItem(Engine::PlaybackItem{.track = track}, m_preparedNext->item)
+       && !m_preparedNext->allowsConcurrentDecoding) {
+        return reject("target-decoder-exclusive");
+    }
 
     if(!directManualRemoteCrossfade) {
         if(!m_preparedNext || !samePlaybackItem(Engine::PlaybackItem{.track = track}, m_preparedNext->item)
@@ -4743,7 +4792,7 @@ bool AudioEngine::setupNewTrackStream(const Track& track, bool applyPendingSeek)
     else {
         const int baseMs       = m_playbackBufferLengthMs / 4;
         const int decodeHighMs = std::max(1, m_decoder.highWatermarkMs());
-        targetMs               = std::max({baseMs, decodeHighMs, outputDemandMs});
+        targetMs               = std::max({baseMs, decodeHighMs, outputDemandMs, m_decoder.playbackPrebufferMs()});
     }
 
     const auto startupPrefillMs = std::clamp(targetMs, 1, std::max(1, streamBufferLength));
@@ -4780,6 +4829,11 @@ bool AudioEngine::setupNewTrackStream(const Track& track, bool applyPendingSeek)
         }
 
         performSimpleSeek(pendingSeek->positionMs, pendingSeek->requestId, startupPrefillMs);
+
+        if(m_initialRestore && m_initialRestore->trackId == track.id()
+           && m_initialRestore->positionMs == pendingSeek->positionMs) {
+            m_initialRestore->applied = true;
+        }
 
         if(!m_decoder.isValid()) {
             qCWarning(ENGINE) << "Pending-seek stream setup left decoder invalid";
@@ -4951,12 +5005,13 @@ bool AudioEngine::prepareNextTrackImmediate(const Engine::PlaybackItem& item, co
 
     const uint64_t preparedBufferMs = transitionReserveMs();
     NextTrackPreparer::Context context;
-    context.audioLoader        = m_audioLoader;
-    context.currentTrack       = m_currentTrack;
-    context.playbackState      = m_playbackState.load(std::memory_order_relaxed);
-    context.playbackHints      = m_decoderPlaybackHints;
-    context.bufferLengthMs     = preparedBufferMs;
-    context.preferredPrefillMs = (prefillTargetMs > 0) ? prefillTargetMs : preferredPreparedPrefillMs();
+    context.audioLoader                     = m_audioLoader;
+    context.currentTrack                    = m_currentTrack;
+    context.playbackState                   = m_playbackState.load(std::memory_order_relaxed);
+    context.playbackHints                   = m_decoderPlaybackHints;
+    context.currentAllowsConcurrentDecoding = m_decoder.allowsConcurrentDecoding();
+    context.bufferLengthMs                  = preparedBufferMs;
+    context.preferredPrefillMs              = (prefillTargetMs > 0) ? prefillTargetMs : preferredPreparedPrefillMs();
 
     auto prepared = NextTrackPreparer::prepare(track, context);
     if(!prepared.isValid()) {
@@ -5018,15 +5073,16 @@ bool AudioEngine::enqueueManualRemoteCrossfadePrepare(const Engine::PlaybackItem
     const auto prefillMs     = static_cast<uint64_t>(remotePrebufferTargetMs(streamBufferMs));
 
     NextTrackPrepareWorker::Request request;
-    request.requestId                  = requestId;
-    request.purpose                    = NextTrackPrepareWorker::Purpose::ManualRemoteCrossfade;
-    request.item                       = item;
-    request.context.audioLoader        = m_audioLoader;
-    request.context.currentTrack       = m_currentTrack;
-    request.context.playbackState      = m_playbackState.load(std::memory_order_relaxed);
-    request.context.playbackHints      = m_decoderPlaybackHints;
-    request.context.bufferLengthMs     = static_cast<uint64_t>(std::max(1, streamBufferMs));
-    request.context.preferredPrefillMs = prefillMs;
+    request.requestId                               = requestId;
+    request.purpose                                 = NextTrackPrepareWorker::Purpose::ManualRemoteCrossfade;
+    request.item                                    = item;
+    request.context.audioLoader                     = m_audioLoader;
+    request.context.currentTrack                    = m_currentTrack;
+    request.context.playbackState                   = m_playbackState.load(std::memory_order_relaxed);
+    request.context.playbackHints                   = m_decoderPlaybackHints;
+    request.context.currentAllowsConcurrentDecoding = m_decoder.allowsConcurrentDecoding();
+    request.context.bufferLengthMs                  = static_cast<uint64_t>(std::max(1, streamBufferMs));
+    request.context.preferredPrefillMs              = prefillMs;
 
     qCDebug(ENGINE) << "Queued manual remote crossfade target preparation:"
                     << "currentTrackId=" << m_currentTrack.id() << "currentItemId=" << m_currentTrackItemId
@@ -5122,13 +5178,14 @@ void AudioEngine::enqueuePrepareNextTrack(const Engine::PlaybackItem& item, uint
     const uint64_t itemId           = item.itemId;
     const uint64_t preparedBufferMs = transitionReserveMs();
     NextTrackPrepareWorker::Request request;
-    request.requestId                  = requestId;
-    request.item                       = item;
-    request.context.audioLoader        = m_audioLoader;
-    request.context.currentTrack       = m_currentTrack;
-    request.context.playbackState      = m_playbackState.load(std::memory_order_relaxed);
-    request.context.playbackHints      = m_decoderPlaybackHints;
-    request.context.bufferLengthMs     = preparedBufferMs;
+    request.requestId                               = requestId;
+    request.item                                    = item;
+    request.context.audioLoader                     = m_audioLoader;
+    request.context.currentTrack                    = m_currentTrack;
+    request.context.playbackState                   = m_playbackState.load(std::memory_order_relaxed);
+    request.context.playbackHints                   = m_decoderPlaybackHints;
+    request.context.currentAllowsConcurrentDecoding = m_decoder.allowsConcurrentDecoding();
+    request.context.bufferLengthMs                  = preparedBufferMs;
     request.context.preferredPrefillMs = (prefillTargetMs > 0) ? prefillTargetMs : preferredPreparedPrefillMs();
 
     qCDebug(ENGINE) << "Queued next-track preparation:" << "currentTrackId=" << m_currentTrack.id()
@@ -5342,7 +5399,7 @@ void AudioEngine::executeFullReinitLoad(const Engine::PlaybackItem& item, bool m
     clearAutoBoundaryFadeState(true);
     clearPendingAnalysisData();
     m_decoder.stopDecoding();
-    clearRemoteBufferingState();
+    clearInputBufferingState();
     cleanupActiveStream();
 
     const auto prevState = m_playbackState.load(std::memory_order_relaxed);

--- a/src/core/engine/audioengine.h
+++ b/src/core/engine/audioengine.h
@@ -164,6 +164,8 @@ public Q_SLOTS:
     void pause();
     void stop();
     void stopImmediate();
+    //! Queue a restored position before the target decoder begins its initial prefill.
+    void queueInitialRestore(uint64_t positionMs, int trackId);
     void restorePosition(uint64_t positionMs, bool pause);
 
     void seek(uint64_t positionMs);
@@ -304,11 +306,12 @@ private:
     void handlePipelineWakeSignals(const AudioPipeline::PendingSignals& pendingSignals);
     void handleOutputStateChange(AudioOutput::State state);
 
-    void clearRemoteBufferingState(bool resumePipeline = true);
-    void maybeUpdateRemoteBuffering(const char* reason);
+    void clearInputBufferingState(bool resumePipeline = true);
+    void maybeUpdateInputBuffering(const char* reason);
     [[nodiscard]] int streamBufferLengthMs(const Track& track) const;
     [[nodiscard]] int remotePrebufferTargetMs(int capacityMs) const;
     [[nodiscard]] int remotePrebufferTargetMs(const AudioStreamPtr& stream) const;
+    [[nodiscard]] int inputPrebufferTargetMs(const AudioStreamPtr& stream) const;
 
     [[nodiscard]] uint64_t beginTransportTransition();
     void clearTransportTransition();
@@ -532,13 +535,21 @@ private:
     PendingAudiblePause m_pendingAudiblePause;
     uint64_t m_nextPendingAudiblePauseSerial{0};
 
-    struct RemoteBufferingState
+    struct InitialRestoreState
+    {
+        uint64_t positionMs{0};
+        int trackId{-1};
+        bool applied{false};
+    };
+    std::optional<InitialRestoreState> m_initialRestore;
+
+    struct InputBufferingState
     {
         bool active{false};
         uint64_t generation{0};
         StreamId streamId{InvalidStreamId};
         uint64_t rebufferCount{0};
     };
-    RemoteBufferingState m_remoteBuffering;
+    InputBufferingState m_inputBuffering;
 };
 } // namespace Fooyin

--- a/src/core/engine/audioinput.cpp
+++ b/src/core/engine/audioinput.cpp
@@ -42,9 +42,29 @@ QStringList AudioDecoder::preferredExtensions() const
     return {};
 }
 
+QStringList AudioDecoder::supportedSchemes() const
+{
+    return {};
+}
+
 bool AudioDecoder::supportsRemoteSources() const
 {
     return false;
+}
+
+bool AudioDecoder::allowsConcurrentDecoding() const
+{
+    return true;
+}
+
+int AudioDecoder::playbackPrebufferMs() const
+{
+    return 0;
+}
+
+QStringList AudioDecoder::takeWarnings()
+{
+    return {};
 }
 
 bool AudioDecoder::needsMoreInput() const
@@ -71,6 +91,8 @@ void AudioDecoder::setPlaybackHints(PlaybackHints hints)
 }
 
 void AudioDecoder::playbackHintsChanged(PlaybackHints /*hints*/) { }
+
+void AudioDecoder::interruptRead() { }
 
 bool AudioDecoder::isRepeatingTrack() const
 {
@@ -102,6 +124,7 @@ void AudioDecoder::start() { }
 void AudioDecoder::requestAbort()
 {
     p->abortSource.request_stop();
+    interruptRead();
 }
 
 std::stop_token AudioDecoder::abortToken() const noexcept
@@ -122,6 +145,11 @@ AudioDecoder::ReadResult AudioDecoder::readAudio(size_t bytes)
 }
 
 QStringList AudioReader::preferredExtensions() const
+{
+    return {};
+}
+
+QStringList AudioReader::supportedSchemes() const
 {
     return {};
 }

--- a/src/core/engine/audioloader.cpp
+++ b/src/core/engine/audioloader.cpp
@@ -137,6 +137,41 @@ CreatorT selectRemoteTrackIoCreator(const std::vector<EntryT>& loaders, Capabili
     return ret;
 }
 
+template <typename EntryT, typename CreatorT>
+CreatorT selectSchemeTrackIoCreator(const std::vector<EntryT>& loaders, const QString& scheme,
+                                    bool includeDisabled = false)
+{
+    CreatorT ret;
+    for(const auto& loader : loaders) {
+        if((!includeDisabled && !loader.enabled) || loader.isArchiveWrapper) {
+            continue;
+        }
+        if(loader.schemes.contains(scheme)) {
+            ret.push_back(loader.creator);
+        }
+    }
+    return ret;
+}
+
+QString sourceScheme(const QString& source)
+{
+    if(!Track::isVirtualPath(source)) {
+        return {};
+    }
+
+    const QUrl url{source, QUrl::StrictMode};
+    return url.scheme().toLower();
+}
+
+void prepareSchemeSource(LoadedSource& input, const QString& filepath)
+{
+    input.device.reset();
+    input.archiveReader.reset();
+    input.source          = {};
+    input.source.filepath = filepath;
+    input.rebind();
+}
+
 template <typename T>
 void prioritisePreferredLoaders(std::vector<std::unique_ptr<T>>& loaders, const QString& ext)
 {
@@ -386,7 +421,7 @@ QStringList AudioLoader::supportedArchiveExtensions() const
 
 bool AudioLoader::canWriteMetadata(const Track& track) const
 {
-    if(track.isRemote()) {
+    if(track.isRemote() || !sourceScheme(track.filepath()).isEmpty()) {
         return false;
     }
 
@@ -420,6 +455,7 @@ LoadedDecoder AudioLoader::loadDecoderForTrack(const Track& track, AudioDecoder:
     }
 
     LoadedDecoder ret;
+    const bool isSchemeSource = !sourceScheme(track.filepath()).isEmpty();
 
     for(auto& decoder : decoders) {
         if(track.isRemote()) {
@@ -431,6 +467,9 @@ LoadedDecoder AudioLoader::loadDecoderForTrack(const Track& track, AudioDecoder:
             if(!openRemoteSource(ret.input, track.filepath(), remoteSourceProvider)) {
                 return {};
             }
+        }
+        else if(isSchemeSource) {
+            prepareSchemeSource(ret.input, track.filepath());
         }
         else if(!track.isInArchive()) {
             if(!openFileSource(ret.input, track.filepath())) {
@@ -464,6 +503,7 @@ LoadedReader AudioLoader::loadReaderForTrack(const Track& track) const
 
     LoadedReader best;
     int bestSubsongCount{0};
+    const bool isSchemeSource = !sourceScheme(track.filepath()).isEmpty();
 
     for(auto& reader : readers) {
         LoadedReader ret;
@@ -476,6 +516,9 @@ LoadedReader AudioLoader::loadReaderForTrack(const Track& track) const
             if(!openRemoteSource(ret.input, track.filepath(), remoteSourceProvider)) {
                 return {};
             }
+        }
+        else if(isSchemeSource) {
+            prepareSchemeSource(ret.input, track.filepath());
         }
         else if(!track.isInArchive()) {
             if(!openFileSource(ret.input, track.filepath())) {
@@ -573,6 +616,7 @@ std::vector<std::unique_ptr<AudioDecoder>> AudioLoader::decodersForFile(const QS
 {
     const QString ext      = QFileInfo{file}.suffix().toLower();
     const bool isInArchive = Track::isArchivePath(file);
+    const QString scheme   = sourceScheme(file);
 
     std::vector<DecoderCreator> creators;
     {
@@ -580,6 +624,10 @@ std::vector<std::unique_ptr<AudioDecoder>> AudioLoader::decodersForFile(const QS
         if(Track::isRemotePath(file)) {
             creators = selectRemoteTrackIoCreator<LoaderEntry<DecoderCreator>, std::vector<DecoderCreator>>(
                 p->m_decoders, [](const AudioDecoder& decoder) { return decoder.supportsRemoteSources(); });
+        }
+        else if(!scheme.isEmpty()) {
+            creators = selectSchemeTrackIoCreator<LoaderEntry<DecoderCreator>, std::vector<DecoderCreator>>(
+                p->m_decoders, scheme);
         }
         else {
             creators = selectTrackIoCreator<LoaderEntry<DecoderCreator>, std::vector<DecoderCreator>>(p->m_decoders,
@@ -614,6 +662,7 @@ std::vector<std::unique_ptr<AudioReader>> AudioLoader::readersForFile(const QStr
 {
     const QString ext      = QFileInfo{file}.suffix().toLower();
     const bool isInArchive = Track::isArchivePath(file);
+    const QString scheme   = sourceScheme(file);
 
     std::vector<ReaderCreator> creators;
     {
@@ -622,6 +671,10 @@ std::vector<std::unique_ptr<AudioReader>> AudioLoader::readersForFile(const QStr
             creators = selectRemoteTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(
                 p->m_readers, [](const AudioReader& reader) { return reader.supportsRemoteSources(); },
                 includeDisabled);
+        }
+        else if(!scheme.isEmpty()) {
+            creators = selectSchemeTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(
+                p->m_readers, scheme, includeDisabled);
         }
         else {
             creators = selectTrackIoCreator<LoaderEntry<ReaderCreator>, std::vector<ReaderCreator>>(
@@ -699,6 +752,9 @@ bool AudioLoader::readTrackMetadata(Track& track) const
             }
             source = loadedSource.source;
         }
+        else if(!sourceScheme(track.filepath()).isEmpty()) {
+            source.device = nullptr;
+        }
         else if(!track.isInArchive()) {
             if(!file.open(QIODevice::ReadOnly)) {
                 qCWarning(AUD_LDR) << "Failed to open file:" << source.filepath;
@@ -736,7 +792,8 @@ QByteArray AudioLoader::readTrackCover(const Track& track, Track::Cover cover) c
     const auto readers = readersForTrack(track);
 
     for(const auto& reader : readers) {
-        if(!track.isInArchive() && !reader->canReadCover()) {
+        const bool isSchemeSource = !sourceScheme(track.filepath()).isEmpty();
+        if(!track.isInArchive() && !isSchemeSource && !reader->canReadCover()) {
             continue;
         }
 
@@ -744,7 +801,7 @@ QByteArray AudioLoader::readTrackCover(const Track& track, Track::Cover cover) c
         source.filepath = track.filepath();
         QFile file{track.filepath()};
 
-        if(!track.isInArchive()) {
+        if(!track.isInArchive() && !isSchemeSource) {
             if(!file.open(QIODevice::ReadOnly)) {
                 return {};
             }
@@ -763,7 +820,7 @@ QByteArray AudioLoader::readTrackCover(const Track& track, Track::Cover cover) c
 
 bool AudioLoader::writeTrackMetadata(const Track& track, AudioReader::WriteOptions options) const
 {
-    if(track.isInArchive() || track.isRemote()) {
+    if(track.isInArchive() || track.isRemote() || !sourceScheme(track.filepath()).isEmpty()) {
         return false;
     }
 
@@ -799,7 +856,7 @@ bool AudioLoader::writeTrackMetadata(const Track& track, AudioReader::WriteOptio
 bool AudioLoader::writeTrackCover(const Track& track, const TrackCovers& coverData,
                                   AudioReader::WriteOptions options) const
 {
-    if(track.isInArchive() || track.isRemote()) {
+    if(track.isInArchive() || track.isRemote() || !sourceScheme(track.filepath()).isEmpty()) {
         return false;
     }
 
@@ -841,6 +898,7 @@ void AudioLoader::addDecoder(const QString& name, const DecoderCreator& creator,
     }
 
     const auto decoderExtensions = normaliseExtensions(decoder->extensions());
+    const auto decoderSchemes    = normaliseExtensions(decoder->supportedSchemes());
 
     const std::unique_lock lock{p->m_mutex};
 
@@ -853,6 +911,7 @@ void AudioLoader::addDecoder(const QString& name, const DecoderCreator& creator,
     loader.name             = name;
     loader.index            = priority >= 0 ? priority : static_cast<int>(p->m_decoders.size());
     loader.extensions       = isArchiveWrapper ? archiveExtensionsFromReaders(p->m_archiveReaders) : decoderExtensions;
+    loader.schemes          = isArchiveWrapper ? QStringList{} : decoderSchemes;
     loader.isArchiveWrapper = isArchiveWrapper;
     loader.creator          = creator;
 
@@ -877,6 +936,7 @@ void AudioLoader::addReader(const QString& name, const ReaderCreator& creator, i
     }
 
     const auto readerExtensions = normaliseExtensions(reader->extensions());
+    const auto readerSchemes    = normaliseExtensions(reader->supportedSchemes());
 
     const std::unique_lock lock{p->m_mutex};
 
@@ -889,6 +949,7 @@ void AudioLoader::addReader(const QString& name, const ReaderCreator& creator, i
     loader.name             = name;
     loader.index            = priority >= 0 ? priority : static_cast<int>(p->m_readers.size());
     loader.extensions       = isArchiveWrapper ? archiveExtensionsFromReaders(p->m_archiveReaders) : readerExtensions;
+    loader.schemes          = isArchiveWrapper ? QStringList{} : readerSchemes;
     loader.isArchiveWrapper = isArchiveWrapper;
     loader.creator          = creator;
 

--- a/src/core/engine/conversion/conversionrunner.cpp
+++ b/src/core/engine/conversion/conversionrunner.cpp
@@ -240,7 +240,7 @@ PcmHashResult pcmHashFailure(QString error)
 PcmHashResult calculatePcmHash(const AudioLoader& loader, const Track& track,
                                std::optional<AudioFormat> comparisonFormat, SampleFormat sampleFormat)
 {
-    auto loaded = loader.loadDecoderForTrack(track, AudioDecoder::NoLooping);
+    auto loaded = loader.loadDecoderForTrack(track, AudioDecoder::NoLooping | AudioDecoder::ForConversion);
     if(!loaded.decoder || !loaded.format) {
         return pcmHashFailure(u"PCM verification could not open input"_s);
     }
@@ -496,6 +496,7 @@ struct TrackEncodingResult
     bool cancelled{false};
     AudioFormat encoderInputFormat;
     QString error;
+    QStringList warnings;
 };
 
 struct SharedProcessingContext
@@ -513,6 +514,7 @@ TrackEncodingResult trackEncodingFailure(QString error, const AudioFormat& forma
         .cancelled          = false,
         .encoderInputFormat = format,
         .error              = std::move(error),
+        .warnings           = {},
     };
 }
 
@@ -530,7 +532,8 @@ TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const 
         previewDuration = *duration;
     }
 
-    auto loaded = request.audioLoader->loadDecoderForTrack(track, AudioDecoder::NoLooping);
+    auto loaded
+        = request.audioLoader->loadDecoderForTrack(track, AudioDecoder::NoLooping | AudioDecoder::ForConversion);
     if(!loaded.decoder || !loaded.format) {
         return trackEncodingFailure(u"No decoder available"_s);
     }
@@ -650,13 +653,25 @@ TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const 
     QString error;
     AudioEncoder::Result encoderResult;
 
+    if(request.sourceObserver) {
+        request.sourceObserver->trackStarted(track, *loaded.format);
+    }
+
+    const auto observerGuard = qScopeGuard([&request, &track, &failed, &sourceComplete]() {
+        if(request.sourceObserver) {
+            request.sourceObserver->trackFinished(track, !failed && sourceComplete);
+        }
+    });
+
     while(true) {
         if(shouldCancel(request)) {
+            const QStringList warnings = loaded.decoder->takeWarnings();
             return {
                 .ok                 = false,
                 .cancelled          = true,
                 .encoderInputFormat = encoderInputFormat,
                 .error              = u"Conversion cancelled"_s,
+                .warnings           = warnings,
             };
         }
 
@@ -670,6 +685,10 @@ TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const 
                     inputBuffer = trimBuffer(inputBuffer, frames);
                     sourceFramesRemaining -= static_cast<uint64_t>(frames);
                     sourceComplete = sourceFramesRemaining == 0;
+                }
+
+                if(request.sourceObserver && inputBuffer.frameCount() > 0) {
+                    request.sourceObserver->sourceAudio(track, inputBuffer);
                 }
 
                 if(hasProcessing) {
@@ -705,6 +724,7 @@ TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const 
             case AudioDecoder::ReadStatus::NeedMoreInput:
                 continue;
             case AudioDecoder::ReadStatus::EndOfStream:
+                sourceComplete = true;
                 break;
             case AudioDecoder::ReadStatus::Error:
                 failed = true;
@@ -732,6 +752,7 @@ TrackEncodingResult encodeTrack(const ConversionRunner::Request& request, const 
         .cancelled          = false,
         .encoderInputFormat = encoderInputFormat,
         .error              = error,
+        .warnings           = loaded.decoder->takeWarnings(),
     };
 }
 
@@ -888,6 +909,7 @@ std::vector<ConversionTrackResult> runGroupedOutputs(const ConversionRunner::Req
         SharedProcessingContext sharedProcessing;
         AudioFormat combinedFormat;
         TrackEncodingResult encoding;
+        QStringList sourceWarnings;
 
         for(size_t i{0}; i < groupTracks.size(); ++i) {
             const Track& track           = groupTracks[i];
@@ -896,6 +918,7 @@ std::vector<ConversionTrackResult> runGroupedOutputs(const ConversionRunner::Req
             encoding = encodeTrack(request, track, progressIndex++, pathResult.outputPath, output.path(), *encoder,
                                    i == 0, combinedFormat, preserveProcessingState ? &sharedProcessing : nullptr,
                                    !preserveProcessingState || finalTrackInGroup);
+            sourceWarnings.append(encoding.warnings);
             if(!encoding.ok) {
                 progressIndex += static_cast<int>(groupTracks.size() - i - 1);
                 break;
@@ -914,16 +937,17 @@ std::vector<ConversionTrackResult> runGroupedOutputs(const ConversionRunner::Req
         if(!encoding.ok || !finishResult.ok) {
             const QString error = !encoding.ok ? encoding.error : finishResult.error;
             encoder.reset();
-            addResults(encoding.cancelled ? ConversionResultStatus::Cancelled : ConversionResultStatus::Failed, error);
+            addResults(encoding.cancelled ? ConversionResultStatus::Cancelled : ConversionResultStatus::Failed, error,
+                       sourceWarnings);
             continue;
         }
 
         if(shouldCancel(request)) {
-            addResults(ConversionResultStatus::Cancelled, u"Conversion cancelled"_s);
+            addResults(ConversionResultStatus::Cancelled, u"Conversion cancelled"_s, sourceWarnings);
             continue;
         }
 
-        QStringList warnings;
+        QStringList warnings{sourceWarnings};
         const QString metadataError = transferMetadata(request, groupTracks.front(), output.path(), false);
         if(!metadataError.isEmpty()) {
             warnings.append(metadataError);
@@ -936,7 +960,7 @@ std::vector<ConversionTrackResult> runGroupedOutputs(const ConversionRunner::Req
         if(request.job.preset.other.verifyOutput) {
             const QString verificationError = verifyOutput(*request.audioLoader, output.path());
             if(!verificationError.isEmpty()) {
-                addResults(ConversionResultStatus::Failed, verificationError);
+                addResults(ConversionResultStatus::Failed, verificationError, warnings);
                 continue;
             }
         }
@@ -1018,7 +1042,7 @@ std::vector<ConversionTrackResult> runIndividualOutputs(const ConversionRunner::
                 .outputPath  = pathResult.outputPath,
                 .status      = encoding.cancelled ? ConversionResultStatus::Cancelled : ConversionResultStatus::Failed,
                 .error       = error,
-                .warnings    = {},
+                .warnings    = encoding.warnings,
             });
             continue;
         }
@@ -1029,12 +1053,12 @@ std::vector<ConversionTrackResult> runIndividualOutputs(const ConversionRunner::
                 .outputPath  = pathResult.outputPath,
                 .status      = ConversionResultStatus::Cancelled,
                 .error       = u"Conversion cancelled"_s,
-                .warnings    = {},
+                .warnings    = encoding.warnings,
             });
             continue;
         }
 
-        QStringList warnings;
+        QStringList warnings{encoding.warnings};
         const QString metadataError = transferMetadata(request, track, output.path(), true);
         if(!metadataError.isEmpty()) {
             warnings.append(metadataError);
@@ -1050,13 +1074,21 @@ std::vector<ConversionTrackResult> runIndividualOutputs(const ConversionRunner::
                 verificationError = verifyLosslessPcm(*request.audioLoader, track, output.path(), request.job.preset);
             }
             if(!verificationError.isEmpty()) {
-                results.push_back(failedResult(track, pathResult.outputPath, verificationError));
+                results.push_back({.sourceTrack = track,
+                                   .outputPath  = pathResult.outputPath,
+                                   .status      = ConversionResultStatus::Failed,
+                                   .error       = verificationError,
+                                   .warnings    = warnings});
                 continue;
             }
         }
 
         if(!output.commit(outputError)) {
-            results.push_back(failedResult(track, pathResult.outputPath, outputError));
+            results.push_back({.sourceTrack = track,
+                               .outputPath  = pathResult.outputPath,
+                               .status      = ConversionResultStatus::Failed,
+                               .error       = outputError,
+                               .warnings    = warnings});
             continue;
         }
 

--- a/src/core/engine/decode/decodercontext.cpp
+++ b/src/core/engine/decode/decodercontext.cpp
@@ -136,6 +136,16 @@ bool DecoderContext::isSeekable() const
     return m_decoder && m_decoder->isSeekable();
 }
 
+bool DecoderContext::allowsConcurrentDecoding() const
+{
+    return !m_decoder || m_decoder->allowsConcurrentDecoding();
+}
+
+int DecoderContext::playbackPrebufferMs() const
+{
+    return m_decoder ? std::max(0, m_decoder->playbackPrebufferMs()) : 0;
+}
+
 AudioDecoder::RepeatHandling DecoderContext::repeatHandling() const
 {
     return m_decoder ? m_decoder->repeatHandling() : AudioDecoder::RepeatHandling::EngineTransition;

--- a/src/core/engine/decode/decodercontext.h
+++ b/src/core/engine/decode/decodercontext.h
@@ -62,6 +62,8 @@ public:
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] bool isDecoding() const;
     [[nodiscard]] bool isSeekable() const;
+    [[nodiscard]] bool allowsConcurrentDecoding() const;
+    [[nodiscard]] int playbackPrebufferMs() const;
     [[nodiscard]] AudioDecoder::RepeatHandling repeatHandling() const;
     [[nodiscard]] AudioStreamPtr activeStream() const;
     [[nodiscard]] StreamId activeStreamId() const;

--- a/src/core/engine/decode/decodingcontroller.cpp
+++ b/src/core/engine/decode/decodingcontroller.cpp
@@ -210,6 +210,8 @@ public:
         bool valid{false};
         bool decoding{false};
         bool seekable{false};
+        bool allowsConcurrentDecoding{true};
+        int playbackPrebufferMs{0};
         AudioDecoder::RepeatHandling repeatHandling{AudioDecoder::RepeatHandling::EngineTransition};
         AudioStreamPtr activeStream;
         StreamId activeStreamId{InvalidStreamId};
@@ -332,6 +334,8 @@ public:
         next.valid                     = context.isValid();
         next.decoding                  = context.isDecoding();
         next.seekable                  = context.isSeekable();
+        next.allowsConcurrentDecoding  = context.allowsConcurrentDecoding();
+        next.playbackPrebufferMs       = context.playbackPrebufferMs();
         next.repeatHandling            = context.repeatHandling();
         next.activeStream              = context.activeStream();
         next.activeStreamId            = context.activeStreamId();
@@ -754,6 +758,16 @@ bool DecodingController::isDecoding() const
 bool DecodingController::isSeekable() const
 {
     return p->currentSnapshot().seekable;
+}
+
+bool DecodingController::allowsConcurrentDecoding() const
+{
+    return p->currentSnapshot().allowsConcurrentDecoding;
+}
+
+int DecodingController::playbackPrebufferMs() const
+{
+    return p->currentSnapshot().playbackPrebufferMs;
 }
 
 AudioDecoder::RepeatHandling DecodingController::repeatHandling() const

--- a/src/core/engine/decode/decodingcontroller.h
+++ b/src/core/engine/decode/decodingcontroller.h
@@ -84,6 +84,8 @@ public:
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] bool isDecoding() const;
     [[nodiscard]] bool isSeekable() const;
+    [[nodiscard]] bool allowsConcurrentDecoding() const;
+    [[nodiscard]] int playbackPrebufferMs() const;
     [[nodiscard]] AudioDecoder::RepeatHandling repeatHandling() const;
 
     [[nodiscard]] AudioStreamPtr activeStream() const;

--- a/src/core/engine/decode/nexttrackpreparer.cpp
+++ b/src/core/engine/decode/nexttrackpreparer.cpp
@@ -92,18 +92,18 @@ NextTrackPreparationState NextTrackPreparer::prepare(const Track& track, const C
     NextTrackPreparationState state;
     state.item.track = track;
 
-    const auto canceled = [&context]() {
+    const auto cancelled = [&context]() {
         return context.cancelFlag && context.cancelFlag->load(std::memory_order_relaxed);
     };
 
-    if(!track.isValid() || !context.audioLoader || canceled()) {
+    if(!track.isValid() || !context.audioLoader || !context.currentAllowsConcurrentDecoding || cancelled()) {
         return {};
     }
 
     DecoderContext decoderContext;
     decoderContext.setPlaybackHints(context.playbackHints);
 
-    if(canceled()) {
+    if(cancelled()) {
         return {};
     }
 
@@ -115,7 +115,7 @@ NextTrackPreparationState NextTrackPreparer::prepare(const Track& track, const C
 
     const ActiveDecoderRegistration activeDecoder{context.activeDecoderChanged, decoder.decoder.get()};
 
-    if(canceled()) {
+    if(cancelled()) {
         return {};
     }
 
@@ -124,10 +124,12 @@ NextTrackPreparationState NextTrackPreparer::prepare(const Track& track, const C
         return {};
     }
 
-    state.format = decoderContext.format();
+    state.format                   = decoderContext.format();
+    state.allowsConcurrentDecoding = decoderContext.allowsConcurrentDecoding();
 
     const bool sameFileSegmentHandoff = isMultiTrackFileTransition(context.currentTrack, track);
     const bool canPrimePreparedStream = context.playbackState == Engine::PlaybackState::Playing
+                                     && context.currentAllowsConcurrentDecoding && state.allowsConcurrentDecoding
                                      && (decoderContext.isSeekable() || track.offset() == 0) && !sameFileSegmentHandoff;
 
     if(canPrimePreparedStream) {
@@ -147,7 +149,7 @@ NextTrackPreparationState NextTrackPreparer::prepare(const Track& track, const C
                 decoderContext.seek(track.offset());
             }
 
-            if(canceled()) {
+            if(cancelled()) {
                 return {};
             }
 
@@ -155,7 +157,7 @@ NextTrackPreparationState NextTrackPreparer::prepare(const Track& track, const C
 
             const auto chunksDecoded = decoderContext.prefillActiveStreamMs(clampedPrefillMs);
 
-            if(canceled()) {
+            if(cancelled()) {
                 return {};
             }
 
@@ -293,12 +295,13 @@ void NextTrackPrepareWorker::run(const std::stop_token& stopToken)
         auto prepared = NextTrackPreparer::prepare(request.item.track, request.context);
         prepared.item = request.item;
 
-        const bool canceled = request.context.cancelFlag && request.context.cancelFlag->load(std::memory_order_relaxed);
+        const bool cancelled
+            = request.context.cancelFlag && request.context.cancelFlag->load(std::memory_order_relaxed);
 
         const uint64_t currentActive = m_activeJobToken.load(std::memory_order_relaxed);
         const bool stale             = (currentActive != request.jobToken);
 
-        if(!canceled && !stale && completion) {
+        if(!cancelled && !stale && completion) {
             completion(request.jobToken, request.requestId, request.purpose, request.item, std::move(prepared));
         }
     }

--- a/src/core/engine/decode/nexttrackpreparer.h
+++ b/src/core/engine/decode/nexttrackpreparer.h
@@ -46,6 +46,7 @@ struct FYCORE_EXPORT NextTrackPreparationState
     AudioFormat format;
     AudioStreamPtr preparedStream;
     uint64_t preparedDecodePositionMs{0};
+    bool allowsConcurrentDecoding{true};
 
     [[nodiscard]] bool isValid() const
     {
@@ -68,6 +69,7 @@ public:
         Track currentTrack; // Used to check for same-file transition
         Engine::PlaybackState playbackState{Engine::PlaybackState::Stopped};
         AudioDecoder::PlaybackHints playbackHints{AudioDecoder::NoHints};
+        bool currentAllowsConcurrentDecoding{true};
         uint64_t bufferLengthMs{0};     // Internal prepared-stream reserve target
         uint64_t preferredPrefillMs{0}; // Minimum decoded reserve to accumulate before handoff
         std::shared_ptr<std::atomic<bool>> cancelFlag;

--- a/src/core/engine/enginehandler.cpp
+++ b/src/core/engine/enginehandler.cpp
@@ -350,7 +350,8 @@ void EngineHandler::handleTrackChangeRequest(const Player::TrackChangeRequest& r
         return;
     }
 
-    if(request.context.reason == Player::AdvanceReason::StartupRestore && m_pendingStartupRestore.has_value()) {
+    if(request.context.reason == Player::AdvanceReason::StartupRestore && m_pendingStartupRestore.has_value()
+       && m_pendingStartupRestore->positionMs > 0) {
         m_pendingStartupRestoreItemId = request.itemId;
     }
     else if(m_pendingStartupRestore.has_value()) {
@@ -363,6 +364,10 @@ void EngineHandler::handleTrackChangeRequest(const Player::TrackChangeRequest& r
     clearEngineOwnedTransition();
     m_pendingTrackChange = request;
     m_pendingTrackChangeGeneration.reset();
+
+    if(request.context.reason == Player::AdvanceReason::StartupRestore && m_pendingStartupRestore.has_value()) {
+        dispatchCommand(&AudioEngine::queueInitialRestore, m_pendingStartupRestore->positionMs, track.id());
+    }
     dispatchCommand(&AudioEngine::loadTrack, makePlaybackItem(track, request.itemId), request.context.userInitiated);
 }
 

--- a/src/core/playlist/parsers/m3uparser.cpp
+++ b/src/core/playlist/parsers/m3uparser.cpp
@@ -105,7 +105,7 @@ bool isCuePath(const QString& path)
 
 QString resolvePlaylistEntryPath(const QString& playlistPath, const QString& entry, const QDir& dir)
 {
-    if(Track::isArchivePath(entry) || Track::isRemotePath(entry)) {
+    if(Track::isArchivePath(entry) || Track::isRemotePath(entry) || Track::isVirtualPath(entry)) {
         return entry;
     }
 
@@ -271,7 +271,8 @@ TrackList M3uParser::readPlaylist(QIODevice* device, const QString& filepath, co
                 track.setSubsong(subsong);
             }
 
-            if(!Track::isArchivePath(path) && !Track::isRemotePath(path) && !QFile::exists(path)) {
+            if(!Track::isArchivePath(path) && !Track::isRemotePath(path) && !Track::isVirtualPath(path)
+               && !QFile::exists(path)) {
                 // Handle potential windows filepath
                 track.setFilePath(path.replace(u'\\', u'/'));
             }
@@ -335,11 +336,15 @@ void M3uParser::savePlaylist(QIODevice* device, const QString& extension, const 
         if(writeMetdata) {
             stream << u"#EXTINF:%1,%2 - %3\n"_s.arg(track.duration() / 1000).arg(track.artist(), track.title());
         }
+
         QString path = track.filepath();
         if(track.subsong() > 0) {
             path += u"#%1"_s.arg(track.subsong());
         }
-        stream << PlaylistParser::determineTrackPath(QUrl::fromLocalFile(path), dir, type) << "\n";
+
+        const QUrl trackUrl
+            = track.isRemote() || track.isVirtual() ? QUrl{path, QUrl::StrictMode} : QUrl::fromLocalFile(path);
+        stream << determineTrackPath(trackUrl, dir, type) << "\n";
     }
 }
 } // namespace Fooyin

--- a/src/core/playlist/parsers/plsparser.cpp
+++ b/src/core/playlist/parsers/plsparser.cpp
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <QTextStream>
 #include <QUrl>
 
@@ -43,9 +44,22 @@ struct PlsEntry
     int durationSeconds{-1};
 };
 
+int endingSubsong(QString* filepath)
+{
+    static const QRegularExpression regex{uR"(#(\d+)$)"_s};
+    const QRegularExpressionMatch match = regex.match(*filepath);
+    if(!match.hasMatch()) {
+        return -1;
+    }
+
+    const int subsong = match.captured(1).toInt();
+    filepath->remove(match.capturedStart(), match.capturedLength());
+    return subsong;
+}
+
 QString resolvePlaylistEntryPath(const QString& playlistPath, const QString& entry, const QDir& dir)
 {
-    if(Track::isArchivePath(entry) || Track::isRemotePath(entry)) {
+    if(Track::isArchivePath(entry) || Track::isRemotePath(entry) || Track::isVirtualPath(entry)) {
         return entry;
     }
 
@@ -177,10 +191,16 @@ TrackList PlsParser::readPlaylist(QIODevice* device, const QString& filepath, co
             continue;
         }
 
-        QString path = resolvePlaylistEntryPath(filepath, entry.file, dir);
-        Track track{path};
+        QString path      = resolvePlaylistEntryPath(filepath, entry.file, dir);
+        const int subsong = endingSubsong(&path);
 
-        if(!Track::isArchivePath(path) && !Track::isRemotePath(path) && !QFile::exists(path)) {
+        Track track{path};
+        if(subsong > 0) {
+            track.setSubsong(subsong);
+        }
+
+        if(!Track::isArchivePath(path) && !Track::isRemotePath(path) && !Track::isVirtualPath(path)
+           && !QFile::exists(path)) {
             track.setFilePath(path.replace(u'\\', u'/'));
         }
 
@@ -211,9 +231,16 @@ void PlsParser::savePlaylist(QIODevice* device, const QString& /*extension*/, co
     for(size_t i{0}; i < count; ++i) {
         const Track& track      = tracks.at(i);
         const size_t entryIndex = i + 1;
-        const QUrl trackUrl     = track.isRemote() ? QUrl{track.filepath()} : QUrl::fromLocalFile(track.filepath());
 
-        stream << "File" << entryIndex << "=" << PlaylistParser::determineTrackPath(trackUrl, dir, type) << "\n";
+        QString path = track.filepath();
+        if(track.subsong() > 0) {
+            path += u"#%1"_s.arg(track.subsong());
+        }
+
+        const QUrl trackUrl
+            = track.isRemote() || track.isVirtual() ? QUrl{path, QUrl::StrictMode} : QUrl::fromLocalFile(path);
+
+        stream << "File" << entryIndex << "=" << determineTrackPath(trackUrl, dir, type) << "\n";
 
         if(writeMetdata) {
             const QString title = track.title();

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -62,6 +62,61 @@ bool isRemoteTrackPath(const QString& path)
     return scheme == "http"_L1 || scheme == "https"_L1;
 }
 
+bool isWindowsAbsolutePath(const QString& path)
+{
+    return (path.size() >= 3 && path.at(0).isLetter() && path.at(1) == u':'
+            && (path.at(2) == u'/' || path.at(2) == u'\\'))
+        || path.startsWith(uR"(\\)"_s) || path.startsWith("//"_L1);
+}
+
+bool isVirtualTrackPath(const QString& path)
+{
+    if(path.isEmpty() || Fooyin::Track::isArchivePath(path) || isRemoteTrackPath(path) || isWindowsAbsolutePath(path)) {
+        return false;
+    }
+
+    const QUrl url{path, QUrl::StrictMode};
+    return url.isValid() && !url.scheme().isEmpty() && url.scheme().compare(u"file"_s, Qt::CaseInsensitive) != 0;
+}
+
+QString virtualUrlName(const QString& path)
+{
+    const QUrl url{path, QUrl::StrictMode};
+    if(const QString name = QFileInfo{url.path()}.fileName(); !name.isEmpty()) {
+        return name;
+    }
+
+    const qsizetype separator = path.indexOf("://"_L1);
+    if(separator < 0) {
+        return {};
+    }
+
+    const QStringView authority = QStringView{path}.sliced(separator + 3);
+    const qsizetype slash       = authority.indexOf(u'/');
+    return (slash < 0 ? authority : authority.first(slash)).toString();
+}
+
+QString virtualUrlPath(const QString& path)
+{
+    const qsizetype separator = path.indexOf("://"_L1);
+    if(separator < 0) {
+        return {};
+    }
+
+    const qsizetype prefixEnd = separator + 3;
+    const qsizetype lastSlash = path.lastIndexOf(u'/');
+    return lastSlash < prefixEnd ? path.first(prefixEnd) : path.first(lastSlash);
+}
+
+QString prettyVirtualUrl(const QString& path)
+{
+    const qsizetype separator = path.indexOf(":///"_L1);
+    if(separator < 0) {
+        return path;
+    }
+    return path.first(separator + 3) + path.sliced(separator + 4);
+}
+
 QString remoteTrackFilename(const QString& path)
 {
     const QUrl url{path};
@@ -369,6 +424,11 @@ QString TrackPrivate::directory() const
     if(isRemoteTrackPath(filepath)) {
         return remoteTrackDirectory(filepath);
     }
+    if(isVirtualTrackPath(filepath)) {
+        const QString parent = virtualUrlPath(filepath);
+        const QString name   = virtualUrlName(parent);
+        return !name.isEmpty() ? name : parent;
+    }
 
     const QFileInfo info{isInArchive ? filepathWithinArchive : filepath};
     QString dir = info.dir().dirName();
@@ -383,6 +443,9 @@ QString TrackPrivate::filename() const
     if(isRemoteTrackPath(filepath)) {
         return remoteTrackFilename(filepath);
     }
+    if(isVirtualTrackPath(filepath)) {
+        return virtualUrlName(filepath);
+    }
 
     return QFileInfo{isInArchive ? filepathWithinArchive : filepath}.completeBaseName();
 }
@@ -391,6 +454,9 @@ QString TrackPrivate::extension() const
 {
     if(isRemoteTrackPath(filepath)) {
         return remoteTrackExtension(filepath);
+    }
+    if(isVirtualTrackPath(filepath)) {
+        return QUrl{filepath, QUrl::StrictMode}.scheme().toLower();
     }
 
     return QFileInfo{isInArchive ? filepathWithinArchive : filepath}.suffix().toLower();
@@ -634,7 +700,7 @@ bool Track::metadataWasModified() const
 
 bool Track::exists() const
 {
-    if(isRemote()) {
+    if(isRemote() || isVirtual()) {
         return true;
     }
 
@@ -657,6 +723,11 @@ bool Track::isInArchive() const
 bool Track::isRemote() const
 {
     return isRemotePath(p->filepath);
+}
+
+bool Track::isVirtual() const
+{
+    return isVirtualPath(p->filepath);
 }
 
 QString Track::archivePath() const
@@ -761,6 +832,9 @@ QString Track::prettyFilepath() const
     if(isInArchive()) {
         return archivePath() + "/"_L1 + pathInArchive();
     }
+    if(isVirtual()) {
+        return prettyVirtualUrl(p->filepath);
+    }
 
     return p->filepath;
 }
@@ -774,6 +848,10 @@ QString Track::path() const
 {
     if(isRemote()) {
         return {};
+    }
+
+    if(isVirtual()) {
+        return virtualUrlPath(p->filepath);
     }
 
     if(isInArchive()) {
@@ -799,6 +877,9 @@ QString Track::filenameExt() const
         const QUrl remoteUrl{p->filepath};
         const QString filename = QFileInfo{remoteUrl.path()}.fileName();
         return !filename.isEmpty() ? filename : remoteUrl.host();
+    }
+    if(isVirtual()) {
+        return virtualUrlName(p->filepath);
     }
 
     return QFileInfo{p->filepath}.fileName();
@@ -1225,6 +1306,11 @@ bool Track::isArchivePath(const QString& path)
 bool Track::isRemotePath(const QString& path)
 {
     return isRemoteTrackPath(path);
+}
+
+bool Track::isVirtualPath(const QString& path)
+{
+    return isVirtualTrackPath(path);
 }
 
 bool Track::isMultiValueTag(const QString& tag)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/gui/coverrepository.h
     ${CMAKE_SOURCE_DIR}/include/gui/configdialog.h
     ${CMAKE_SOURCE_DIR}/include/gui/contextmenuutils.h
+    ${CMAKE_SOURCE_DIR}/include/gui/conversion/conversionservice.h
     ${CMAKE_SOURCE_DIR}/include/gui/dsp/dsplayouteditor.h
     ${CMAKE_SOURCE_DIR}/include/gui/dsp/dspsettingsdialog.h
     ${CMAKE_SOURCE_DIR}/include/gui/dsp/dspsettingsprovider.h

--- a/src/gui/conversion/conversioncontroller.cpp
+++ b/src/gui/conversion/conversioncontroller.cpp
@@ -27,6 +27,8 @@
 #include <utils/async.h>
 
 #include <QAbstractButton>
+#include <QDir>
+#include <QFileDialog>
 #include <QFileInfo>
 #include <QFutureWatcher>
 #include <QMessageBox>
@@ -47,7 +49,9 @@ class ConversionSession : public QObject
 public:
     ConversionSession(std::shared_ptr<AudioLoader> audioLoader, AudioEncoderRegistry* encoderRegistry,
                       DspRegistry* dspRegistry, ConversionJob job, QString askFolder, bool showReport,
-                      QWidget* parentWindow, QObject* parent)
+                      std::shared_ptr<ConversionInputObserver> sourceObserver,
+                      std::function<void(const std::vector<ConversionTrackResult>&)> completion, QWidget* parentWindow,
+                      QObject* parent)
         : QObject{parent}
         , m_audioLoader{std::move(audioLoader)}
         , m_encoderRegistry{encoderRegistry}
@@ -55,6 +59,8 @@ public:
         , m_job{std::move(job)}
         , m_askFolder{std::move(askFolder)}
         , m_showReport{showReport}
+        , m_sourceObserver{std::move(sourceObserver)}
+        , m_completion{std::move(completion)}
         , m_parentWindow{parentWindow}
         , m_cancelled{std::make_shared<std::atomic_bool>(false)}
         , m_progress{new ElapsedProgressDialog(tr("Preparing conversion…"), tr("Cancel"), 0, 100, parentWindow)}
@@ -78,12 +84,14 @@ public:
     {
         auto future = Utils::asyncExec([audioLoader = m_audioLoader, encoderRegistry = m_encoderRegistry,
                                         dspRegistry = m_dspRegistry, job = m_job, askFolder = m_askFolder,
-                                        cancelled = m_cancelled, progress = m_progress, session = this]() {
+                                        cancelled = m_cancelled, progress = m_progress, session = this,
+                                        sourceObserver = m_sourceObserver]() {
             ConversionRunner::Request request;
             request.audioLoader     = audioLoader.get();
             request.encoderRegistry = encoderRegistry;
             request.dspRegistry     = dspRegistry;
             request.job             = job;
+            request.sourceObserver  = sourceObserver;
             request.askFolder       = askFolder;
             request.cancelCallback  = [cancelled]() {
                 return cancelled->load(std::memory_order_acquire);
@@ -97,7 +105,14 @@ public:
                                                : 0.0;
                 const auto percentage      = static_cast<int>(
                     ((static_cast<double>(current.trackIndex) + trackProgress) / trackCount) * 100.0);
-                const QString text = tr("Current file") + ":\n"_L1 + current.sourcePath;
+                const QString progressText = current.sourceDurationMs > 0
+                                               ? tr("%1%").arg(QString::number(trackProgress * 100.0, 'f', 1))
+                                               : tr("Calculating…");
+                const QString text         = tr("Converting %1 of %2 (%3)")
+                                                 .arg(current.trackIndex + 1)
+                                                 .arg(current.trackCount)
+                                                 .arg(progressText)
+                                           + "\n"_L1 + tr("Current file") + ":\n"_L1 + current.sourcePath;
                 QMetaObject::invokeMethod(progress, [progress, percentage, text]() {
                     progress->setText(text);
                     progress->setValue(percentage);
@@ -203,6 +218,10 @@ private:
             report.exec();
         }
 
+        if(m_completion) {
+            m_completion(results);
+        }
+
         m_progress->deleteLater();
         deleteLater();
     }
@@ -214,6 +233,8 @@ private:
     ConversionJob m_job;
     QString m_askFolder;
     bool m_showReport;
+    std::shared_ptr<ConversionInputObserver> m_sourceObserver;
+    std::function<void(const std::vector<ConversionTrackResult>&)> m_completion;
     QWidget* m_parentWindow;
     std::shared_ptr<std::atomic_bool> m_cancelled;
     ElapsedProgressDialog* m_progress;
@@ -237,6 +258,13 @@ ConversionController::ConversionController(std::shared_ptr<AudioLoader> audioLoa
 
 void ConversionController::showSetup(const TrackList& tracks)
 {
+    showSetup(tracks, {}, {}, {});
+}
+
+void ConversionController::showSetup(const TrackList& tracks, const QString& suggestedFilenamePattern,
+                                     std::shared_ptr<ConversionInputObserver> sourceObserver,
+                                     std::function<void(const std::vector<ConversionTrackResult>&)> completion)
+{
     if(tracks.empty()) {
         return;
     }
@@ -245,37 +273,108 @@ void ConversionController::showSetup(const TrackList& tracks)
                                            m_dspSettingsRegistry);
     setup->setAttribute(Qt::WA_DeleteOnClose);
     setup->setModal(false);
+    setup->applySuggestedFilenamePattern(suggestedFilenamePattern);
 
-    QObject::connect(setup, &QDialog::finished, this, [this, setup](int result) {
-        if(result != QDialog::Accepted) {
-            Q_EMIT conversionPresetsChanged();
-            return;
-        }
+    QObject::connect(setup, &QDialog::finished, this,
+                     [this, setup, sourceObserver = std::move(sourceObserver),
+                      completion = std::move(completion)](int result) mutable {
+                         if(result != QDialog::Accepted) {
+                             Q_EMIT conversionPresetsChanged();
+                             return;
+                         }
 
-        ConversionJob job     = setup->job();
-        const bool showReport = setup->showReport();
-        ConverterSettings::setLastUsedConversionPreset({
-            .name       = u"[last used]"_s,
-            .preset     = job.preset,
-            .showReport = showReport,
-        });
-        Q_EMIT conversionPresetsChanged();
-        start(std::move(job), setup->askFolder(), showReport);
-    });
+                         ConversionJob job     = setup->job();
+                         const bool showReport = setup->showReport();
+                         ConverterSettings::setLastUsedConversionPreset({
+                             .name       = u"[last used]"_s,
+                             .preset     = job.preset,
+                             .showReport = showReport,
+                         });
+                         Q_EMIT conversionPresetsChanged();
+                         start(std::move(job), setup->askFolder(), showReport, std::move(sourceObserver),
+                               std::move(completion));
+                     });
 
     setup->show();
     setup->raise();
     setup->activateWindow();
 }
 
+std::vector<ConversionPresetInfo> ConversionController::presets() const
+{
+    std::vector<ConversionPresetInfo> result;
+
+    for(const StoredConversionPreset& stored : ConverterSettings::conversionPresets()) {
+        if(!stored.preset.id.isEmpty()) {
+            result.push_back({.id = stored.preset.id, .name = stored.name});
+        }
+    }
+
+    return result;
+}
+
+bool ConversionController::startPreset(const QString& presetId, const TrackList& tracks)
+{
+    return startPreset(presetId, tracks, {}, {}, {});
+}
+
+bool ConversionController::startPreset(const QString& presetId, const TrackList& tracks,
+                                       const QString& suggestedFilenamePattern,
+                                       std::shared_ptr<ConversionInputObserver> sourceObserver,
+                                       std::function<void(const std::vector<ConversionTrackResult>&)> completion)
+{
+    if(presetId.isEmpty() || tracks.empty()) {
+        return false;
+    }
+
+    const auto presets = ConverterSettings::conversionPresets();
+    const auto stored
+        = std::ranges::find(presets, presetId, [](const StoredConversionPreset& preset) { return preset.preset.id; });
+    if(stored == presets.cend()) {
+        return false;
+    }
+
+    QString askFolder;
+    if(stored->preset.destination.mode == DestinationMode::Ask) {
+        askFolder = QFileDialog::getExistingDirectory(m_parentWindow, tr("Choose destination"), QDir::homePath());
+        if(askFolder.isEmpty()) {
+            return false;
+        }
+    }
+
+    StoredConversionPreset selected{*stored};
+    if(!suggestedFilenamePattern.trimmed().isEmpty()
+       && selected.preset.destination.filenamePattern.trimmed() == u"%filename%"_s) {
+        selected.preset.destination.filenamePattern = suggestedFilenamePattern.trimmed();
+    }
+
+    StoredConversionPreset lastUsed{selected};
+    lastUsed.name        = u"[last used]"_s;
+    lastUsed.preset.name = lastUsed.name;
+    ConverterSettings::setLastUsedConversionPreset(lastUsed);
+    Q_EMIT conversionPresetsChanged();
+
+    start({.tracks = tracks, .preset = std::move(selected.preset)}, std::move(askFolder), selected.showReport,
+          std::move(sourceObserver), std::move(completion));
+    return true;
+}
+
 void ConversionController::start(ConversionJob job, QString askFolder, bool showReport)
+{
+    start(std::move(job), std::move(askFolder), showReport, {}, {});
+}
+
+void ConversionController::start(ConversionJob job, QString askFolder, bool showReport,
+                                 std::shared_ptr<ConversionInputObserver> sourceObserver,
+                                 std::function<void(const std::vector<ConversionTrackResult>&)> completion)
 {
     if(job.tracks.empty()) {
         return;
     }
 
-    auto* session = new ConversionSession{m_audioLoader,        m_encoderRegistry, m_dspRegistry,  std::move(job),
-                                          std::move(askFolder), showReport,        m_parentWindow, this};
+    auto* session = new ConversionSession{
+        m_audioLoader, m_encoderRegistry,         m_dspRegistry,         std::move(job), std::move(askFolder),
+        showReport,    std::move(sourceObserver), std::move(completion), m_parentWindow, this};
     session->start();
 }
 } // namespace Fooyin

--- a/src/gui/conversion/conversioncontroller.h
+++ b/src/gui/conversion/conversioncontroller.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <core/engine/conversion/conversiondefs.h>
+#include <gui/conversion/conversionservice.h>
 
 #include <QObject>
 
@@ -35,7 +36,8 @@ class DspRegistry;
 class DspSettingsRegistry;
 class SettingsManager;
 
-class ConversionController : public QObject
+class ConversionController : public QObject,
+                             public ConversionService
 {
     Q_OBJECT
 
@@ -45,8 +47,21 @@ public:
                          DspSettingsRegistry* dspSettingsRegistry, SettingsManager* settings, QWidget* parentWindow,
                          QObject* parent = nullptr);
 
-    void showSetup(const TrackList& tracks);
+    void showSetup(const TrackList& tracks) override;
+    void showSetup(const TrackList& tracks, const QString& suggestedFilenamePattern,
+                   std::shared_ptr<ConversionInputObserver> sourceObserver,
+                   std::function<void(const std::vector<ConversionTrackResult>&)> completion) override;
+
+    [[nodiscard]] std::vector<ConversionPresetInfo> presets() const override;
+    bool startPreset(const QString& presetId, const TrackList& tracks) override;
+    bool startPreset(const QString& presetId, const TrackList& tracks, const QString& suggestedFilenamePattern,
+                     std::shared_ptr<ConversionInputObserver> sourceObserver,
+                     std::function<void(const std::vector<ConversionTrackResult>&)> completion) override;
+
     void start(ConversionJob job, QString askFolder, bool showReport);
+    void start(ConversionJob job, QString askFolder, bool showReport,
+               std::shared_ptr<ConversionInputObserver> sourceObserver,
+               std::function<void(const std::vector<ConversionTrackResult>&)> completion);
 
 Q_SIGNALS:
     void conversionPresetsChanged();

--- a/src/gui/conversion/convertersetupdialog.cpp
+++ b/src/gui/conversion/convertersetupdialog.cpp
@@ -199,6 +199,14 @@ bool ConverterSetupDialog::showReport() const
     return m_showReport->isChecked();
 }
 
+void ConverterSetupDialog::applySuggestedFilenamePattern(const QString& pattern)
+{
+    const QString trimmedPattern = pattern.trimmed();
+    if(!trimmedPattern.isEmpty() && m_filenamePattern->text().trimmed() == u"%filename%"_s) {
+        m_filenamePattern->setText(trimmedPattern);
+    }
+}
+
 void ConverterSetupDialog::accept()
 {
     if(!selectedEncoder()) {

--- a/src/gui/conversion/convertersetupdialog.h
+++ b/src/gui/conversion/convertersetupdialog.h
@@ -62,6 +62,8 @@ public:
     [[nodiscard]] QString askFolder() const;
     [[nodiscard]] bool showReport() const;
 
+    void applySuggestedFilenamePattern(const QString& pattern);
+
     void accept() override;
 
 private:

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -299,6 +299,8 @@ GuiApplication::GuiApplication(Application* core)
 {
     m_coverRepository->setPendingTrackCoverProvider(m_core->pendingTrackCoverProvider());
 
+    m_guiPluginContext.conversionService = m_conversionController;
+
     m_scriptParser.addProvider(playlistVariableProvider());
 
     QObject::connect(m_settings->settingsDialog(), &SettingsDialogController::opening, this, [this]() {

--- a/src/gui/metadatalookup/metadataapply.cpp
+++ b/src/gui/metadatalookup/metadataapply.cpp
@@ -21,11 +21,14 @@
 
 #include <QMap>
 
+#include <cmath>
 #include <functional>
 #include <ranges>
 #include <set>
 
 using namespace Qt::StringLiterals;
+
+constexpr int64_t MaxDurationDifferenceMs = 3000;
 
 namespace Fooyin {
 namespace {
@@ -177,5 +180,68 @@ MetadataApplyResult applyReleaseMetadata(const TrackList& localTracks, const Rel
     }
 
     return result;
+}
+
+std::optional<TrackList> applyAutomaticDiscMetadata(const TrackList& tracks, const Release& release,
+                                                    const QString& discId)
+{
+    if(tracks.empty() || discId.isEmpty()) {
+        return {};
+    }
+
+    const ReleaseMedium* matchingMedium{nullptr};
+    bool hasDiscIds{false};
+
+    for(const ReleaseMedium& medium : release.media) {
+        hasDiscIds = hasDiscIds || !medium.discIds.isEmpty();
+        if(!medium.discIds.contains(discId)) {
+            continue;
+        }
+        if(matchingMedium) {
+            return {};
+        }
+        matchingMedium = &medium;
+    }
+
+    if(!matchingMedium && !hasDiscIds && release.media.size() == 1) {
+        matchingMedium = &release.media.front();
+    }
+    if(!matchingMedium || matchingMedium->tracks.size() != tracks.size()) {
+        return {};
+    }
+
+    std::vector<TrackMatch> matches;
+    matches.reserve(tracks.size());
+
+    for(size_t index{0}; index < tracks.size(); ++index) {
+        const Track& local         = tracks.at(index);
+        const ReleaseTrack& remote = matchingMedium->tracks.at(index);
+        if(std::cmp_not_equal(remote.position, index + 1) || local.trackNumber().toInt() != remote.position
+           || remote.durationMs <= 0
+           || std::llabs(static_cast<int64_t>(local.duration()) - remote.durationMs) > MaxDurationDifferenceMs) {
+            return {};
+        }
+        matches.push_back({.localIndex = index, .remoteIndex = index, .confidence = 100, .ambiguous = false});
+    }
+
+    Release selectedRelease{release};
+    selectedRelease.media = {*matchingMedium};
+
+    const MetadataApplyResult applied = applyReleaseMetadata(tracks, selectedRelease, matches,
+                                                             {.policy = ExistingMetadataPolicy::ReplaceLookupFields,
+                                                              .writeGenres            = true,
+                                                              .writeReleaseIds        = true,
+                                                              .useOriginalReleaseDate = false});
+
+    TrackList updated{tracks};
+
+    for(size_t index{0}; index < applied.tracks.size(); ++index) {
+        const size_t localIndex = applied.trackIndices.at(index);
+        if(localIndex < updated.size()) {
+            updated.at(localIndex) = applied.tracks.at(index);
+        }
+    }
+
+    return updated;
 }
 } // namespace Fooyin

--- a/src/gui/metadatalookup/metadataapply.h
+++ b/src/gui/metadatalookup/metadataapply.h
@@ -23,6 +23,8 @@
 
 #include "metadatamatcher.h"
 
+#include <optional>
+
 namespace Fooyin {
 enum class ExistingMetadataPolicy : uint8_t
 {
@@ -58,4 +60,7 @@ struct MetadataApplyResult
 FYGUI_EXPORT MetadataApplyResult applyReleaseMetadata(const TrackList& localTracks, const Release& release,
                                                       const std::vector<TrackMatch>& matches,
                                                       const MetadataApplyOptions& options);
+
+[[nodiscard]] FYGUI_EXPORT std::optional<TrackList>
+applyAutomaticDiscMetadata(const TrackList& tracks, const Release& release, const QString& discId);
 } // namespace Fooyin

--- a/src/gui/metadatalookup/sources/musicbrainzmetadata.cpp
+++ b/src/gui/metadatalookup/sources/musicbrainzmetadata.cpp
@@ -514,8 +514,9 @@ void MusicBrainzMetadata::handleReply()
     m_active.reset();
     QObject::disconnect(reply, nullptr, this, nullptr);
 
-    const int status                               = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    const QByteArray retryAfter                    = reply->rawHeader("Retry-After");
+    const int status            = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QString reason        = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute).toString();
+    const QByteArray retryAfter = reply->rawHeader("Retry-After");
     const QNetworkReply::NetworkError networkError = reply->error();
     const QString networkErrorText                 = reply->errorString();
     const QByteArray data                          = reply->readAll();
@@ -534,7 +535,10 @@ void MusicBrainzMetadata::handleReply()
 
     if(networkError != QNetworkReply::NoError) {
         qCWarning(METADATA_LOOKUP) << "MusicBrainz request failed with HTTP" << status << networkErrorText;
-        Q_EMIT failed(tr("MusicBrainz request failed: %1").arg(networkErrorText));
+        const QString error
+            = status > 0 ? (reason.isEmpty() ? u"HTTP %1"_s.arg(status) : u"HTTP %1: %2"_s.arg(status).arg(reason))
+                         : networkErrorText;
+        Q_EMIT failed(tr("MusicBrainz request failed: %1").arg(error));
         finishOperation();
         return;
     }

--- a/src/gui/playlist/manager/playlistmanagermodel.cpp
+++ b/src/gui/playlist/manager/playlistmanagermodel.cpp
@@ -27,6 +27,7 @@
 #include <gui/guiconstants.h>
 #include <gui/iconloader.h>
 #include <gui/trackmimedata.h>
+#include <utils/helpers.h>
 #include <utils/stringutils.h>
 
 #include <QMimeData>

--- a/src/gui/playlist/playlistcontroller.h
+++ b/src/gui/playlist/playlistcontroller.h
@@ -22,6 +22,7 @@
 #include "playlist/playlistmodel.h"
 
 #include <core/player/playbackqueue.h>
+#include <core/player/playerdefs.h>
 #include <core/playlist/playlist.h>
 #include <core/playlist/playlistchangeset.h>
 #include <gui/playlist/currentplaylistcontroller.h>
@@ -59,7 +60,7 @@ class PlaylistController : public CurrentPlaylistController
     Q_OBJECT
 
 public:
-    PlaylistController(Application* app, QObject* parent = nullptr);
+    explicit PlaylistController(Application* app, QObject* parent = nullptr);
     ~PlaylistController() override;
 
     [[nodiscard]] PlayerController* playerController() const;

--- a/src/gui/selectioninfo/infopopulator.cpp
+++ b/src/gui/selectioninfo/infopopulator.cpp
@@ -201,7 +201,9 @@ void InfoPopulatorPrivate::addTrackMetadata(const Track& track, bool extended,
 
 void InfoPopulatorPrivate::addTrackLocation(int total, const Track& track)
 {
-    const bool isRemote = track.isRemote();
+    const bool isRemote    = track.isRemote();
+    const bool isVirtual   = track.isVirtual();
+    const bool isLocalFile = !isRemote && !isVirtual;
 
     checkAddEntryNode(u"FileName"_s, total > 1 ? InfoPopulator::tr("File Names") : InfoPopulator::tr("File Name"),
                       ItemParent::Location, track.filename());
@@ -215,13 +217,14 @@ void InfoPopulatorPrivate::addTrackLocation(int total, const Track& track)
         checkAddEntryNode(isRemote ? u"Url"_s : u"FilePath"_s,
                           isRemote ? InfoPopulator::tr("URL") : InfoPopulator::tr("File Path"), ItemParent::Location,
                           track.prettyFilepath());
-        if(track.subsong() >= 0) {
+        if(track.subsong() > 0 || (isVirtual && track.subsong() >= 0)) {
+            const int displayedSubsong = track.subsong() + (isVirtual ? 1 : 0);
             checkAddEntryNode(u"SubsongIndex"_s, InfoPopulator::tr("Subsong Index"), ItemParent::Location,
-                              track.subsong());
+                              QString::number(displayedSubsong));
         }
     }
 
-    if(!isRemote) {
+    if(isLocalFile) {
         checkAddEntryNode(
             u"FileSize"_s, total > 1 ? InfoPopulator::tr("Total Size") : InfoPopulator::tr("File Size"),
             ItemParent::Location, fileSize(track), InfoItem::Total,
@@ -239,7 +242,7 @@ void InfoPopulatorPrivate::addTrackLocation(int total, const Track& track)
     }
 
     if(total == 1) {
-        if(!isRemote && track.createdTime() > 0) {
+        if(isLocalFile && track.createdTime() > 0) {
             checkAddEntryNode(u"Created"_s, InfoPopulator::tr("Created"), ItemParent::Location, track.createdTime(),
                               InfoItem::Max, InfoItem::FormatUIntFunc{Utils::formatTimeMs});
         }

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -2,6 +2,7 @@ include(FooyinPluginSelection)
 
 set(FOOYIN_KNOWN_PLUGINS
     alsa
+    cdda
     discord
     equaliser
     fileops
@@ -74,6 +75,7 @@ if(UNIX AND NOT APPLE)
     list(
         APPEND
         FOOYIN_DEFAULT_PLUGINS
+        cdda
         mpris
         notify
         pulseaudio
@@ -81,7 +83,13 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WIN32)
-    list(APPEND FOOYIN_DEFAULT_PLUGINS wasapi mediacontrol thumbnailtoolbar)
+    list(
+        APPEND
+        FOOYIN_DEFAULT_PLUGINS
+        wasapi
+        mediacontrol
+        thumbnailtoolbar
+    )
 endif()
 
 if(APPLE)
@@ -106,9 +114,13 @@ elseif("alsa" IN_LIST FOOYIN_RESOLVED_PLUGINS)
 endif()
 
 if(UNIX AND NOT APPLE)
+    fooyin_add_selected_plugin(cdda)
     fooyin_add_selected_plugin(mpris)
     fooyin_add_selected_plugin(notify)
 else()
+    if("cdda" IN_LIST FOOYIN_RESOLVED_PLUGINS)
+        message(STATUS "cdda plugin is only available on Unix platforms other than macOS; skipping.")
+    endif()
     if("mpris" IN_LIST FOOYIN_RESOLVED_PLUGINS)
         message(STATUS "mpris plugin is only available on Unix platforms other than macOS; skipping.")
     endif()

--- a/src/plugins/cdda/CMakeLists.txt
+++ b/src/plugins/cdda/CMakeLists.txt
@@ -1,0 +1,46 @@
+if(NOT UNIX OR APPLE)
+    message(STATUS "Audio CD plugin is currently only available on Linux; skipping.")
+    return()
+endif()
+
+find_package(Cdio QUIET)
+if(NOT Cdio_FOUND)
+    message(STATUS "libcdio and libcdio-paranoia not found; skipping Audio CD plugin.")
+    return()
+endif()
+
+create_fooyin_plugin_internal(
+    cdda
+    DEPENDS Fooyin::Gui
+            Fooyin::GuiPrivate
+            Cdio::Cdio
+    SOURCES accuraterip.cpp
+            accuraterip.h
+            cddadecoder.cpp
+            cddadecoder.h
+            cddadrivemanager.cpp
+            cddadrivemanager.h
+            cddadrivesettings.cpp
+            cddadrivesettings.h
+            cddadrivesettingsdialog.cpp
+            cddadrivesettingsdialog.h
+            cddaplugin.cpp
+            cddaplugin.h
+            cddareader.cpp
+            cddareader.h
+            cddasectorreader.cpp
+            cddasectorreader.h
+            cddatoc.cpp
+            cddatoc.h
+            cddatypes.h
+            cddaurl.cpp
+            cddaurl.h
+            openaudiocddialog.cpp
+            openaudiocddialog.h
+            ripaudiocddialog.cpp
+            ripaudiocddialog.h
+            drive/cddrivebackend.cpp
+            drive/cddrivebackend.h
+            drive/libcdiodrivebackend.cpp
+            drive/libcdiodrivebackend.h
+)

--- a/src/plugins/cdda/accuraterip.cpp
+++ b/src/plugins/cdda/accuraterip.cpp
@@ -1,0 +1,370 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "accuraterip.h"
+
+#include "cddatoc.h"
+
+#include <QCoreApplication>
+#include <QRegularExpression>
+#include <QTextDocumentFragment>
+#include <QtEndian>
+
+#include <cstring>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+uint32_t digitSum(uint32_t value)
+{
+    uint32_t result{0};
+
+    while(true) {
+        result += value % 10;
+        value /= 10;
+
+        if(value == 0) {
+            break;
+        }
+    }
+
+    return result;
+}
+
+uint32_t readLe32(const QByteArray& data, qsizetype offset)
+{
+    return qFromLittleEndian<uint32_t>(data.constData() + offset);
+}
+
+QString normalisedDriveName(QString value)
+{
+    value = value.simplified().toUpper();
+
+    value.replace("HL-DT-ST"_L1, "LG ELECTRONICS"_L1);
+    value.replace("MATSHITA"_L1, "PANASONIC"_L1);
+    value.replace("JLMS"_L1, "LITE-ON"_L1);
+
+    static const QRegularExpression regex{u"[^A-Z0-9]"_s};
+    value.remove(regex);
+
+    return value;
+}
+} // namespace
+
+std::expected<AccurateRipDiscId, QString> accurateRipDiscId(const CdToc& toc)
+{
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(invalidTocUserMessage());
+    }
+    if(!std::ranges::all_of(toc.tracks, &CdTocTrack::isAudio)) {
+        return std::unexpected(QCoreApplication::translate(
+            "Fooyin::Cdda::AccurateRip", "AccurateRip verification of mixed-mode discs is not supported"));
+    }
+
+    AccurateRipDiscId result;
+    result.trackCount = static_cast<int>(toc.tracks.size());
+
+    for(int index{0}; std::cmp_less(index, toc.tracks.size()); ++index) {
+        const auto offset = static_cast<uint32_t>(toc.tracks.at(index).firstSector);
+        result.id1 += offset;
+        result.id2 += std::max(offset, 1U) * static_cast<uint32_t>(index + 1);
+    }
+
+    const auto leadout = static_cast<uint32_t>(toc.leadoutSector);
+    result.id1 += leadout;
+    result.id2 += std::max(leadout, 1U) * static_cast<uint32_t>(result.trackCount + 1);
+
+    uint32_t cddbSum{0};
+    for(const CdTocTrack& track : toc.tracks) {
+        cddbSum += digitSum(static_cast<uint32_t>((track.firstSector + LeadInSectors) / SectorsPerSecond));
+    }
+
+    const auto duration = static_cast<uint32_t>((toc.leadoutSector / SectorsPerSecond)
+                                                - (toc.tracks.front().firstSector / SectorsPerSecond));
+    result.cddbId       = ((cddbSum % 0xFFU) << 24) | (duration << 8) | static_cast<uint32_t>(result.trackCount);
+
+    return result;
+}
+
+QUrl accurateRipDiscUrl(const AccurateRipDiscId& id)
+{
+    const QString id1 = QString::number(id.id1, 16).rightJustified(8, u'0');
+    return QUrl{u"https://www.accuraterip.com/accuraterip/%1/%2/%3/dBAR-%4-%5-%6-%7.bin"_s.arg(id1.at(7))
+                    .arg(id1.at(6))
+                    .arg(id1.at(5))
+                    .arg(id.trackCount, 3, 10, u'0')
+                    .arg(id.id1, 8, 16, u'0')
+                    .arg(id.id2, 8, 16, u'0')
+                    .arg(id.cddbId, 8, 16, u'0')};
+}
+
+std::expected<std::vector<AccurateRipPressing>, QString> parseAccurateRipResponse(const QByteArray& data,
+                                                                                  const AccurateRipDiscId& expected)
+{
+    std::vector<AccurateRipPressing> result;
+
+    qsizetype offset{0};
+    while(offset < data.size()) {
+        if(data.size() - offset < 13) {
+            return std::unexpected(
+                QCoreApplication::translate("Fooyin::Cdda::AccurateRip", "Truncated AccurateRip response header"));
+        }
+
+        const auto tracks   = static_cast<uint8_t>(data.at(offset));
+        const uint32_t id1  = readLe32(data, offset + 1);
+        const uint32_t id2  = readLe32(data, offset + 5);
+        const uint32_t cddb = readLe32(data, offset + 9);
+
+        offset += 13;
+
+        if(tracks < 1 || tracks > MaximumTracks || data.size() - offset < tracks * 9LL) {
+            return std::unexpected(
+                QCoreApplication::translate("Fooyin::Cdda::AccurateRip", "Invalid AccurateRip response record"));
+        }
+
+        AccurateRipPressing pressing;
+        pressing.reserve(tracks);
+
+        for(int track{0}; std::cmp_less(track, tracks); ++track) {
+            pressing.push_back({.confidence = static_cast<uint8_t>(data.at(offset)),
+                                .crc        = readLe32(data, offset + 1),
+                                .crc2       = readLe32(data, offset + 5)});
+            offset += 9;
+        }
+
+        if(std::cmp_equal(tracks, expected.trackCount) && id1 == expected.id1 && id2 == expected.id2
+           && cddb == expected.cddbId) {
+            result.push_back(std::move(pressing));
+        }
+    }
+
+    if(result.empty()) {
+        return std::unexpected(QCoreApplication::translate("Fooyin::Cdda::AccurateRip",
+                                                           "AccurateRip response did not contain the requested disc"));
+    }
+
+    return result;
+}
+
+std::vector<AccurateRipDriveOffset> parseAccurateRipDriveOffsets(const QByteArray& html)
+{
+    static const QRegularExpression row{uR"(<tr\b[^>]*>(.*?)</tr\s*>)"_s,
+                                        QRegularExpression::CaseInsensitiveOption
+                                            | QRegularExpression::DotMatchesEverythingOption};
+    static const QRegularExpression cell{uR"(<t[dh]\b[^>]*>(.*?)</t[dh]\s*>)"_s,
+                                         QRegularExpression::CaseInsensitiveOption
+                                             | QRegularExpression::DotMatchesEverythingOption};
+    static const QRegularExpression signedInteger{uR"(^[+-]?\d+$)"_s};
+    static const QRegularExpression unsignedInteger{uR"(^\d+$)"_s};
+    static const QRegularExpression percentage{uR"(^(\d+)\s*%$)"_s};
+
+    std::vector<AccurateRipDriveOffset> result;
+
+    auto rowMatch = row.globalMatch(QString::fromUtf8(html));
+    while(rowMatch.hasNext()) {
+        std::vector<QString> cells;
+
+        const QString rowHtml = rowMatch.next().captured(1);
+        auto cellMatch        = cell.globalMatch(rowHtml);
+        while(cellMatch.hasNext()) {
+            const QString cellHtml = cellMatch.next().captured(1);
+            cells.push_back(QTextDocumentFragment::fromHtml(cellHtml).toPlainText().simplified());
+        }
+
+        if(cells.size() < 2 || cells.front().isEmpty()) {
+            continue;
+        }
+
+        const QString& correctionText = cells.at(1);
+        const bool purged             = correctionText.compare("[Purged]"_L1, Qt::CaseInsensitive) == 0;
+        if(purged) {
+            result.push_back({.name = std::move(cells.front()), .purged = true});
+            continue;
+        }
+        if(cells.size() < 4 || !signedInteger.match(correctionText).hasMatch()
+           || !unsignedInteger.match(cells.at(2)).hasMatch()) {
+            continue;
+        }
+
+        const auto percentageMatch = percentage.match(cells.at(3));
+        if(!percentageMatch.hasMatch()) {
+            continue;
+        }
+
+        bool correctionOk{false};
+        bool submissionsOk{false};
+        bool percentageOk{false};
+        const int correction       = correctionText.toInt(&correctionOk);
+        const int submissions      = cells.at(2).toInt(&submissionsOk);
+        const int agreementPercent = percentageMatch.captured(1).toInt(&percentageOk);
+        if(!correctionOk || !submissionsOk || !percentageOk || agreementPercent > 100) {
+            continue;
+        }
+
+        result.push_back({.name                   = std::move(cells.front()),
+                          .correctionSampleFrames = correction,
+                          .submissions            = submissions,
+                          .agreementPercent       = agreementPercent,
+                          .purged                 = false});
+    }
+
+    return result;
+}
+
+std::optional<AccurateRipDriveOffset> findAccurateRipDriveOffset(const std::vector<AccurateRipDriveOffset>& offsets,
+                                                                 const QString& vendor, const QString& model)
+{
+    std::optional<AccurateRipDriveOffset> result;
+
+    const QString identity = normalisedDriveName(vendor + u' ' + model);
+    for(const auto& offset : offsets) {
+        if(normalisedDriveName(offset.name) != identity) {
+            continue;
+        }
+
+        if(result
+           && (result->correctionSampleFrames != offset.correctionSampleFrames || result->purged != offset.purged)) {
+            return {};
+        }
+
+        if(!result || offset.submissions > result->submissions) {
+            result = offset;
+        }
+    }
+
+    return result;
+}
+
+AccurateRipVerifier::AccurateRipVerifier(CdToc toc, std::vector<AccurateRipPressing> pressings)
+    : m_toc{std::move(toc)}
+    , m_pressings{std::move(pressings)}
+{ }
+
+AccurateRipVerifier::~AccurateRipVerifier() = default;
+
+AccurateRipVerifier::State* AccurateRipVerifier::stateFor(const Track& track)
+{
+    const auto state
+        = std::ranges::find_if(m_states, [&track](const State& value) { return value.track.sameIdentityAs(track); });
+    return state == m_states.end() ? nullptr : &*state;
+}
+
+void AccurateRipVerifier::trackStarted(const Track& track, const AudioFormat& format)
+{
+    const std::scoped_lock lock{m_mutex};
+
+    const int index       = track.subsong();
+    const bool validIndex = index >= 0 && std::cmp_less(index, m_toc.tracks.size());
+    const uint64_t frames
+        = validIndex
+            ? static_cast<uint64_t>(m_toc.tracks.at(index).endSectorExclusive - m_toc.tracks.at(index).firstSector)
+                  * FramesPerSector
+            : 0;
+
+    m_states.push_back({.track       = track,
+                        .totalFrames = frames,
+                        .validFormat = validIndex && format.sampleFormat() == SampleFormat::S16
+                                    && format.sampleRate() == 44100 && format.channelCount() == 2});
+}
+
+void AccurateRipVerifier::sourceAudio(const Track& track, const AudioBuffer& buffer)
+{
+    const std::scoped_lock lock{m_mutex};
+
+    State* state = stateFor(track);
+    if(!state || !state->validFormat) {
+        return;
+    }
+
+    const auto data = buffer.constData();
+    for(size_t offset{0}; offset + sizeof(uint32_t) <= data.size(); offset += sizeof(uint32_t)) {
+        int16_t left{0};
+        int16_t right{0};
+        std::memcpy(&left, data.data() + offset, sizeof(left));
+        std::memcpy(&right, data.data() + offset + sizeof(left), sizeof(right));
+
+        const uint32_t sample
+            = static_cast<uint16_t>(left) | (static_cast<uint32_t>(static_cast<uint16_t>(right)) << 16);
+        const uint64_t position                   = ++state->position;
+        constexpr uint64_t ChecksumBoundaryFrames = 5L * FramesPerSector;
+        const uint64_t first                      = track.subsong() == 0 ? ChecksumBoundaryFrames : 0;
+        const uint64_t last = std::cmp_equal(track.subsong() + 1, m_toc.tracks.size())
+                                ? state->totalFrames - std::min(state->totalFrames, ChecksumBoundaryFrames)
+                                : state->totalFrames;
+
+        if(position >= first && position <= last) {
+            const uint64_t product = static_cast<uint64_t>(sample) * position;
+            state->crcV1 += static_cast<uint32_t>(product);
+            state->crcV2 += static_cast<uint32_t>(product) + static_cast<uint32_t>(product >> 32);
+        }
+    }
+}
+
+void AccurateRipVerifier::trackFinished(const Track& track, bool complete)
+{
+    const std::scoped_lock lock{m_mutex};
+
+    if(State* state = stateFor(track)) {
+        state->complete = complete && state->position == state->totalFrames;
+    }
+}
+
+std::vector<AccurateRipTrackResult> AccurateRipVerifier::results() const
+{
+    const std::scoped_lock lock{m_mutex};
+
+    std::vector<AccurateRipTrackResult> result;
+    result.reserve(m_states.size());
+
+    for(const State& state : m_states) {
+        AccurateRipTrackResult trackResult{.track        = state.track,
+                                           .status       = AccurateRipVerifyStatus::Incomplete,
+                                           .crcV1        = state.crcV1,
+                                           .crcV2        = state.crcV2,
+                                           .confidence   = 0,
+                                           .databaseCrcs = {}};
+        if(!state.validFormat) {
+            trackResult.status = AccurateRipVerifyStatus::InvalidFormat;
+        }
+        else if(!state.complete) {
+            trackResult.status = AccurateRipVerifyStatus::Incomplete;
+        }
+        else {
+            trackResult.status = AccurateRipVerifyStatus::Mismatch;
+            const int index    = state.track.subsong();
+            for(const auto& pressing : m_pressings) {
+                if(index < 0 || std::cmp_greater_equal(index, pressing.size())) {
+                    continue;
+                }
+                const auto& expected = pressing.at(index);
+                if(!std::ranges::contains(trackResult.databaseCrcs, expected.crc)) {
+                    trackResult.databaseCrcs.push_back(expected.crc);
+                }
+                if(state.crcV1 == expected.crc || state.crcV2 == expected.crc) {
+                    trackResult.status = AccurateRipVerifyStatus::Verified;
+                    trackResult.confidence += static_cast<int>(expected.confidence);
+                }
+            }
+        }
+        result.push_back(std::move(trackResult));
+    }
+
+    return result;
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/accuraterip.cpp
+++ b/src/plugins/cdda/accuraterip.cpp
@@ -108,10 +108,10 @@ QUrl accurateRipDiscUrl(const AccurateRipDiscId& id)
     return QUrl{u"https://www.accuraterip.com/accuraterip/%1/%2/%3/dBAR-%4-%5-%6-%7.bin"_s.arg(id1.at(7))
                     .arg(id1.at(6))
                     .arg(id1.at(5))
-                    .arg(id.trackCount, 3, 10, u'0')
-                    .arg(id.id1, 8, 16, u'0')
-                    .arg(id.id2, 8, 16, u'0')
-                    .arg(id.cddbId, 8, 16, u'0')};
+                    .arg(id.trackCount, 3, 10, QChar{u'0'})
+                    .arg(id.id1, 8, 16, QChar{u'0'})
+                    .arg(id.id2, 8, 16, QChar{u'0'})
+                    .arg(id.cddbId, 8, 16, QChar{u'0'})};
 }
 
 std::expected<std::vector<AccurateRipPressing>, QString> parseAccurateRipResponse(const QByteArray& data,
@@ -353,7 +353,7 @@ std::vector<AccurateRipTrackResult> AccurateRipVerifier::results() const
                     continue;
                 }
                 const auto& expected = pressing.at(index);
-                if(!std::ranges::contains(trackResult.databaseCrcs, expected.crc)) {
+                if(std::ranges::find(trackResult.databaseCrcs, expected.crc) == trackResult.databaseCrcs.end()) {
                     trackResult.databaseCrcs.push_back(expected.crc);
                 }
                 if(state.crcV1 == expected.crc || state.crcV2 == expected.crc) {

--- a/src/plugins/cdda/accuraterip.h
+++ b/src/plugins/cdda/accuraterip.h
@@ -1,0 +1,118 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddatypes.h"
+
+#include <core/engine/conversion/conversionrunner.h>
+
+#include <QByteArray>
+#include <QUrl>
+
+#include <expected>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace Fooyin::Cdda {
+struct AccurateRipDiscId
+{
+    uint32_t id1{0};
+    uint32_t id2{0};
+    uint32_t cddbId{0};
+    int trackCount{0};
+
+    bool operator==(const AccurateRipDiscId&) const = default;
+};
+
+struct AccurateRipChecksum
+{
+    uint32_t confidence{0};
+    uint32_t crc{0};
+    uint32_t crc2{0};
+};
+using AccurateRipPressing = std::vector<AccurateRipChecksum>;
+
+struct AccurateRipDriveOffset
+{
+    QString name;
+    int correctionSampleFrames{0};
+    int submissions{0};
+    int agreementPercent{0};
+    bool purged{false};
+};
+
+enum class AccurateRipVerifyStatus : uint8_t
+{
+    Verified = 0,
+    Mismatch,
+    Incomplete,
+    InvalidFormat,
+};
+
+struct AccurateRipTrackResult
+{
+    Track track;
+    AccurateRipVerifyStatus status{AccurateRipVerifyStatus::Incomplete};
+    uint32_t crcV1{0};
+    uint32_t crcV2{0};
+    int confidence{0};
+    std::vector<uint32_t> databaseCrcs;
+};
+
+std::expected<AccurateRipDiscId, QString> accurateRipDiscId(const CdToc& toc);
+QUrl accurateRipDiscUrl(const AccurateRipDiscId& id);
+
+std::expected<std::vector<AccurateRipPressing>, QString> parseAccurateRipResponse(const QByteArray& data,
+                                                                                  const AccurateRipDiscId& expected);
+std::vector<AccurateRipDriveOffset> parseAccurateRipDriveOffsets(const QByteArray& html);
+std::optional<AccurateRipDriveOffset> findAccurateRipDriveOffset(const std::vector<AccurateRipDriveOffset>& offsets,
+                                                                 const QString& vendor, const QString& model);
+
+class AccurateRipVerifier : public ConversionInputObserver
+{
+public:
+    AccurateRipVerifier(CdToc toc, std::vector<AccurateRipPressing> pressings);
+    ~AccurateRipVerifier() override;
+
+    void trackStarted(const Track& track, const AudioFormat& format) override;
+    void sourceAudio(const Track& track, const AudioBuffer& buffer) override;
+    void trackFinished(const Track& track, bool complete) override;
+
+    [[nodiscard]] std::vector<AccurateRipTrackResult> results() const;
+
+private:
+    struct State
+    {
+        Track track;
+        uint64_t totalFrames{0};
+        uint64_t position{0};
+        uint32_t crcV1{0};
+        uint32_t crcV2{0};
+        bool validFormat{false};
+        bool complete{false};
+    };
+    [[nodiscard]] State* stateFor(const Track& track);
+
+    CdToc m_toc;
+    std::vector<AccurateRipPressing> m_pressings;
+    std::vector<State> m_states;
+    mutable std::mutex m_mutex;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cdda.json.in
+++ b/src/plugins/cdda/cdda.json.in
@@ -1,0 +1,15 @@
+{
+    "Name" : "Audio CD",
+    "Version" : "${FOOYIN_VERSION}",
+    "Author" : "fooyin",
+    "Copyright" : "Copyright © 2026, Luke Taylor <luket@pm.me>",
+    "License" : [ "Fooyin is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.",
+                  "",
+                  "Fooyin is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.",
+                  "",
+                  "You should have received a copy of the GNU General Public License along with Fooyin.  If not, see <http://www.gnu.org/licenses/>"
+                ],
+    "Category" : "Audio.Input",
+    "Description" : "Plays and extracts audio CDs using libcdio",
+    "Url" : "https://github.com/fooyin/fooyin"
+}

--- a/src/plugins/cdda/cddadecoder.cpp
+++ b/src/plugins/cdda/cddadecoder.cpp
@@ -1,0 +1,410 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddadecoder.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <QLoggingCategory>
+
+#include <algorithm>
+#include <limits>
+
+using namespace Qt::StringLiterals;
+
+Q_LOGGING_CATEGORY(CDDA_DECODER, "fy.cdda.decoder")
+
+constexpr int SectorsPerRead = 16;
+constexpr int BytesPerFrame  = 4;
+
+namespace Fooyin::Cdda {
+CddaDecoder::CddaDecoder(std::shared_ptr<CdDriveManager> driveManager,
+                         std::shared_ptr<const CdDriveSettingsProvider> settingsProvider)
+    : m_driveManager{std::move(driveManager)}
+    , m_settingsProvider{std::move(settingsProvider)}
+    , m_format{SampleFormat::S16, 44100, 2}
+    , m_subsong{-1}
+    , m_nextSector{0}
+    , m_nextLogicalFrame{0}
+    , m_consumedFrames{0}
+    , m_bufferPosition{0}
+    , m_activeSession{nullptr}
+    , m_initialised{false}
+    , m_readFailed{false}
+    , m_forConversion{false}
+    , m_readOffsetFrames{0}
+{ }
+
+CddaDecoder::~CddaDecoder()
+{
+    stop();
+}
+
+QStringList CddaDecoder::extensions() const
+{
+    return {};
+}
+
+QStringList CddaDecoder::supportedSchemes() const
+{
+    return {QString::fromLatin1(Scheme)};
+}
+
+bool CddaDecoder::isSeekable() const
+{
+    return m_initialised;
+}
+
+bool CddaDecoder::allowsConcurrentDecoding() const
+{
+    return false;
+}
+
+int CddaDecoder::playbackPrebufferMs() const
+{
+    return 1000;
+}
+
+std::optional<AudioFormat> CddaDecoder::init(const AudioSource& source, const Track& track, DecoderOptions options)
+{
+    stop();
+    m_error.clear();
+    m_warnings.clear();
+
+    const auto discId = discIdFromCddaUrl(source.filepath);
+    if(!discId || source.filepath != track.filepath()) {
+        qCWarning(CDDA_DECODER) << "Invalid audio CD decoder source:"
+                                << "source=" << source.filepath << "track=" << track.filepath();
+        return {};
+    }
+
+    auto observation = m_driveManager->resolveDisc(*discId);
+    if(!observation) {
+        qCWarning(CDDA_DECODER) << "Failed to resolve audio CD source:"
+                                << "source=" << source.filepath
+                                << "errorCode=" << static_cast<int>(observation.error().code)
+                                << "error=" << observation.error().message;
+        return {};
+    }
+    if(!observation->toc) {
+        qCWarning(CDDA_DECODER) << "Resolved audio CD source has no TOC:"
+                                << "source=" << source.filepath << "drive=" << observation->drive.id;
+        return {};
+    }
+
+    const auto tocTrack = audioTrackForSubsong(*observation->toc, track.subsong());
+    if(!tocTrack) {
+        qCWarning(CDDA_DECODER) << "Audio CD track index is out of range:"
+                                << "source=" << source.filepath << "subsong=" << track.subsong();
+        return {};
+    }
+
+    m_discId           = *discId;
+    m_observedDriveId  = observation->drive.id;
+    m_toc              = *observation->toc;
+    m_track            = *tocTrack;
+    m_subsong          = track.subsong();
+    m_nextSector       = m_track.firstSector;
+    m_nextLogicalFrame = 0;
+    m_consumedFrames   = 0;
+    m_forConversion    = options.testFlag(ForConversion);
+    m_initialised      = true;
+
+    return m_format;
+}
+
+void CddaDecoder::stop()
+{
+    releaseLease();
+
+    m_discId.clear();
+    m_observedDriveId.clear();
+    m_toc              = {};
+    m_track            = {};
+    m_subsong          = -1;
+    m_nextSector       = 0;
+    m_nextLogicalFrame = 0;
+    m_consumedFrames   = 0;
+    m_buffer.clear();
+    m_bufferPosition   = 0;
+    m_initialised      = false;
+    m_readFailed       = false;
+    m_forConversion    = false;
+    m_readOffsetFrames = 0;
+}
+
+void CddaDecoder::seek(uint64_t pos)
+{
+    if(!m_initialised) {
+        return;
+    }
+
+    const auto trackSectors = static_cast<uint64_t>(m_track.endSectorExclusive - m_track.firstSector);
+    const auto duration     = durationForSectors(trackSectors);
+    const uint64_t clamped  = std::min(pos, duration.value_or(0));
+    const uint64_t relativeSector
+        = duration && pos >= *duration
+            ? trackSectors
+            : std::min(trackSectors, clamped > std::numeric_limits<uint64_t>::max() / SectorsPerSecond
+                                         ? trackSectors
+                                         : (clamped * SectorsPerSecond) / 1000);
+
+    m_nextSector       = m_track.firstSector + static_cast<int>(relativeSector);
+    m_nextLogicalFrame = relativeSector * FramesPerSector;
+    m_consumedFrames   = relativeSector * FramesPerSector;
+    m_buffer.clear();
+    m_bufferPosition = 0;
+    m_error.clear();
+    m_readFailed = false;
+}
+
+AudioDecoder::ReadResult CddaDecoder::readAudio(size_t bytes)
+{
+    if(!m_initialised) {
+        return ReadResult::errorResult(tr("Audio CD decoder is not initialised"));
+    }
+
+    if(m_readFailed) {
+        return ReadResult::errorResult(m_error);
+    }
+    if(abortToken().stop_requested()) {
+        return ReadResult::errorResult(tr("Audio CD read was cancelled"));
+    }
+
+    const size_t alignedRequest = bytes - (bytes % BytesPerFrame);
+    if(alignedRequest == 0) {
+        return ReadResult::needMoreInput();
+    }
+
+    static constexpr size_t maximumRequest = std::numeric_limits<int>::max() - (BytesPerFrame - 1);
+    const auto request                     = static_cast<qsizetype>(std::min(alignedRequest, maximumRequest));
+
+    AudioBuffer output{m_format, currentTimestamp()};
+    output.reserve(request);
+
+    while(output.byteCount() < request) {
+        if(m_forConversion && output.byteCount() > 0 && m_bufferPosition >= m_buffer.size()) {
+            break;
+        }
+
+        const qsizetype buffered = m_buffer.size() - m_bufferPosition;
+        if(buffered > 0) {
+            const qsizetype count = std::min(buffered, request - output.byteCount());
+            output.append(reinterpret_cast<const std::byte*>(m_buffer.constData() + m_bufferPosition), count);
+            m_bufferPosition += count;
+            m_consumedFrames += static_cast<uint64_t>(count / BytesPerFrame);
+            if(m_bufferPosition == m_buffer.size()) {
+                m_buffer.clear();
+                m_bufferPosition = 0;
+            }
+
+            continue;
+        }
+
+        const uint64_t trackFrames
+            = static_cast<uint64_t>(m_track.endSectorExclusive - m_track.firstSector) * FramesPerSector;
+        if((m_forConversion && m_nextLogicalFrame >= trackFrames)
+           || (!m_forConversion && m_nextSector >= m_track.endSectorExclusive)) {
+            break;
+        }
+
+        if(!acquireLease()) {
+            m_readFailed = true;
+            break;
+        }
+
+        const qsizetype remainingBytes = request - output.byteCount();
+        if(m_forConversion) {
+            const int requestedFrames
+                = static_cast<int>(std::min<uint64_t>(remainingBytes / BytesPerFrame, MaximumFramesPerPolicyRead));
+            const int frameCount
+                = static_cast<int>(std::min<uint64_t>(requestedFrames, trackFrames - m_nextLogicalFrame));
+            auto read = m_sectorReader->readCorrectedFrames(m_toc, m_track, m_nextLogicalFrame, frameCount,
+                                                            m_readOffsetFrames);
+            if(!read) {
+                setReadError(read.error());
+                break;
+            }
+
+            m_nextLogicalFrame += static_cast<uint64_t>(read->framesRead);
+            m_buffer         = std::move(read->pcm);
+            m_bufferPosition = 0;
+            continue;
+        }
+
+        const int requestedSectors
+            = std::clamp(static_cast<int>((remainingBytes / BytesPerSector) + (remainingBytes % BytesPerSector != 0)),
+                         1, SectorsPerRead);
+        const int count = std::min(requestedSectors, m_track.endSectorExclusive - m_nextSector);
+        auto read       = m_lease->session()->readAudioSectors(m_nextSector, count);
+        if(!read) {
+            setReadError(read.error());
+            break;
+        }
+
+        if(const auto valid = validateSectorRead(*read, count); !valid) {
+            setReadError(valid.error());
+            break;
+        }
+
+        if(read->sectorsRead == 0) {
+            setReadError(CdError{
+                .code = CdDriveError::ReadFailed, .message = tr("CD drive returned no audio data"), .platformCode = 0});
+            break;
+        }
+
+        m_nextSector += read->sectorsRead;
+        m_buffer         = std::move(read->pcm);
+        m_bufferPosition = 0;
+    }
+
+    if(output.byteCount() > 0) {
+        return ReadResult::data(std::move(output));
+    }
+
+    if(m_readFailed) {
+        qCWarning(CDDA_DECODER) << "Audio CD read failed:"
+                                << "subsong=" << m_subsong << "nextSector=" << m_nextSector
+                                << "endSectorExclusive=" << m_track.endSectorExclusive << "error=" << m_error;
+        return ReadResult::errorResult(m_error);
+    }
+
+    releaseLease();
+    return ReadResult::endOfStream();
+}
+
+AudioBuffer CddaDecoder::readBuffer(size_t bytes)
+{
+    auto result = readAudio(bytes);
+    return result.status == ReadStatus::DecodedAudio ? std::move(result.buffer) : AudioBuffer{};
+}
+
+QStringList CddaDecoder::takeWarnings()
+{
+    if(m_sectorReader) {
+        m_warnings.append(m_sectorReader->takeWarnings());
+    }
+    return std::exchange(m_warnings, {});
+}
+
+void CddaDecoder::interruptRead()
+{
+    const std::scoped_lock lock{m_sessionMutex};
+    if(m_activeSession) {
+        m_activeSession->cancel();
+    }
+}
+
+bool CddaDecoder::acquireLease()
+{
+    if(m_lease) {
+        return true;
+    }
+
+    if(abortToken().stop_requested()) {
+        m_error = tr("Audio CD read was cancelled");
+        return false;
+    }
+
+    auto lease = m_driveManager->acquire(m_discId);
+    if(!lease) {
+        m_error = lease.error().message;
+        qCWarning(CDDA_DECODER) << "Failed to acquire audio CD drive:"
+                                << "subsong=" << m_subsong << "error=" << m_error;
+        return false;
+    }
+
+    const auto actualTrack = audioTrackForSubsong(lease->toc(), m_subsong);
+    if(!actualTrack || *actualTrack != m_track) {
+        m_error = tr("The disc in the CD drive has changed");
+        return false;
+    }
+
+    m_lease.emplace(std::move(*lease));
+    qCDebug(CDDA_DECODER) << "Acquired audio CD drive:"
+                          << "subsong=" << m_subsong << "drive=" << m_lease->drive().id;
+
+    if(m_forConversion) {
+        const CdDriveSettings settings = normaliseDriveSettings(m_settingsProvider->settingsForDrive(m_lease->drive()));
+
+        m_readOffsetFrames = settings.readOffsetFrames;
+
+        if(settings.readSpeedLimit > 0 && m_lease->drive().supportsSpeedLimit) {
+            if(const auto speed = m_lease->session()->setReadSpeed(settings.readSpeedLimit); !speed) {
+                m_warnings.push_back(tr("Could not limit CD read speed: %1").arg(speed.error().message));
+            }
+        }
+
+        m_sectorReader = std::make_unique<CddaSectorReader>(m_lease->session(), settings.security, abortToken());
+        qCDebug(CDDA_DECODER) << "Configured audio CD extraction:"
+                              << "subsong=" << m_subsong << "security=" << static_cast<int>(settings.security)
+                              << "readOffsetFrames=" << m_readOffsetFrames
+                              << "readSpeedLimit=" << settings.readSpeedLimit;
+
+        if(!m_observedDriveId.isEmpty() && m_observedDriveId != m_lease->drive().id) {
+            m_warnings.push_back(
+                tr("The selected CD drive became unavailable; extraction settings for %1 are being used")
+                    .arg(m_lease->drive().displayName));
+        }
+    }
+
+    {
+        const std::scoped_lock lock{m_sessionMutex};
+        m_activeSession = m_lease->session();
+    }
+
+    return true;
+}
+
+void CddaDecoder::releaseLease()
+{
+    if(m_sectorReader) {
+        m_warnings.append(m_sectorReader->takeWarnings());
+        m_sectorReader.reset();
+    }
+
+    {
+        const std::scoped_lock lock{m_sessionMutex};
+        m_activeSession = nullptr;
+    }
+
+    m_lease.reset();
+}
+
+void CddaDecoder::setReadError(CdError error)
+{
+    if(m_lease) {
+        m_driveManager->invalidateDrive(m_lease->drive().id);
+    }
+
+    m_error      = std::move(error.message);
+    m_readFailed = true;
+
+    qCWarning(CDDA_DECODER) << "Audio CD device read error:"
+                            << "subsong=" << m_subsong << "nextSector=" << m_nextSector
+                            << "endSectorExclusive=" << m_track.endSectorExclusive << "error=" << m_error;
+
+    releaseLease();
+}
+
+uint64_t CddaDecoder::currentTimestamp() const
+{
+    return (m_consumedFrames * 1000) / static_cast<uint64_t>(m_format.sampleRate());
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadecoder.h
+++ b/src/plugins/cdda/cddadecoder.h
@@ -1,0 +1,91 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddadrivemanager.h"
+#include "cddadrivesettings.h"
+
+#include <core/engine/audioinput.h>
+
+#include <QByteArray>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace Fooyin::Cdda {
+class CddaDecoder : public AudioDecoder
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::CddaDecoder)
+
+public:
+    explicit CddaDecoder(std::shared_ptr<CdDriveManager> driveManager,
+                         std::shared_ptr<const CdDriveSettingsProvider> settingsProvider = {});
+    ~CddaDecoder() override;
+
+    [[nodiscard]] QStringList extensions() const override;
+    [[nodiscard]] QStringList supportedSchemes() const override;
+    [[nodiscard]] bool isSeekable() const override;
+    [[nodiscard]] bool allowsConcurrentDecoding() const override;
+    [[nodiscard]] int playbackPrebufferMs() const override;
+
+    std::optional<AudioFormat> init(const AudioSource& source, const Track& track, DecoderOptions options) override;
+    void stop() override;
+    void seek(uint64_t pos) override;
+    ReadResult readAudio(size_t bytes) override;
+    AudioBuffer readBuffer(size_t bytes) override;
+    [[nodiscard]] QStringList takeWarnings() override;
+
+protected:
+    void interruptRead() override;
+
+private:
+    [[nodiscard]] bool acquireLease();
+    void releaseLease();
+    void setReadError(CdError error);
+    [[nodiscard]] uint64_t currentTimestamp() const;
+
+    std::shared_ptr<CdDriveManager> m_driveManager;
+    std::shared_ptr<const CdDriveSettingsProvider> m_settingsProvider;
+
+    AudioFormat m_format;
+    QString m_discId;
+    QString m_observedDriveId;
+    QString m_error;
+    QStringList m_warnings;
+    CdToc m_toc;
+    CdTocTrack m_track;
+    int m_subsong;
+    int m_nextSector;
+    uint64_t m_nextLogicalFrame;
+    uint64_t m_consumedFrames;
+    QByteArray m_buffer;
+    qsizetype m_bufferPosition;
+    std::optional<CdDriveLease> m_lease;
+    std::unique_ptr<CddaSectorReader> m_sectorReader;
+
+    mutable std::mutex m_sessionMutex;
+    CdDriveSession* m_activeSession;
+
+    bool m_initialised;
+    bool m_readFailed;
+    bool m_forConversion;
+    int m_readOffsetFrames;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadrivemanager.cpp
+++ b/src/plugins/cdda/cddadrivemanager.cpp
@@ -1,0 +1,637 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddadrivemanager.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+struct CdDriveAccessState
+{
+    std::mutex mutex;
+    std::unordered_set<QString> reservedDrives;
+};
+
+class CdDriveManagerPrivate
+{
+public:
+    explicit CdDriveManagerPrivate(std::unique_ptr<CdDriveBackend> backend, std::chrono::milliseconds cacheLifetime)
+        : m_backend{std::move(backend)}
+        , m_cacheLifetime{cacheLifetime}
+        , m_accessState{std::make_shared<CdDriveAccessState>()}
+    { }
+
+    std::unique_ptr<CdDriveBackend> m_backend;
+    std::chrono::milliseconds m_cacheLifetime;
+    std::shared_ptr<CdDriveAccessState> m_accessState;
+    std::mutex m_mutex;
+    std::unordered_map<QString, CdDriveObservation> m_cache;
+    std::unordered_map<QString, QString> m_preferredDrives;
+    std::chrono::steady_clock::time_point m_lastRefresh;
+    uint64_t m_nextGeneration{1};
+    bool m_cacheValid{false};
+};
+
+namespace {
+CdError driveBusyError()
+{
+    return {.code         = CdDriveError::DriveBusy,
+            .message      = CdDriveManager::tr("The CD drive is already in use"),
+            .platformCode = 0};
+}
+
+CdDriveObservation errorObservation(CdDriveInfo drive, CdError error)
+{
+    CdDriveObservation observation;
+    observation.drive = std::move(drive);
+    observation.error = std::move(error);
+    return observation;
+}
+
+class DriveReservation
+{
+public:
+    DriveReservation(std::shared_ptr<CdDriveAccessState> state, QString driveId)
+        : m_state{std::move(state)}
+        , m_driveId{std::move(driveId)}
+    { }
+
+    ~DriveReservation()
+    {
+        release();
+    }
+
+    DriveReservation(const DriveReservation&)            = delete;
+    DriveReservation& operator=(const DriveReservation&) = delete;
+
+    DriveReservation(DriveReservation&& other) noexcept
+        : m_state{std::move(other.m_state)}
+        , m_driveId{std::move(other.m_driveId)}
+    { }
+
+    DriveReservation& operator=(DriveReservation&& other) noexcept
+    {
+        if(this != &other) {
+            release();
+            m_state   = std::move(other.m_state);
+            m_driveId = std::move(other.m_driveId);
+        }
+        return *this;
+    }
+
+    std::pair<std::shared_ptr<CdDriveAccessState>, QString> take()
+    {
+        auto ownership = std::pair{std::move(m_state), std::move(m_driveId)};
+        m_state.reset();
+        m_driveId.clear();
+        return ownership;
+    }
+
+private:
+    void release()
+    {
+        if(m_state && !m_driveId.isEmpty()) {
+            const std::scoped_lock lock{m_state->mutex};
+            m_state->reservedDrives.erase(m_driveId);
+        }
+        m_driveId.clear();
+        m_state.reset();
+    }
+
+    std::shared_ptr<CdDriveAccessState> m_state;
+    QString m_driveId;
+};
+
+class ReservedDriveSession
+{
+public:
+    ReservedDriveSession(DriveReservation reservation, std::expected<CdDriveBackend::OpenedDrive, CdError> opened)
+        : m_reservation{std::move(reservation)}
+        , m_opened{std::move(opened)}
+    { }
+
+    ~ReservedDriveSession()
+    {
+        if(m_opened) {
+            m_opened->session.reset();
+        }
+    }
+
+    ReservedDriveSession(const ReservedDriveSession&)            = delete;
+    ReservedDriveSession& operator=(const ReservedDriveSession&) = delete;
+    ReservedDriveSession(ReservedDriveSession&&) noexcept        = default;
+    ReservedDriveSession& operator=(ReservedDriveSession&&)      = delete;
+
+    std::expected<CdDriveBackend::OpenedDrive, CdError>& opened()
+    {
+        return m_opened;
+    }
+
+    DriveReservation takeReservation()
+    {
+        return std::move(m_reservation);
+    }
+
+private:
+    // The session is reset in the destructor before this reservation is released
+    DriveReservation m_reservation;
+    std::expected<CdDriveBackend::OpenedDrive, CdError> m_opened;
+};
+
+std::expected<DriveReservation, CdError> reserveDrive(const std::shared_ptr<CdDriveAccessState>& state,
+                                                      const QString& driveId)
+{
+    const std::scoped_lock lock{state->mutex};
+
+    if(state->reservedDrives.contains(driveId)) {
+        return std::unexpected(driveBusyError());
+    }
+
+    state->reservedDrives.emplace(driveId);
+    return DriveReservation{state, driveId};
+}
+
+std::expected<ReservedDriveSession, CdError> openReserved(CdDriveManagerPrivate& manager, const QString& driveId)
+{
+    auto reservation = reserveDrive(manager.m_accessState, driveId);
+    if(!reservation) {
+        return std::unexpected(reservation.error());
+    }
+
+    return ReservedDriveSession{std::move(*reservation), manager.m_backend->open(driveId)};
+}
+
+CdDriveObservation inspectDrive(ReservedDriveSession& reserved)
+{
+    CdDriveObservation observation;
+    observation.drive = reserved.opened()->drive;
+
+    auto toc = reserved.opened()->session->readToc();
+    if(!toc) {
+        observation.error = toc.error();
+        return observation;
+    }
+
+    auto discId = musicBrainzDiscId(*toc);
+    if(!discId) {
+        observation.error
+            = CdError{.code = CdDriveError::NotAudioDisc, .message = invalidTocUserMessage(), .platformCode = 0};
+        return observation;
+    }
+
+    observation.toc    = std::move(*toc);
+    observation.discId = std::move(*discId);
+    return observation;
+}
+
+bool sameMedia(const CdDriveObservation& lhs, const CdDriveObservation& rhs)
+{
+    return lhs.drive == rhs.drive && lhs.toc == rhs.toc && lhs.discId == rhs.discId && lhs.error == rhs.error;
+}
+
+void sortObservations(std::vector<CdDriveObservation>& observations)
+{
+    std::ranges::sort(observations, {}, [](const auto& observation) { return observation.drive.id; });
+}
+} // namespace
+
+CdDriveLease::CdDriveLease(std::shared_ptr<CdDriveAccessState> state, QString driveId, CdDriveInfo drive, CdToc toc,
+                           QString discId, uint64_t generation, std::unique_ptr<CdDriveSession> session)
+    : m_state{std::move(state)}
+    , m_driveId{std::move(driveId)}
+    , m_drive{std::move(drive)}
+    , m_toc{std::move(toc)}
+    , m_discId{std::move(discId)}
+    , m_generation{generation}
+    , m_session{std::move(session)}
+{ }
+
+CdDriveLease::~CdDriveLease()
+{
+    release();
+}
+
+CdDriveLease::CdDriveLease(CdDriveLease&& other) noexcept
+    : m_state{std::move(other.m_state)}
+    , m_driveId{std::move(other.m_driveId)}
+    , m_drive{std::move(other.m_drive)}
+    , m_toc{std::move(other.m_toc)}
+    , m_discId{std::move(other.m_discId)}
+    , m_generation{std::exchange(other.m_generation, 0)}
+    , m_session{std::move(other.m_session)}
+{ }
+
+CdDriveLease& CdDriveLease::operator=(CdDriveLease&& other) noexcept
+{
+    if(this != &other) {
+        release();
+        m_state      = std::move(other.m_state);
+        m_driveId    = std::move(other.m_driveId);
+        m_drive      = std::move(other.m_drive);
+        m_toc        = std::move(other.m_toc);
+        m_discId     = std::move(other.m_discId);
+        m_generation = std::exchange(other.m_generation, 0);
+        m_session    = std::move(other.m_session);
+    }
+    return *this;
+}
+
+CdDriveLease::operator bool() const
+{
+    return m_session != nullptr;
+}
+
+CdDriveSession* CdDriveLease::session() const
+{
+    return m_session.get();
+}
+
+const CdDriveInfo& CdDriveLease::drive() const
+{
+    return m_drive;
+}
+
+const CdToc& CdDriveLease::toc() const
+{
+    return m_toc;
+}
+
+const QString& CdDriveLease::discId() const
+{
+    return m_discId;
+}
+
+uint64_t CdDriveLease::generation() const
+{
+    return m_generation;
+}
+
+void CdDriveLease::release()
+{
+    m_session.reset();
+
+    if(m_state && !m_driveId.isEmpty()) {
+        const std::scoped_lock lock{m_state->mutex};
+        m_state->reservedDrives.erase(m_driveId);
+    }
+
+    m_driveId.clear();
+    m_state.reset();
+}
+
+CdDriveManager::CdDriveManager(std::unique_ptr<CdDriveBackend> backend, std::chrono::milliseconds cacheLifetime)
+    : p{std::make_unique<CdDriveManagerPrivate>(std::move(backend),
+                                                std::max(cacheLifetime, std::chrono::milliseconds{0}))}
+{ }
+
+CdDriveManager::~CdDriveManager() = default;
+
+std::vector<CdDriveInfo> CdDriveManager::drives()
+{
+    std::vector<CdDriveInfo> result = p->m_backend->drives();
+    {
+        const std::scoped_lock lock{p->m_mutex};
+        for(CdDriveInfo& drive : result) {
+            if(const auto cached = p->m_cache.find(drive.id); cached != p->m_cache.cend()) {
+                drive = cached->second.drive;
+            }
+        }
+    }
+    std::ranges::sort(result, {}, &CdDriveInfo::id);
+    return result;
+}
+
+CdDriveObservation CdDriveManager::observeDrive(const CdDriveInfo& drive)
+{
+    auto reserved = openReserved(*p, drive.id);
+    if(!reserved && reserved.error().code == CdDriveError::DriveBusy) {
+        return errorObservation(drive, reserved.error());
+    }
+
+    CdDriveObservation observation
+        = reserved->opened() ? inspectDrive(*reserved) : errorObservation(drive, reserved->opened().error());
+
+    const std::scoped_lock lock{p->m_mutex};
+
+    const auto previous = p->m_cache.find(drive.id);
+    if(previous != p->m_cache.cend() && sameMedia(previous->second, observation)) {
+        observation.generation = previous->second.generation;
+        observation.cdText     = previous->second.cdText;
+    }
+    else {
+        observation.generation = p->m_nextGeneration++;
+    }
+
+    p->m_cache.insert_or_assign(drive.id, observation);
+    return observation;
+}
+
+std::expected<CdText, CdError> CdDriveManager::readCdText(const CdDriveObservation& observation)
+{
+    if(!observation.toc || observation.discId.isEmpty()) {
+        return std::unexpected(CdError{
+            .code = CdDriveError::NotAudioDisc, .message = tr("Audio CD identity is unavailable"), .platformCode = 0});
+    }
+
+    auto reserved = openReserved(*p, observation.drive.id);
+    if(!reserved) {
+        return std::unexpected(reserved.error());
+    }
+    if(!reserved->opened()) {
+        return std::unexpected(reserved->opened().error());
+    }
+
+    auto toc = reserved->opened()->session->readToc();
+    if(!toc) {
+        return std::unexpected(toc.error());
+    }
+
+    const auto discId = musicBrainzDiscId(*toc);
+    if(!discId || *discId != observation.discId) {
+        return std::unexpected(CdError{.code         = CdDriveError::MediaChanged,
+                                       .message      = tr("The disc in the CD drive has changed"),
+                                       .platformCode = 0});
+    }
+
+    CdText cdText = reserved->opened()->session->readCdText(*toc);
+
+    const std::scoped_lock lock{p->m_mutex};
+
+    auto cached = p->m_cache.find(observation.drive.id);
+    if(cached != p->m_cache.end() && cached->second.discId == observation.discId
+       && cached->second.generation == observation.generation) {
+        cached->second.cdText = cdText;
+    }
+
+    return cdText;
+}
+
+std::vector<CdDriveObservation> CdDriveManager::observations(bool forceRefresh)
+{
+    const auto now = std::chrono::steady_clock::now();
+    {
+        const std::scoped_lock lock{p->m_mutex};
+
+        if(!forceRefresh && p->m_cacheValid && now - p->m_lastRefresh < p->m_cacheLifetime) {
+            std::vector<CdDriveObservation> cached;
+            for(const auto& [id, value] : std::as_const(p->m_cache)) {
+                cached.push_back(value);
+            }
+            sortObservations(cached);
+            return cached;
+        }
+    }
+
+    const std::vector<CdDriveInfo> availableDrives = drives();
+
+    std::vector<CdDriveObservation> fresh;
+    fresh.reserve(availableDrives.size());
+    std::unordered_set<QString> availableIds;
+    availableIds.reserve(availableDrives.size());
+    bool refreshComplete{true};
+
+    for(const CdDriveInfo& drive : availableDrives) {
+        availableIds.insert(drive.id);
+
+        auto reserved = openReserved(*p, drive.id);
+        if(!reserved) {
+            const std::scoped_lock lock{p->m_mutex};
+            if(const auto cached = p->m_cache.find(drive.id); cached != p->m_cache.cend()) {
+                fresh.push_back(cached->second);
+            }
+            else {
+                fresh.push_back(errorObservation(drive, reserved.error()));
+                refreshComplete = false;
+            }
+            continue;
+        }
+
+        CdDriveObservation observation
+            = reserved->opened() ? inspectDrive(*reserved) : errorObservation(drive, reserved->opened().error());
+
+        const std::scoped_lock lock{p->m_mutex};
+        const auto previous = p->m_cache.find(drive.id);
+        if(previous != p->m_cache.cend() && sameMedia(previous->second, observation)) {
+            observation.generation = previous->second.generation;
+            observation.cdText     = previous->second.cdText;
+        }
+        else {
+            observation.generation = p->m_nextGeneration++;
+        }
+        p->m_cache.insert_or_assign(drive.id, observation);
+        fresh.push_back(std::move(observation));
+    }
+
+    {
+        const std::scoped_lock lock{p->m_accessState->mutex};
+        availableIds.insert(p->m_accessState->reservedDrives.cbegin(), p->m_accessState->reservedDrives.cend());
+    }
+    {
+        const std::scoped_lock lock{p->m_mutex};
+        std::erase_if(p->m_cache, [&](const auto& cached) { return !availableIds.contains(cached.first); });
+        p->m_lastRefresh = now;
+        p->m_cacheValid  = refreshComplete;
+    }
+
+    sortObservations(fresh);
+    return fresh;
+}
+
+std::expected<CdDriveObservation, CdError> CdDriveManager::resolveDisc(const QString& discId, bool forceRefresh)
+{
+    if(!isValidDiscId(discId)) {
+        return std::unexpected(
+            CdError{.code = CdDriveError::NotAudioDisc, .message = tr("Invalid CD disc identity"), .platformCode = 0});
+    }
+
+    std::vector<CdDriveObservation> observed;
+    if(!forceRefresh) {
+        const std::scoped_lock lock{p->m_mutex};
+        for(const auto& [id, value] : std::as_const(p->m_cache)) {
+            observed.push_back(value);
+        }
+        sortObservations(observed);
+    }
+
+    if(forceRefresh || observed.empty()) {
+        observed = observations(true);
+    }
+
+    auto matches = [&] {
+        std::vector<CdDriveObservation> result;
+        std::ranges::copy_if(observed, std::back_inserter(result),
+                             [&](const auto& observation) { return observation.discId == discId; });
+        return result;
+    }();
+
+    if(matches.empty() && !forceRefresh) {
+        observed = observations(true);
+        matches.clear();
+        std::ranges::copy_if(observed, std::back_inserter(matches),
+                             [&](const auto& observation) { return observation.discId == discId; });
+    }
+
+    if(matches.empty()) {
+        return std::unexpected(CdError{
+            .code = CdDriveError::NoMedia, .message = tr("The requested audio CD is not inserted"), .platformCode = 0});
+    }
+
+    QString preferred;
+    {
+        const std::scoped_lock lock{p->m_mutex};
+        if(const auto it = p->m_preferredDrives.find(discId); it != p->m_preferredDrives.cend()) {
+            preferred = it->second;
+        }
+    }
+
+    if(const auto it = std::ranges::find(matches, preferred, [](const auto& item) { return item.drive.id; });
+       it != matches.end()) {
+        return *it;
+    }
+
+    return matches.front();
+}
+
+std::expected<CdDriveLease, CdError> CdDriveManager::acquire(const QString& discId)
+{
+    if(!isValidDiscId(discId)) {
+        return std::unexpected(
+            CdError{.code = CdDriveError::NotAudioDisc, .message = tr("Invalid CD disc identity"), .platformCode = 0});
+    }
+
+    std::optional<CdError> firstFailure;
+    bool sawBusy{false};
+
+    for(int attempt{0}; attempt < 2; ++attempt) {
+        std::vector<CdDriveObservation> observed;
+        if(attempt == 0) {
+            const std::scoped_lock lock{p->m_mutex};
+            for(const auto& [id, observation] : std::as_const(p->m_cache)) {
+                observed.push_back(observation);
+            }
+        }
+        if(attempt > 0 || observed.empty()) {
+            observed = observations(true);
+        }
+
+        std::vector<CdDriveObservation> matches;
+        std::ranges::copy_if(observed, std::back_inserter(matches),
+                             [&](const auto& observation) { return observation.discId == discId; });
+
+        QString preferred;
+        {
+            const std::scoped_lock lock{p->m_mutex};
+            if(const auto it = p->m_preferredDrives.find(discId); it != p->m_preferredDrives.cend()) {
+                preferred = it->second;
+            }
+        }
+
+        std::ranges::sort(matches, [&](const CdDriveObservation& lhs, const CdDriveObservation& rhs) {
+            const bool lhsPreferred = lhs.drive.id == preferred;
+            const bool rhsPreferred = rhs.drive.id == preferred;
+            return lhsPreferred != rhsPreferred ? lhsPreferred : lhs.drive.id < rhs.drive.id;
+        });
+
+        for(const CdDriveObservation& resolved : matches) {
+            const QString driveId = resolved.drive.id;
+            auto reserved         = openReserved(*p, driveId);
+            if(!reserved) {
+                sawBusy = true;
+                continue;
+            }
+
+            if(!reserved->opened()) {
+                if(!firstFailure) {
+                    firstFailure = reserved->opened().error();
+                }
+                invalidateDrive(driveId);
+                continue;
+            }
+
+            auto toc = reserved->opened()->session->readToc();
+            if(!toc) {
+                if(!firstFailure) {
+                    firstFailure = toc.error();
+                }
+                invalidateDrive(driveId);
+                continue;
+            }
+
+            auto actualDiscId = musicBrainzDiscId(*toc);
+            if(!actualDiscId || *actualDiscId != discId) {
+                if(!firstFailure) {
+                    firstFailure = CdError{.code         = CdDriveError::MediaChanged,
+                                           .message      = tr("The disc in the CD drive has changed"),
+                                           .platformCode = 0};
+                }
+                invalidateDrive(driveId);
+                continue;
+            }
+
+            auto reservation                    = reserved->takeReservation();
+            auto [state, reservedId]            = reservation.take();
+            CdDriveBackend::OpenedDrive& opened = *reserved->opened();
+            return CdDriveLease{std::move(state),         std::move(reservedId),    std::move(opened.drive),
+                                std::move(*toc),          std::move(*actualDiscId), resolved.generation,
+                                std::move(opened.session)};
+        }
+    }
+
+    if(firstFailure) {
+        return std::unexpected(*firstFailure);
+    }
+    if(sawBusy) {
+        return std::unexpected(driveBusyError());
+    }
+    return std::unexpected(CdError{
+        .code = CdDriveError::NoMedia, .message = tr("The requested audio CD is not inserted"), .platformCode = 0});
+}
+
+void CdDriveManager::setPreferredDrive(const QString& discId, const QString& driveId)
+{
+    const std::scoped_lock lock{p->m_mutex};
+
+    if(driveId.isEmpty()) {
+        p->m_preferredDrives.erase(discId);
+    }
+    else {
+        p->m_preferredDrives.insert_or_assign(discId, driveId);
+    }
+}
+
+void CdDriveManager::invalidateDrive(const QString& driveId)
+{
+    const std::scoped_lock lock{p->m_mutex};
+    p->m_cache.erase(driveId);
+    p->m_cacheValid = false;
+}
+
+void CdDriveManager::invalidateAll()
+{
+    const std::scoped_lock lock{p->m_mutex};
+    p->m_cache.clear();
+    p->m_cacheValid = false;
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadrivemanager.h
+++ b/src/plugins/cdda/cddadrivemanager.h
@@ -1,0 +1,115 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drive/cddrivebackend.h"
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <QCoreApplication>
+
+namespace Fooyin::Cdda {
+struct CdDriveAccessState;
+
+struct CdDriveObservation
+{
+    CdDriveInfo drive;
+    std::optional<CdToc> toc;
+    std::optional<CdText> cdText;
+    QString discId;
+    std::optional<CdError> error;
+    uint64_t generation{0};
+
+    bool operator==(const CdDriveObservation&) const = default;
+};
+
+class CdDriveLease
+{
+public:
+    CdDriveLease() = default;
+    ~CdDriveLease();
+
+    CdDriveLease(const CdDriveLease&)            = delete;
+    CdDriveLease& operator=(const CdDriveLease&) = delete;
+    CdDriveLease(CdDriveLease&& other) noexcept;
+    CdDriveLease& operator=(CdDriveLease&& other) noexcept;
+
+    [[nodiscard]] explicit operator bool() const;
+
+    [[nodiscard]] CdDriveSession* session() const;
+    [[nodiscard]] const CdDriveInfo& drive() const;
+    [[nodiscard]] const CdToc& toc() const;
+    [[nodiscard]] const QString& discId() const;
+    [[nodiscard]] uint64_t generation() const;
+
+private:
+    friend class CdDriveManager;
+
+    CdDriveLease(std::shared_ptr<CdDriveAccessState> state, QString driveId, CdDriveInfo drive, CdToc toc,
+                 QString discId, uint64_t generation, std::unique_ptr<CdDriveSession> session);
+    void release();
+
+    std::shared_ptr<CdDriveAccessState> m_state;
+    QString m_driveId;
+    CdDriveInfo m_drive;
+    CdToc m_toc;
+    QString m_discId;
+    uint64_t m_generation{0};
+    std::unique_ptr<CdDriveSession> m_session;
+};
+
+class CdDriveManagerPrivate;
+
+class CdDriveManager
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::CdDriveManager)
+
+public:
+    explicit CdDriveManager(std::unique_ptr<CdDriveBackend> backend,
+                            std::chrono::milliseconds cacheLifetime = std::chrono::seconds{2});
+    ~CdDriveManager();
+
+    CdDriveManager(const CdDriveManager&)            = delete;
+    CdDriveManager& operator=(const CdDriveManager&) = delete;
+
+    //! Enumerates drive devices without opening them or reading media.
+    [[nodiscard]] std::vector<CdDriveInfo> drives();
+    //! Opens and inspects one selected drive, updating its cache; returns DriveBusy while the drive is leased.
+    [[nodiscard]] CdDriveObservation observeDrive(const CdDriveInfo& drive);
+    //! Reads optional CD-Text for an already observed disc and caches it; returns DriveBusy for a leased drive.
+    [[nodiscard]] std::expected<CdText, CdError> readCdText(const CdDriveObservation& observation);
+    //! Returns cached observations until their lifetime expires; refreshes retain cached data for leased drives.
+    [[nodiscard]] std::vector<CdDriveObservation> observations(bool forceRefresh = false);
+    //! Resolves a stable disc identity to an inserted drive, preferring the user's current selection.
+    [[nodiscard]] std::expected<CdDriveObservation, CdError> resolveDisc(const QString& discId,
+                                                                         bool forceRefresh = false);
+    //! Reopens and revalidates the selected disc while reserving all physical I/O to that drive.
+    [[nodiscard]] std::expected<CdDriveLease, CdError> acquire(const QString& discId);
+
+    void setPreferredDrive(const QString& discId, const QString& driveId);
+    void invalidateDrive(const QString& driveId);
+    void invalidateAll();
+
+private:
+    std::unique_ptr<CdDriveManagerPrivate> p;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadrivesettings.cpp
+++ b/src/plugins/cdda/cddadrivesettings.cpp
@@ -1,0 +1,115 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddadrivesettings.h"
+
+#include <utils/settings/settingsmanager.h>
+
+#include <QCryptographicHash>
+#include <QLoggingCategory>
+
+using namespace Qt::StringLiterals;
+
+Q_LOGGING_CATEGORY(CDDA_SETTINGS, "fy.cdda.settings")
+
+namespace Fooyin::Cdda {
+CdDriveSettings normaliseDriveSettings(CdDriveSettings settings)
+{
+    settings.readOffsetFrames
+        = std::clamp(settings.readOffsetFrames, -MaximumReadOffsetFrames, MaximumReadOffsetFrames);
+
+    switch(settings.security) {
+        case CdRippingSecurity::Disabled:
+        case CdRippingSecurity::Standard:
+        case CdRippingSecurity::Paranoid:
+            break;
+        default:
+            settings.security = CdRippingSecurity::Disabled;
+            break;
+    }
+
+    settings.readSpeedLimit = std::clamp(settings.readSpeedLimit, 0, MaximumReadSpeed);
+    return settings;
+}
+
+QString cdDriveSettingsKey(const QString& backend, QString vendor, QString model, const QString& location)
+{
+    const QString backendName = backend.simplified().toCaseFolded();
+    vendor                    = vendor.simplified().toCaseFolded();
+    model                     = model.simplified().toCaseFolded();
+
+    const auto encodedIdentityPart = [](const QString& value) {
+        return QString::fromLatin1(
+            value.toUtf8().toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
+    };
+
+    if(!model.isEmpty()) {
+        return u"%1-model:%2:%3"_s.arg(backendName, encodedIdentityPart(vendor), encodedIdentityPart(model));
+    }
+    if(location.isEmpty()) {
+        return {};
+    }
+    return u"%1-location:%2"_s.arg(backendName, encodedIdentityPart(location));
+}
+
+QString cdDriveSettingsGroup(const QString& settingsKey)
+{
+    const QByteArray digest = QCryptographicHash::hash(settingsKey.toUtf8(), QCryptographicHash::Sha256)
+                                  .toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
+    return u"CDDA-Drive-%1"_s.arg(QString::fromLatin1(digest));
+}
+
+CdDriveSettings CdDriveSettingsStore::settingsForDrive(const CdDriveInfo& drive) const
+{
+    CdDriveSettings result;
+    if(drive.settingsKey.isEmpty()) {
+        return result;
+    }
+
+    const QString prefix    = cdDriveSettingsGroup(drive.settingsKey);
+    result.readOffsetFrames = m_settings.value(prefix + u"/ReadOffsetFrames"_s, 0).toInt();
+    result.security         = static_cast<CdRippingSecurity>(
+        m_settings.value(prefix + u"/Security"_s, static_cast<int>(CdRippingSecurity::Disabled)).toInt());
+    result.readSpeedLimit = m_settings.value(prefix + u"/ReadSpeedLimit"_s, 0).toInt();
+
+    return normaliseDriveSettings(result);
+}
+
+bool CdDriveSettingsStore::hasSettingsForDrive(const CdDriveInfo& drive) const
+{
+    return !drive.settingsKey.isEmpty()
+        && m_settings.contains(cdDriveSettingsGroup(drive.settingsKey) + u"/Identity"_s);
+}
+
+void CdDriveSettingsStore::setSettingsForDrive(const CdDriveInfo& drive, const CdDriveSettings& settings)
+{
+    if(drive.settingsKey.isEmpty()) {
+        qCWarning(CDDA_SETTINGS) << "Cannot save CD drive settings without a stable identity:" << drive.id;
+        return;
+    }
+
+    const CdDriveSettings normalised = normaliseDriveSettings(settings);
+
+    const QString prefix = cdDriveSettingsGroup(drive.settingsKey);
+    m_settings.setValue(prefix + u"/Identity"_s, drive.settingsKey);
+    m_settings.setValue(prefix + u"/ReadOffsetFrames"_s, normalised.readOffsetFrames);
+    m_settings.setValue(prefix + u"/Security"_s, static_cast<int>(normalised.security));
+    m_settings.setValue(prefix + u"/ReadSpeedLimit"_s, normalised.readSpeedLimit);
+}
+
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadrivesettings.h
+++ b/src/plugins/cdda/cddadrivesettings.h
@@ -1,0 +1,64 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddasectorreader.h"
+
+#include <core/coresettings.h>
+
+namespace Fooyin {
+class SettingsManager;
+
+namespace Cdda {
+constexpr auto MaximumReadOffsetFrames = 44100;
+constexpr auto MaximumReadSpeed        = 128;
+
+struct CdDriveSettings
+{
+    int readOffsetFrames{0};
+    CdRippingSecurity security{CdRippingSecurity::Disabled};
+    int readSpeedLimit{0}; // For ripping; 0 = max
+
+    bool operator==(const CdDriveSettings&) const = default;
+};
+
+[[nodiscard]] CdDriveSettings normaliseDriveSettings(CdDriveSettings settings);
+[[nodiscard]] QString cdDriveSettingsKey(const QString& backend, QString vendor, QString model,
+                                         const QString& location);
+[[nodiscard]] QString cdDriveSettingsGroup(const QString& settingsKey);
+
+class CdDriveSettingsProvider
+{
+public:
+    virtual ~CdDriveSettingsProvider()                                                     = default;
+    [[nodiscard]] virtual CdDriveSettings settingsForDrive(const CdDriveInfo& drive) const = 0;
+};
+
+class CdDriveSettingsStore final : public CdDriveSettingsProvider
+{
+public:
+    [[nodiscard]] CdDriveSettings settingsForDrive(const CdDriveInfo& drive) const override;
+    [[nodiscard]] bool hasSettingsForDrive(const CdDriveInfo& drive) const;
+    void setSettingsForDrive(const CdDriveInfo& drive, const CdDriveSettings& settings);
+
+private:
+    FySettings m_settings;
+};
+} // namespace Cdda
+} // namespace Fooyin

--- a/src/plugins/cdda/cddadrivesettingsdialog.cpp
+++ b/src/plugins/cdda/cddadrivesettingsdialog.cpp
@@ -1,0 +1,172 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cddadrivesettingsdialog.h"
+
+#include "accuraterip.h"
+
+#include <core/network/networkaccessmanager.h>
+#include <core/network/networkutils.h>
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QPushButton>
+#include <QSizePolicy>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+CdDriveSettingsDialog::CdDriveSettingsDialog(CdDriveInfo drive, std::shared_ptr<CdDriveSettingsStore> settingsStore,
+                                             std::shared_ptr<NetworkAccessManager> networkAccess, QWidget* parent)
+    : QDialog{parent}
+    , m_drive{std::move(drive)}
+    , m_settingsStore{std::move(settingsStore)}
+    , m_networkAccess{std::move(networkAccess)}
+    , m_readOffset{new QSpinBox(this)}
+    , m_security{new QComboBox(this)}
+    , m_speedLimit{new QComboBox(this)}
+    , m_lookupOffset{new QPushButton(tr("Lookup with AccurateRip"), this)}
+    , m_offsetStatus{new QLabel(this)}
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(tr("Drive Settings - %1").arg(m_drive.displayName));
+    setModal(true);
+
+    m_readOffset->setRange(-MaximumReadOffsetFrames, MaximumReadOffsetFrames);
+    m_readOffset->setToolTip(
+        tr("Compensates for a drive that reads slightly before or after the requested CD position.\n"
+           "Positive values read later; negative values read earlier.\n"
+           "Use AccurateRip to look up the correction for this drive model, or enter a known value manually."));
+
+    m_security->addItem(tr("Disabled"), static_cast<int>(CdRippingSecurity::Disabled));
+    m_security->addItem(tr("Standard"), static_cast<int>(CdRippingSecurity::Standard));
+    m_security->addItem(tr("Paranoid"), static_cast<int>(CdRippingSecurity::Paranoid));
+    m_security->setToolTip(
+        tr("Controls error detection and correction while ripping; playback is unaffected.\n"
+           "Disabled: direct reads with no verification (fastest).\n"
+           "Standard: verifies overlapping reads and retries inconsistencies (slower).\n"
+           "Paranoid: performs the most thorough available checking and additional retries (slowest)."));
+
+    m_speedLimit->addItem(tr("Maximum"), 0);
+    for(const int speed : {1, 2, 4, 8, 16, 24, 32, 40, 48, 52}) {
+        m_speedLimit->addItem(u"%1×"_s.arg(speed), speed);
+    }
+    m_speedLimit->setEnabled(m_drive.supportsSpeedLimit);
+    m_speedLimit->setToolTip(m_drive.supportsSpeedLimit
+                                 ? tr("Limits the drive's read speed while ripping; playback is unaffected.")
+                                 : tr("This drive doesn't support read-speed control."));
+
+    const CdDriveSettings settings = m_settingsStore->settingsForDrive(m_drive);
+    m_readOffset->setValue(settings.readOffsetFrames);
+    m_security->setCurrentIndex(m_security->findData(static_cast<int>(settings.security)));
+    m_speedLimit->setCurrentIndex(std::max(0, m_speedLimit->findData(settings.readSpeedLimit)));
+
+    auto* form = new QGridLayout();
+
+    int row{0};
+    form->addWidget(new QLabel(tr("Read offset correction") + u":"_s, this), row, 0);
+    form->addWidget(m_readOffset, row++, 1);
+    form->addWidget(m_lookupOffset, row++, 1);
+    form->addWidget(new QLabel(tr("Ripping security") + u":"_s, this), row, 0);
+    form->addWidget(m_security, row++, 1);
+    form->addWidget(new QLabel(tr("Drive speed limit") + u":"_s, this), row, 0);
+    form->addWidget(m_speedLimit, row++, 1);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, this, &CdDriveSettingsDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    QObject::connect(m_lookupOffset, &QPushButton::clicked, this, &CdDriveSettingsDialog::lookupAccurateRipOffset);
+
+    m_lookupOffset->setEnabled(!m_drive.model.isEmpty());
+    m_offsetStatus->setWordWrap(true);
+    m_offsetStatus->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    m_offsetStatus->setMinimumHeight(m_offsetStatus->fontMetrics().lineSpacing() * 3);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addLayout(form);
+    layout->addWidget(m_offsetStatus);
+    layout->addWidget(buttons);
+}
+
+void CdDriveSettingsDialog::lookupAccurateRipOffset()
+{
+    if(m_drive.model.isEmpty()) {
+        return;
+    }
+
+    m_lookupOffset->setEnabled(false);
+    m_offsetStatus->setText(tr("Looking up drive…"));
+
+    const QNetworkRequest request = makeNetworkRequest(QUrl{u"https://www.accuraterip.com/driveoffsets.htm"_s});
+
+    QNetworkReply* reply = m_networkAccess->get(request);
+    QObject::connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater);
+    QObject::connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        m_lookupOffset->setEnabled(true);
+
+        if(reply->error() != QNetworkReply::NoError) {
+            m_offsetStatus->setText(tr("Lookup failed: %1").arg(reply->errorString()));
+            return;
+        }
+
+        const QByteArray payload = reply->read((4 * 1024 * 1024) + 1);
+        if(payload.size() > 4LL * 1024 * 1024) {
+            m_offsetStatus->setText(tr("AccurateRip returned an unexpectedly large drive list."));
+            return;
+        }
+
+        const auto match
+            = findAccurateRipDriveOffset(parseAccurateRipDriveOffsets(payload), m_drive.vendor, m_drive.model);
+        if(!match) {
+            m_offsetStatus->setText(tr("No unambiguous entry was found for this drive."));
+            return;
+        }
+
+        if(match->purged) {
+            m_offsetStatus->setText(tr("This drive was purged because its offset is not consistent."));
+            return;
+        }
+
+        m_readOffset->setValue(match->correctionSampleFrames);
+        //: Correction = CD Drive read offset correction
+        m_offsetStatus->setText(
+            tr("Found correction: %1 (%Ln submission(s), %2% agreement).", nullptr, match->submissions)
+                .arg(match->correctionSampleFrames)
+                .arg(match->agreementPercent));
+    });
+}
+
+void CdDriveSettingsDialog::accept()
+{
+    const CdDriveSettings settings{
+        .readOffsetFrames = m_readOffset->value(),
+        .security         = static_cast<CdRippingSecurity>(m_security->currentData().toInt()),
+        .readSpeedLimit   = m_speedLimit->currentData().toInt(),
+    };
+
+    m_settingsStore->setSettingsForDrive(m_drive, settings);
+
+    QDialog::accept();
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddadrivesettingsdialog.h
+++ b/src/plugins/cdda/cddadrivesettingsdialog.h
@@ -1,0 +1,61 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cddadrivesettings.h"
+
+#include <QDialog>
+
+#include <memory>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QSpinBox;
+
+namespace Fooyin {
+class NetworkAccessManager;
+}
+
+namespace Fooyin::Cdda {
+class CdDriveSettingsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    CdDriveSettingsDialog(CdDriveInfo drive, std::shared_ptr<CdDriveSettingsStore> settingsStore,
+                          std::shared_ptr<NetworkAccessManager> networkAccess, QWidget* parent = nullptr);
+
+    void accept() override;
+
+private:
+    void lookupAccurateRipOffset();
+
+    CdDriveInfo m_drive;
+    std::shared_ptr<CdDriveSettingsStore> m_settingsStore;
+    std::shared_ptr<NetworkAccessManager> m_networkAccess;
+
+    QSpinBox* m_readOffset;
+    QComboBox* m_security;
+    QComboBox* m_speedLimit;
+    QPushButton* m_lookupOffset;
+    QLabel* m_offsetStatus;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddaplugin.cpp
+++ b/src/plugins/cdda/cddaplugin.cpp
@@ -1,0 +1,259 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddaplugin.h"
+
+#include "accuraterip.h"
+#include "cddadecoder.h"
+#include "cddadrivemanager.h"
+#include "cddadrivesettings.h"
+#include "cddareader.h"
+#include "cddatoc.h"
+#include "drive/libcdiodrivebackend.h"
+#include "openaudiocddialog.h"
+#include "ripaudiocddialog.h"
+
+#include <core/network/networkaccessmanager.h>
+#include <core/network/networkutils.h>
+#include <core/player/playercontroller.h>
+#include <core/playlist/playlist.h>
+#include <core/playlist/playlisthandler.h>
+#include <core/plugins/coreplugincontext.h>
+#include <gui/conversion/conversionservice.h>
+#include <gui/guiconstants.h>
+#include <gui/metadatalookup/metadatalookupdialog.h>
+#include <gui/playlist/currentplaylistcontroller.h>
+#include <gui/plugins/guiplugincontext.h>
+#include <utils/actions/actioncontainer.h>
+#include <utils/actions/actionmanager.h>
+#include <utils/actions/command.h>
+#include <utils/utils.h>
+
+#include <QAction>
+#include <QMainWindow>
+#include <QNetworkReply>
+#include <QPointer>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+void CddaPlugin::initialise(const CorePluginContext& context)
+{
+    m_playerController = context.playerController;
+    m_playlistHandler  = context.playlistHandler;
+    m_networkAccess    = context.networkAccess;
+    m_settingsManager  = context.settingsManager;
+
+    m_driveManager  = std::make_shared<CdDriveManager>(std::make_unique<LibcdioDriveBackend>());
+    m_settingsStore = std::make_shared<CdDriveSettingsStore>();
+}
+
+void CddaPlugin::initialise(const GuiPluginContext& context)
+{
+    m_playlistController = context.playlistSelection;
+    m_conversionService  = context.conversionService;
+
+    auto* openAction = new QAction(tr("Open audio &CD…"), this);
+    openAction->setStatusTip(tr("Open an audio CD for playback or ripping"));
+    auto* command = context.actionManager->registerAction(openAction, "File.OpenAudioCd");
+    command->setCategories({tr("File")});
+    context.actionManager->actionContainer(Constants::Menus::File)->addAction(command, Actions::Groups::One);
+
+    QObject::connect(openAction, &QAction::triggered, this, [this]() {
+        auto* dialog = new OpenAudioCdDialog(m_driveManager, m_settingsStore, m_networkAccess, m_settingsManager,
+                                             Utils::getMainWindow());
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+        QObject::connect(dialog, &OpenAudioCdDialog::addRequested, this, &CddaPlugin::addToPlaylist);
+        QObject::connect(dialog, &OpenAudioCdDialog::playRequested, this, &CddaPlugin::play);
+        QObject::connect(dialog, &OpenAudioCdDialog::ripRequested, this, &CddaPlugin::rip);
+
+        dialog->show();
+        dialog->raise();
+        dialog->activateWindow();
+    });
+}
+
+void CddaPlugin::addToPlaylist(const TrackList& tracks, const CdDriveObservation& observation)
+{
+    if(tracks.empty()) {
+        return;
+    }
+
+    m_driveManager->setPreferredDrive(observation.discId, observation.drive.id);
+
+    const Playlist* playlist = m_playlistController->currentPlaylist();
+    if(!playlist || playlist->isAutoPlaylist() || playlist->isLocked()) {
+        playlist = m_playlistHandler->createNewPlaylist(tr("Audio CD"));
+        m_playlistController->changeCurrentPlaylist(playlist->id());
+    }
+
+    m_playlistHandler->appendToPlaylist(playlist->id(), tracks);
+    m_playlistController->selectTracks(tracks);
+}
+
+void CddaPlugin::play(const TrackList& tracks, const CdDriveObservation& observation)
+{
+    if(tracks.empty()) {
+        return;
+    }
+
+    m_driveManager->setPreferredDrive(observation.discId, observation.drive.id);
+    Playlist* playlist = m_playlistHandler->createNewPlaylist(tr("Audio CD"), tracks);
+    m_playlistController->changeCurrentPlaylist(playlist->id());
+    m_playerController->startPlayback(playlist);
+}
+
+void CddaPlugin::rip(const TrackList& tracks, const CdDriveObservation& observation)
+{
+    if(tracks.empty() || !observation.toc) {
+        return;
+    }
+
+    m_driveManager->setPreferredDrive(observation.discId, observation.drive.id);
+
+    QString discToc;
+    if(const auto toc = musicBrainzToc(*observation.toc)) {
+        discToc = *toc;
+    }
+
+    auto* dialog = new RipAudioCdDialog(
+        tracks, m_conversionService->presets(), !discToc.isEmpty() && !observation.discId.isEmpty(),
+        m_settingsStore->hasSettingsForDrive(observation.drive), Utils::getMainWindow());
+
+    QObject::connect(dialog, &RipAudioCdDialog::metadataLookupRequested, this,
+                     [this, dialog, discToc, discId = observation.discId](const TrackList& lookupTracks) {
+                         auto* lookup = new MetadataLookupDialog(lookupTracks, m_networkAccess, m_settingsManager,
+                                                                 {.mode       = LookupMode::DiscToc,
+                                                                  .artist     = {},
+                                                                  .album      = {},
+                                                                  .discToc    = discToc,
+                                                                  .discId     = discId,
+                                                                  .identifier = {}},
+                                                                 dialog);
+                         lookup->setModal(true);
+
+                         QObject::connect(lookup, &MetadataLookupDialog::tracksApplied, dialog,
+                                          &RipAudioCdDialog::applyLookupTracks);
+                         QObject::connect(lookup, &QObject::destroyed, dialog,
+                                          &RipAudioCdDialog::metadataLookupFinished);
+
+                         lookup->show();
+                         lookup->raise();
+                         lookup->activateWindow();
+                     });
+    QObject::connect(dialog, &RipAudioCdDialog::ripRequested, this,
+                     [this, dialog, toc = *observation.toc](const TrackList& ripTracks, const QString& presetId,
+                                                            bool showSetup, bool verifyAccurateRip) {
+                         startRip(dialog, ripTracks, toc, presetId, showSetup, verifyAccurateRip);
+                     });
+
+    dialog->show();
+    dialog->raise();
+    dialog->activateWindow();
+}
+
+void CddaPlugin::startRip(RipAudioCdDialog* dialog, TrackList tracks, CdToc toc, QString presetId, bool showSetup,
+                          bool verifyAccurateRip)
+{
+    if(!verifyAccurateRip) {
+        startConversion(dialog, tracks, presetId, showSetup, {});
+        return;
+    }
+
+    const auto discId = accurateRipDiscId(toc);
+    if(!discId) {
+        startConversion(dialog, tracks, presetId, showSetup, {}, discId.error());
+        return;
+    }
+
+    QNetworkReply* reply = m_networkAccess->get(makeNetworkRequest(accurateRipDiscUrl(*discId)));
+    QObject::connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater);
+    QObject::connect(reply, &QNetworkReply::finished, dialog,
+                     [this, dialog, reply, tracks = std::move(tracks), toc = std::move(toc),
+                      presetId = std::move(presetId), discId = *discId, showSetup]() {
+                         if(reply->error() != QNetworkReply::NoError) {
+                             startConversion(dialog, tracks, presetId, showSetup, {},
+                                             reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 404
+                                                 ? tr("This disc is not present in AccurateRip.")
+                                                 : tr("AccurateRip lookup failed: %1").arg(reply->errorString()));
+                             return;
+                         }
+
+                         const QByteArray payload = reply->read((8 * 1024 * 1024) + 1);
+                         if(payload.size() > 8L * 1024 * 1024) {
+                             startConversion(dialog, tracks, presetId, showSetup, {},
+                                             tr("AccurateRip returned an unexpectedly large disc record."));
+                             return;
+                         }
+
+                         const auto records = parseAccurateRipResponse(payload, discId);
+                         if(!records) {
+                             startConversion(dialog, tracks, presetId, showSetup, {}, records.error());
+                             return;
+                         }
+
+                         startConversion(dialog, tracks, presetId, showSetup,
+                                         std::make_shared<AccurateRipVerifier>(toc, *records));
+                     });
+}
+
+void CddaPlugin::startConversion(RipAudioCdDialog* dialog, const TrackList& tracks, const QString& presetId,
+                                 bool showSetup, std::shared_ptr<AccurateRipVerifier> verifier, QString lookupMessage)
+{
+    const QPointer reportParent{dialog->parentWidget()};
+    const auto completion = [verifier, lookupMessage = std::move(lookupMessage), reportParent](const auto&) {
+        const auto results = verifier ? verifier->results() : std::vector<AccurateRipTrackResult>{};
+        if(!results.empty() || !lookupMessage.isEmpty()) {
+            showAccurateRipResults(reportParent, results, lookupMessage);
+        }
+    };
+
+    if(showSetup) {
+        m_conversionService->showSetup(tracks, u"%tracknumber% - %title%"_s, verifier, completion);
+        dialog->accept();
+        return;
+    }
+
+    if(m_conversionService->startPreset(presetId, tracks, u"%tracknumber% - %title%"_s, verifier, completion)) {
+        dialog->accept();
+    }
+    else {
+        dialog->ripStartFailed();
+    }
+}
+
+QString CddaPlugin::inputName() const
+{
+    return tr("Audio CD");
+}
+
+InputCreator CddaPlugin::inputCreator() const
+{
+    InputCreator creator;
+    creator.decoder = [driveManager = m_driveManager, settingsStore = m_settingsStore]() {
+        return std::make_unique<CddaDecoder>(driveManager, settingsStore);
+    };
+    creator.reader = [driveManager = m_driveManager]() {
+        return std::make_unique<CddaReader>(driveManager);
+    };
+    return creator;
+}
+} // namespace Fooyin::Cdda
+
+#include "moc_cddaplugin.cpp"

--- a/src/plugins/cdda/cddaplugin.h
+++ b/src/plugins/cdda/cddaplugin.h
@@ -1,0 +1,83 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <core/engine/inputplugin.h>
+#include <core/plugins/coreplugin.h>
+#include <core/plugins/plugin.h>
+#include <core/track.h>
+#include <gui/plugins/guiplugin.h>
+
+#include <memory>
+
+namespace Fooyin {
+class NetworkAccessManager;
+class PlayerController;
+class Playlist;
+class PlaylistHandler;
+class SettingsManager;
+class ConversionService;
+class CurrentPlaylistController;
+
+namespace Cdda {
+class AccurateRipVerifier;
+class CdDriveManager;
+class CdDriveSettingsStore;
+class RipAudioCdDialog;
+struct CdToc;
+struct CdDriveObservation;
+
+class CddaPlugin : public QObject,
+                   public Plugin,
+                   public CorePlugin,
+                   public InputPlugin,
+                   public GuiPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.fooyin.fooyin.plugin" FILE "cdda.json")
+    Q_INTERFACES(Fooyin::Plugin Fooyin::CorePlugin Fooyin::InputPlugin Fooyin::GuiPlugin)
+
+public:
+    void initialise(const CorePluginContext& context) override;
+    void initialise(const GuiPluginContext& context) override;
+
+    [[nodiscard]] QString inputName() const override;
+    [[nodiscard]] InputCreator inputCreator() const override;
+
+private:
+    void addToPlaylist(const TrackList& tracks, const CdDriveObservation& observation);
+    void play(const TrackList& tracks, const CdDriveObservation& observation);
+    void rip(const TrackList& tracks, const CdDriveObservation& observation);
+    void startRip(RipAudioCdDialog* dialog, TrackList tracks, CdToc toc, QString presetId, bool showSetup,
+                  bool verifyAccurateRip);
+    void startConversion(RipAudioCdDialog* dialog, const TrackList& tracks, const QString& presetId, bool showSetup,
+                         std::shared_ptr<AccurateRipVerifier> verifier, QString lookupMessage = {});
+
+    PlayerController* m_playerController;
+    PlaylistHandler* m_playlistHandler;
+    CurrentPlaylistController* m_playlistController;
+    ConversionService* m_conversionService;
+    std::shared_ptr<NetworkAccessManager> m_networkAccess;
+    SettingsManager* m_settingsManager;
+
+    std::shared_ptr<CdDriveManager> m_driveManager;
+    std::shared_ptr<CdDriveSettingsStore> m_settingsStore;
+};
+} // namespace Cdda
+} // namespace Fooyin

--- a/src/plugins/cdda/cddareader.cpp
+++ b/src/plugins/cdda/cddareader.cpp
@@ -1,0 +1,230 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddareader.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+using namespace Qt::StringLiterals;
+
+constexpr auto SampleRate = 44100;
+constexpr auto Channels   = 2;
+constexpr auto BitDepth   = 16;
+constexpr auto Bitrate    = 1411;
+
+namespace Fooyin::Cdda {
+namespace {
+
+std::expected<void, QString> populateTrack(Track& track, const CdTocTrack& tocTrack, int trackTotal,
+                                           const QString& discId, const CdText& cdText)
+{
+    const auto duration = durationForSectors(static_cast<uint64_t>(tocTrack.endSectorExclusive - tocTrack.firstSector));
+    if(!duration) {
+        return std::unexpected(duration.error());
+    }
+
+    const QString physicalTrackNumber = QString::number(tocTrack.number);
+    CdTextFields trackText;
+    if(cdText.tracks.contains(tocTrack.number)) {
+        trackText = cdText.tracks.at(tocTrack.number);
+    }
+
+    if(track.title().isEmpty()) {
+        track.setTitle(trackText.title.isEmpty() ? CddaReader::tr("Track %1").arg(tocTrack.number, 2, 10, u'0')
+                                                 : trackText.title);
+    }
+    if(track.album().isEmpty()) {
+        track.setAlbum(cdText.disc.title.isEmpty() ? CddaReader::tr("Audio CD") : cdText.disc.title);
+    }
+    if(track.artists().isEmpty()) {
+        const QString artist = trackText.performer.isEmpty() ? cdText.disc.performer : trackText.performer;
+        if(!artist.isEmpty()) {
+            track.setArtists({artist});
+        }
+    }
+    if(track.albumArtists().isEmpty() && !cdText.disc.performer.isEmpty()) {
+        track.setAlbumArtists({cdText.disc.performer});
+    }
+    if(track.genres().isEmpty()) {
+        const QString genre = trackText.genre.isEmpty() ? cdText.disc.genre : trackText.genre;
+        if(!genre.isEmpty()) {
+            track.setGenres({genre});
+        }
+    }
+    if(track.composers().isEmpty()) {
+        const QString composer = trackText.composer.isEmpty() ? cdText.disc.composer : trackText.composer;
+        if(!composer.isEmpty()) {
+            track.setComposers({composer});
+        }
+    }
+    if(track.comment().isEmpty()) {
+        track.setComment(trackText.message.isEmpty() ? cdText.disc.message : trackText.message);
+    }
+    if(!track.hasExtraTag(u"ISRC"_s) && !trackText.isrc.isEmpty()) {
+        track.addExtraTag(u"ISRC"_s, trackText.isrc);
+    }
+    if(track.trackNumber().isEmpty()) {
+        track.setTrackNumber(physicalTrackNumber);
+    }
+    if(track.trackTotal().isEmpty()) {
+        track.setTrackTotal(QString::number(trackTotal));
+    }
+
+    track.setDuration(*duration);
+    track.setSampleRate(SampleRate);
+    track.setChannels(Channels);
+    track.setBitDepth(BitDepth);
+    track.setBitrate(Bitrate);
+    track.setCodec(u"CDDA"_s);
+    track.setEncoding(u"Lossless"_s);
+    track.setExtraProperty(u"_CDDA_DISC_ID"_s, discId);
+    track.setExtraProperty(u"_CDDA_TRACK_NUMBER"_s, physicalTrackNumber);
+
+    return {};
+}
+} // namespace
+
+std::expected<TrackList, QString> tracksForDisc(const CdToc& toc, const QString& discId, const CdText& cdText)
+{
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(invalidTocUserMessage());
+    }
+
+    const QString filepath = cddaUrl(discId);
+    if(filepath.isEmpty()) {
+        return std::unexpected(CddaReader::tr("Invalid audio CD identity"));
+    }
+
+    const std::vector<CdTocTrack> tocTracks = audioTracks(toc);
+
+    TrackList tracks;
+    tracks.reserve(tocTracks.size());
+
+    const auto trackTotal = static_cast<int>(tocTracks.size());
+    for(int subsong{0}; subsong < trackTotal; ++subsong) {
+        Track track{filepath, subsong};
+
+        if(const auto result = populateTrack(track, tocTracks.at(subsong), trackTotal, discId, cdText); !result) {
+            return std::unexpected(result.error());
+        }
+
+        track.setMetadataWasRead(true);
+        tracks.push_back(std::move(track));
+    }
+
+    return tracks;
+}
+
+CddaReader::CddaReader(std::shared_ptr<CdDriveManager> driveManager)
+    : m_driveManager{std::move(driveManager)}
+{ }
+
+QStringList CddaReader::extensions() const
+{
+    return {};
+}
+
+QStringList CddaReader::supportedSchemes() const
+{
+    return {QString::fromLatin1(Scheme)};
+}
+
+bool CddaReader::canReadCover() const
+{
+    return false;
+}
+
+bool CddaReader::canWriteMetaData() const
+{
+    return false;
+}
+
+int CddaReader::subsongCount() const
+{
+    return static_cast<int>(m_audioTracks.size());
+}
+
+bool CddaReader::init(const AudioSource& source)
+{
+    clear();
+
+    const auto discId = discIdFromCddaUrl(source.filepath);
+    if(!discId) {
+        m_error = u"Invalid audio CD URI"_s;
+        return false;
+    }
+
+    auto observation = m_driveManager->resolveDisc(*discId);
+    if(!observation) {
+        m_error = observation.error().message;
+        return false;
+    }
+    if(!observation->toc) {
+        m_error = u"Audio CD TPC is unavailable"_s;
+        return false;
+    }
+
+    m_sourcePath  = source.filepath;
+    m_discId      = *discId;
+    m_toc         = *observation->toc;
+    m_cdText      = observation->cdText.value_or(CdText{});
+    m_audioTracks = audioTracks(m_toc);
+
+    return !m_audioTracks.empty();
+}
+
+bool CddaReader::readTrack(const AudioSource& source, Track& track)
+{
+    m_error.clear();
+
+    if(m_sourcePath.isEmpty() || source.filepath != m_sourcePath || track.filepath() != m_sourcePath) {
+        m_error = u"Audio CD reader source changed after initialization"_s;
+        return false;
+    }
+
+    const auto trackTotal = static_cast<int>(m_audioTracks.size());
+
+    const int subsong = track.subsong();
+    if(subsong < 0 || subsong >= trackTotal) {
+        m_error = u"Audio CD track index is out of range"_s;
+        return false;
+    }
+
+    const auto result = populateTrack(track, m_audioTracks.at(subsong), trackTotal, m_discId, m_cdText);
+    if(!result) {
+        m_error = result.error();
+    }
+    return result.has_value();
+}
+
+QString CddaReader::lastError() const
+{
+    return m_error;
+}
+
+void CddaReader::clear()
+{
+    m_sourcePath.clear();
+    m_discId.clear();
+    m_error.clear();
+    m_toc    = {};
+    m_cdText = {};
+    m_audioTracks.clear();
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddareader.cpp
+++ b/src/plugins/cdda/cddareader.cpp
@@ -46,7 +46,7 @@ std::expected<void, QString> populateTrack(Track& track, const CdTocTrack& tocTr
     }
 
     if(track.title().isEmpty()) {
-        track.setTitle(trackText.title.isEmpty() ? CddaReader::tr("Track %1").arg(tocTrack.number, 2, 10, u'0')
+        track.setTitle(trackText.title.isEmpty() ? CddaReader::tr("Track %1").arg(tocTrack.number, 2, 10, QChar{u'0'})
                                                  : trackText.title);
     }
     if(track.album().isEmpty()) {

--- a/src/plugins/cdda/cddareader.h
+++ b/src/plugins/cdda/cddareader.h
@@ -1,0 +1,62 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddadrivemanager.h"
+
+#include <core/engine/audioinput.h>
+
+#include <expected>
+#include <memory>
+#include <vector>
+
+namespace Fooyin::Cdda {
+[[nodiscard]] std::expected<TrackList, QString> tracksForDisc(const CdToc& toc, const QString& discId,
+                                                              const CdText& cdText = {});
+
+class CddaReader : public AudioReader
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::CddaReader)
+
+public:
+    explicit CddaReader(std::shared_ptr<CdDriveManager> driveManager);
+
+    [[nodiscard]] QStringList extensions() const override;
+    [[nodiscard]] QStringList supportedSchemes() const override;
+    [[nodiscard]] bool canReadCover() const override;
+    [[nodiscard]] bool canWriteMetaData() const override;
+    [[nodiscard]] int subsongCount() const override;
+
+    bool init(const AudioSource& source) override;
+    [[nodiscard]] bool readTrack(const AudioSource& source, Track& track) override;
+
+    [[nodiscard]] QString lastError() const;
+
+private:
+    void clear();
+
+    std::shared_ptr<CdDriveManager> m_driveManager;
+    QString m_sourcePath;
+    QString m_discId;
+    QString m_error;
+    CdToc m_toc;
+    CdText m_cdText;
+    std::vector<CdTocTrack> m_audioTracks;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddasectorreader.cpp
+++ b/src/plugins/cdda/cddasectorreader.cpp
@@ -1,0 +1,235 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddasectorreader.h"
+
+#include "cddatoc.h"
+
+#include <QLoggingCategory>
+
+#include <limits>
+#include <optional>
+
+using namespace Qt::StringLiterals;
+
+Q_LOGGING_CATEGORY(CDDA_SECTOR_READER, "fy.cdda.sectorreader")
+
+constexpr auto BytesPerPcmFrame = 4;
+
+namespace Fooyin::Cdda {
+namespace {
+CdError internalReadError()
+{
+    return {.code = CdDriveError::ReadFailed, .message = {}, .platformCode = 0};
+}
+
+} // namespace
+
+CddaSectorReader::CddaSectorReader(CdDriveSession* session, CdRippingSecurity security, std::stop_token stopToken)
+    : m_session{session}
+    , m_security{security}
+    , m_stopToken{std::move(stopToken)}
+{ }
+
+std::expected<CdSectorRead, CdError> CddaSectorReader::readAudioSectors(int firstSector, int count)
+{
+    if(firstSector < 0 || count < 0 || count > MaximumSectorsPerPolicyRead
+       || firstSector > std::numeric_limits<int>::max() - count) {
+        qCWarning(CDDA_SECTOR_READER) << "Rejected invalid sector request:"
+                                      << "firstSector=" << firstSector << "count=" << count
+                                      << "maximum=" << MaximumSectorsPerPolicyRead;
+        return std::unexpected(internalReadError());
+    }
+    if(const auto cancelled = cancellationError()) {
+        return std::unexpected(*cancelled);
+    }
+    if(count == 0) {
+        return CdSectorRead{};
+    }
+
+    return readExact(firstSector, count);
+}
+
+std::expected<CdFrameRead, CdError> CddaSectorReader::readCorrectedFrames(const CdToc& toc, const CdTocTrack& track,
+                                                                          uint64_t firstFrame, int frameCount,
+                                                                          int readOffsetFrames)
+{
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(
+            CdError{.code = CdDriveError::NotAudioDisc, .message = invalidTocUserMessage(), .platformCode = 0});
+    }
+
+    const auto trackIt = std::ranges::find(toc.tracks, track);
+    if(trackIt == toc.tracks.end() || !track.isAudio || frameCount < 0 || frameCount > MaximumFramesPerPolicyRead) {
+        qCWarning(CDDA_SECTOR_READER) << "Rejected invalid track-frame request:"
+                                      << "track=" << track.number << "isAudio=" << track.isAudio
+                                      << "inToc=" << (trackIt != toc.tracks.end()) << "frameCount=" << frameCount
+                                      << "maximum=" << MaximumFramesPerPolicyRead;
+        return std::unexpected(internalReadError());
+    }
+
+    const uint64_t trackFrames = static_cast<uint64_t>(track.endSectorExclusive - track.firstSector) * FramesPerSector;
+    if(firstFrame > trackFrames || static_cast<uint64_t>(frameCount) > trackFrames - firstFrame) {
+        qCWarning(CDDA_SECTOR_READER) << "Rejected out-of-range track-frame request:"
+                                      << "track=" << track.number << "firstFrame=" << firstFrame
+                                      << "frameCount=" << frameCount << "trackFrames=" << trackFrames;
+        return std::unexpected(internalReadError());
+    }
+    if(const auto cancelled = cancellationError()) {
+        return std::unexpected(*cancelled);
+    }
+    if(frameCount == 0) {
+        return CdFrameRead{};
+    }
+
+    const int trackIndex = static_cast<int>(std::distance(toc.tracks.begin(), trackIt));
+    int audioFirst{trackIndex};
+    while(audioFirst > 0 && toc.tracks.at(audioFirst - 1).isAudio) {
+        --audioFirst;
+    }
+    int audioLast{trackIndex};
+    while(std::cmp_less(audioLast + 1, toc.tracks.size()) && toc.tracks.at(audioLast + 1).isAudio) {
+        ++audioLast;
+    }
+
+    const int64_t readableStart = static_cast<int64_t>(toc.tracks.at(audioFirst).firstSector) * FramesPerSector;
+    const int64_t readableEnd   = static_cast<int64_t>(toc.tracks.at(audioLast).endSectorExclusive) * FramesPerSector;
+    const int64_t logicalStart
+        = (static_cast<int64_t>(track.firstSector) * FramesPerSector) + static_cast<int64_t>(firstFrame);
+    const int64_t correctedStart = logicalStart + static_cast<int64_t>(readOffsetFrames);
+    const int64_t correctedEnd   = correctedStart + frameCount;
+    const int prefixFrames
+        = static_cast<int>(std::clamp(readableStart - correctedStart, int64_t{0}, static_cast<int64_t>(frameCount)));
+    const int suffixFrames = static_cast<int>(
+        std::clamp(correctedEnd - readableEnd, int64_t{0}, static_cast<int64_t>(frameCount - prefixFrames)));
+    const int physicalFrames = frameCount - prefixFrames - suffixFrames;
+
+    QStringList correctionWarnings;
+    CdFrameRead output;
+    output.pcm.reserve(static_cast<qsizetype>(frameCount) * BytesPerPcmFrame);
+
+    if(prefixFrames > 0) {
+        output.pcm.append(QByteArray(static_cast<qsizetype>(prefixFrames) * BytesPerPcmFrame, '\0'));
+        correctionWarnings.push_back(
+            tr("CD read offset correction padded %Ln frame(s) with silence before the readable audio range", nullptr,
+               prefixFrames));
+    }
+
+    if(physicalFrames > 0) {
+        const int64_t physicalStart  = std::max(correctedStart, readableStart);
+        const int firstSector        = static_cast<int>(physicalStart / FramesPerSector);
+        const int frameInSector      = static_cast<int>(physicalStart % FramesPerSector);
+        const int64_t physicalEnd    = physicalStart + physicalFrames;
+        const int endSectorExclusive = static_cast<int>((physicalEnd + FramesPerSector - 1) / FramesPerSector);
+
+        QByteArray sectorPcm;
+        sectorPcm.reserve(static_cast<qsizetype>(endSectorExclusive - firstSector) * BytesPerSector);
+
+        int sector{firstSector};
+        while(sector < endSectorExclusive) {
+            const int sectorCount = std::min(endSectorExclusive - sector, MaximumSectorsPerPolicyRead);
+            auto read             = readAudioSectors(sector, sectorCount);
+            if(!read) {
+                return std::unexpected(read.error());
+            }
+            sectorPcm.append(read->pcm);
+            sector += read->sectorsRead;
+        }
+
+        const qsizetype byteOffset = static_cast<qsizetype>(frameInSector) * BytesPerPcmFrame;
+        const qsizetype byteCount  = static_cast<qsizetype>(physicalFrames) * BytesPerPcmFrame;
+        if(byteOffset > sectorPcm.size() || byteCount > sectorPcm.size() - byteOffset) {
+            qCWarning(CDDA_SECTOR_READER)
+                << "Corrected CD read produced an invalid PCM window:"
+                << "bufferBytes=" << sectorPcm.size() << "byteOffset=" << byteOffset << "byteCount=" << byteCount;
+            return std::unexpected(internalReadError());
+        }
+
+        output.pcm.append(sectorPcm.constData() + byteOffset, byteCount);
+    }
+
+    if(suffixFrames > 0) {
+        output.pcm.append(QByteArray(static_cast<qsizetype>(suffixFrames) * BytesPerPcmFrame, '\0'));
+        correctionWarnings.push_back(
+            tr("CD read offset correction padded %Ln frame(s) with silence after the readable audio range", nullptr,
+               suffixFrames));
+    }
+
+    if(output.pcm.size() != static_cast<qsizetype>(frameCount) * BytesPerPcmFrame) {
+        qCWarning(CDDA_SECTOR_READER) << "Corrected CD read produced an incomplete PCM buffer:"
+                                      << "actualBytes=" << output.pcm.size()
+                                      << "expectedBytes=" << static_cast<qsizetype>(frameCount) * BytesPerPcmFrame;
+        return std::unexpected(internalReadError());
+    }
+
+    output.framesRead = frameCount;
+    m_warnings.append(correctionWarnings);
+    return output;
+}
+
+QStringList CddaSectorReader::takeWarnings()
+{
+    return std::exchange(m_warnings, {});
+}
+
+std::expected<CdSectorRead, CdError> CddaSectorReader::readExact(int firstSector, int count)
+{
+    CdSectorRead output;
+    output.pcm.reserve(static_cast<qsizetype>(count) * BytesPerSector);
+
+    while(output.sectorsRead < count) {
+        if(const auto cancelled = cancellationError()) {
+            return std::unexpected(*cancelled);
+        }
+
+        const int remaining = count - output.sectorsRead;
+        const int requested = std::min(remaining, MaximumSectorsPerPolicyRead);
+
+        auto read = m_session->readAudioSectorsSecure(firstSector + output.sectorsRead, requested, m_security);
+        if(!read) {
+            return std::unexpected(read.error());
+        }
+        if(const auto valid = validateSectorRead(*read, requested); !valid) {
+            return std::unexpected(valid.error());
+        }
+        if(const auto cancelled = cancellationError()) {
+            return std::unexpected(*cancelled);
+        }
+        if(read->sectorsRead == 0) {
+            qCWarning(CDDA_SECTOR_READER) << "CD drive made no progress while completing a sector request:"
+                                          << "firstSector=" << firstSector << "requestedSectors=" << count
+                                          << "completedSectors=" << output.sectorsRead;
+            return std::unexpected(internalReadError());
+        }
+
+        output.pcm.append(read->pcm);
+        output.sectorsRead += read->sectorsRead;
+        m_warnings.append(m_session->takeWarnings());
+    }
+
+    return output;
+}
+
+std::optional<CdError> CddaSectorReader::cancellationError() const
+{
+    if(!m_stopToken.stop_requested()) {
+        return {};
+    }
+    return CdError{.code = CdDriveError::Cancelled, .message = tr("CD extraction was cancelled"), .platformCode = 0};
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddasectorreader.h
+++ b/src/plugins/cdda/cddasectorreader.h
@@ -1,0 +1,62 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drive/cddrivebackend.h"
+
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <stop_token>
+
+namespace Fooyin::Cdda {
+constexpr auto MaximumSectorsPerPolicyRead = 16;
+constexpr auto MaximumFramesPerPolicyRead  = MaximumSectorsPerPolicyRead * FramesPerSector;
+
+struct CdFrameRead
+{
+    QByteArray pcm; // Interleaved signed 16-bit stereo PCM.
+    int framesRead{0};
+
+    bool operator==(const CdFrameRead&) const = default;
+};
+
+class CddaSectorReader
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::CddaSectorReader)
+
+public:
+    CddaSectorReader(CdDriveSession* session, CdRippingSecurity security, std::stop_token stopToken = {});
+
+    [[nodiscard]] std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count);
+    [[nodiscard]] std::expected<CdFrameRead, CdError> readCorrectedFrames(const CdToc& toc, const CdTocTrack& track,
+                                                                          uint64_t firstFrame, int frameCount,
+                                                                          int readOffsetFrames);
+    [[nodiscard]] QStringList takeWarnings();
+
+private:
+    [[nodiscard]] std::expected<CdSectorRead, CdError> readExact(int firstSector, int count);
+    [[nodiscard]] std::optional<CdError> cancellationError() const;
+
+    CdDriveSession* m_session;
+    CdRippingSecurity m_security;
+    std::stop_token m_stopToken;
+    QStringList m_warnings;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddatoc.cpp
+++ b/src/plugins/cdda/cddatoc.cpp
@@ -1,0 +1,235 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddatoc.h"
+
+#include <QCoreApplication>
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QLoggingCategory>
+#include <QStringList>
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+#include <limits>
+
+using namespace Qt::StringLiterals;
+
+Q_LOGGING_CATEGORY(CDDA_TOC, "fy.cdda.toc")
+
+namespace Fooyin::Cdda {
+namespace {
+std::expected<uint64_t, QString> checkedMultiply(uint64_t value, uint64_t multiplier)
+{
+    if(multiplier != 0 && value > std::numeric_limits<uint64_t>::max() / multiplier) {
+        return std::unexpected(QCoreApplication::translate("Fooyin::Cdda::CdToc", "CD sector conversion overflow"));
+    }
+    return value * multiplier;
+}
+
+uint32_t musicBrainzOffset(int lba)
+{
+    return static_cast<uint32_t>(lba + LeadInSectors);
+}
+
+const char* cdTocErrorDescription(CdTocError error)
+{
+    switch(error) {
+        case CdTocError::InvalidTrackNumberRange:
+            return "invalid track number range";
+        case CdTocError::MissingTracks:
+            return "missing declared tracks";
+        case CdTocError::InvalidLeadout:
+            return "invalid leadout";
+        case CdTocError::LeadoutTooLarge:
+            return "leadout exceeds the supported range";
+        case CdTocError::InvalidTrackNumbers:
+            return "track numbers are missing, duplicated, or out of order";
+        case CdTocError::InvalidTrackSectorRange:
+            return "invalid track sector range";
+        case CdTocError::NoncontiguousTrackSectorRanges:
+            return "noncontiguous track sector ranges";
+        case CdTocError::TrackBeyondLeadout:
+            return "track extends beyond the leadout";
+        case CdTocError::FinalTrackBeforeLeadout:
+            return "final track does not end at the leadout";
+        case CdTocError::NoAudioTracks:
+            return "no audio tracks";
+    }
+    return "unknown error";
+}
+
+std::unexpected<CdTocError> invalidToc(CdTocError error)
+{
+    qCWarning(CDDA_TOC) << "Invalid CD TOC:" << cdTocErrorDescription(error);
+    return std::unexpected(error);
+}
+} // namespace
+
+QString invalidTocUserMessage()
+{
+    return QCoreApplication::translate("Fooyin::Cdda::CdToc", "The CD has an invalid TOC");
+}
+
+std::expected<void, CdTocError> validateToc(const CdToc& toc)
+{
+    if(toc.firstTrackNumber < 1 || toc.lastTrackNumber < toc.firstTrackNumber || toc.lastTrackNumber > MaximumTracks) {
+        return invalidToc(CdTocError::InvalidTrackNumberRange);
+    }
+
+    const int expectedCount = toc.lastTrackNumber - toc.firstTrackNumber + 1;
+
+    if(std::cmp_not_equal(toc.tracks.size(), expectedCount)) {
+        return invalidToc(CdTocError::MissingTracks);
+    }
+    if(toc.leadoutSector <= 0) {
+        return invalidToc(CdTocError::InvalidLeadout);
+    }
+    if(toc.leadoutSector > std::numeric_limits<int>::max() - LeadInSectors) {
+        return invalidToc(CdTocError::LeadoutTooLarge);
+    }
+
+    bool hasAudio{false};
+    int previousEnd{-1};
+
+    for(int index{0}; std::cmp_less(index, toc.tracks.size()); ++index) {
+        const CdTocTrack& track  = toc.tracks.at(index);
+        const int expectedNumber = toc.firstTrackNumber + index;
+
+        if(track.number != expectedNumber) {
+            return invalidToc(CdTocError::InvalidTrackNumbers);
+        }
+        if(track.firstSector < 0 || track.endSectorExclusive <= track.firstSector) {
+            return invalidToc(CdTocError::InvalidTrackSectorRange);
+        }
+        if(index > 0 && track.firstSector != previousEnd) {
+            return invalidToc(CdTocError::NoncontiguousTrackSectorRanges);
+        }
+        if(track.endSectorExclusive > toc.leadoutSector) {
+            return invalidToc(CdTocError::TrackBeyondLeadout);
+        }
+
+        previousEnd = track.endSectorExclusive;
+        hasAudio |= track.isAudio;
+    }
+
+    if(toc.tracks.back().endSectorExclusive != toc.leadoutSector) {
+        return invalidToc(CdTocError::FinalTrackBeforeLeadout);
+    }
+    if(!hasAudio) {
+        return invalidToc(CdTocError::NoAudioTracks);
+    }
+
+    return {};
+}
+
+std::vector<CdTocTrack> audioTracks(const CdToc& toc)
+{
+    std::vector<CdTocTrack> result;
+    result.reserve(toc.tracks.size());
+    std::ranges::copy_if(toc.tracks, std::back_inserter(result), &CdTocTrack::isAudio);
+    return result;
+}
+
+std::optional<CdTocTrack> audioTrackForSubsong(const CdToc& toc, int subsong)
+{
+    if(subsong < 0) {
+        return {};
+    }
+
+    int audioIndex{0};
+    for(const CdTocTrack& track : toc.tracks) {
+        if(!track.isAudio) {
+            continue;
+        }
+        if(audioIndex++ == subsong) {
+            return track;
+        }
+    }
+    return {};
+}
+
+std::expected<uint64_t, QString> framesForSectors(uint64_t sectors)
+{
+    return checkedMultiply(sectors, FramesPerSector);
+}
+
+std::expected<uint64_t, QString> bytesForSectors(uint64_t sectors)
+{
+    return checkedMultiply(sectors, BytesPerSector);
+}
+
+std::expected<uint64_t, QString> durationForSectors(uint64_t sectors)
+{
+    const auto milliseconds = checkedMultiply(sectors, 1000);
+    if(!milliseconds) {
+        return std::unexpected(milliseconds.error());
+    }
+    return *milliseconds / SectorsPerSecond;
+}
+
+std::expected<QString, CdTocError> musicBrainzDiscId(const CdToc& toc)
+{
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(valid.error());
+    }
+
+    // MusicBrainz stores the leadout at offset 0 and track offsets at their
+    // corresponding 1-based tracknumbers
+    std::array<uint32_t, MaximumTracks + 1> offsets{};
+    offsets[0] = musicBrainzOffset(toc.leadoutSector);
+    for(const CdTocTrack& track : toc.tracks) {
+        offsets.at(track.number) = musicBrainzOffset(track.firstSector);
+    }
+
+    QByteArray input;
+    input.reserve(4 + (offsets.size() * 8));
+
+    input += QByteArray::number(toc.firstTrackNumber, 16).rightJustified(2, '0').toUpper();
+    input += QByteArray::number(toc.lastTrackNumber, 16).rightJustified(2, '0').toUpper();
+    for(const uint32_t offset : offsets) {
+        input += QByteArray::number(offset, 16).rightJustified(8, '0').toUpper();
+    }
+
+    QByteArray discId = QCryptographicHash::hash(input, QCryptographicHash::Sha1).toBase64();
+    discId.replace('+', '.');
+    discId.replace('/', '_');
+    discId.replace('=', '-');
+
+    return QString::fromLatin1(discId);
+}
+
+std::expected<QString, CdTocError> musicBrainzToc(const CdToc& toc)
+{
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(valid.error());
+    }
+
+    QStringList parts{QString::number(toc.firstTrackNumber), QString::number(toc.lastTrackNumber),
+                      QString::number(musicBrainzOffset(toc.leadoutSector))};
+    parts.reserve(3 + toc.tracks.size());
+
+    for(const CdTocTrack& track : toc.tracks) {
+        parts.push_back(QString::number(musicBrainzOffset(track.firstSector)));
+    }
+
+    return parts.join(u'+');
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddatoc.h
+++ b/src/plugins/cdda/cddatoc.h
@@ -1,0 +1,57 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddatypes.h"
+
+#include <QString>
+
+#include <expected>
+#include <optional>
+#include <vector>
+
+namespace Fooyin::Cdda {
+enum class CdTocError : uint8_t
+{
+    InvalidTrackNumberRange = 0,
+    MissingTracks,
+    InvalidLeadout,
+    LeadoutTooLarge,
+    InvalidTrackNumbers,
+    InvalidTrackSectorRange,
+    NoncontiguousTrackSectorRanges,
+    TrackBeyondLeadout,
+    FinalTrackBeforeLeadout,
+    NoAudioTracks,
+};
+
+[[nodiscard]] QString invalidTocUserMessage();
+[[nodiscard]] std::expected<void, CdTocError> validateToc(const CdToc& toc);
+[[nodiscard]] std::vector<CdTocTrack> audioTracks(const CdToc& toc);
+[[nodiscard]] std::optional<CdTocTrack> audioTrackForSubsong(const CdToc& toc, int subsong);
+
+[[nodiscard]] std::expected<uint64_t, QString> framesForSectors(uint64_t sectors);
+[[nodiscard]] std::expected<uint64_t, QString> bytesForSectors(uint64_t sectors);
+[[nodiscard]] std::expected<uint64_t, QString> durationForSectors(uint64_t sectors);
+
+//! Calculates the case-sensitive MusicBrainz Disc ID from a TOC.
+[[nodiscard]] std::expected<QString, CdTocError> musicBrainzDiscId(const CdToc& toc);
+//! Returns the MusicBrainz TOC query value using absolute frame offsets.
+[[nodiscard]] std::expected<QString, CdTocError> musicBrainzToc(const CdToc& toc);
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddatypes.h
+++ b/src/plugins/cdda/cddatypes.h
@@ -1,0 +1,84 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <unordered_map>
+#include <vector>
+
+namespace Fooyin::Cdda {
+constexpr auto SectorsPerSecond = 75;
+constexpr auto FramesPerSector  = 588;
+constexpr auto BytesPerSector   = 2352;
+constexpr auto LeadInSectors    = 150;
+constexpr auto MaximumTracks    = 99;
+
+// Sector positions use logical block addresses; track 1 normally starts at zero
+struct CdTocTrack
+{
+    int number{0};
+    int firstSector{0};
+    int endSectorExclusive{0};
+    bool isAudio{false};
+
+    bool operator==(const CdTocTrack&) const = default;
+};
+
+struct CdToc
+{
+    int firstTrackNumber{0};
+    int lastTrackNumber{0};
+    int leadoutSector{0};
+    std::vector<CdTocTrack> tracks;
+
+    bool operator==(const CdToc&) const = default;
+};
+
+struct CdTextFields
+{
+    QString title;
+    QString performer;
+    QString genre;
+    QString composer;
+    QString message;
+    QString isrc;
+
+    [[nodiscard]] bool empty() const
+    {
+        return title.isEmpty() && performer.isEmpty() && genre.isEmpty() && composer.isEmpty() && message.isEmpty()
+            && isrc.isEmpty();
+    }
+
+    bool operator==(const CdTextFields&) const = default;
+};
+
+struct CdText
+{
+    CdTextFields disc;
+    std::unordered_map<int, CdTextFields> tracks;
+
+    [[nodiscard]] bool empty() const
+    {
+        return disc.empty() && tracks.empty();
+    }
+
+    bool operator==(const CdText&) const = default;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddaurl.cpp
+++ b/src/plugins/cdda/cddaurl.cpp
@@ -1,0 +1,54 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddaurl.h"
+
+#include <QRegularExpression>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+bool isValidDiscId(const QString& discId)
+{
+    static const QRegularExpression expression{uR"(^[A-Za-z0-9._-]{28}$)"_s};
+    return expression.match(discId).hasMatch();
+}
+
+QString cddaUrl(const QString& discId)
+{
+    if(!isValidDiscId(discId)) {
+        return {};
+    }
+    return u"cdda:///%1"_s.arg(discId);
+}
+
+std::optional<QString> discIdFromCddaUrl(const QString& path)
+{
+    static constexpr QLatin1StringView Prefix{"cdda:///"};
+    if(!path.startsWith(Prefix, Qt::CaseSensitive)) {
+        return {};
+    }
+
+    QString discId = path.sliced(Prefix.size());
+    if(!isValidDiscId(discId)) {
+        return {};
+    }
+
+    return discId;
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/cddaurl.h
+++ b/src/plugins/cdda/cddaurl.h
@@ -1,0 +1,31 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+#include <optional>
+
+namespace Fooyin::Cdda {
+constexpr auto Scheme = "cdda";
+
+[[nodiscard]] bool isValidDiscId(const QString& discId);
+[[nodiscard]] QString cddaUrl(const QString& discId);
+[[nodiscard]] std::optional<QString> discIdFromCddaUrl(const QString& path);
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/drive/cddrivebackend.cpp
+++ b/src/plugins/cdda/drive/cddrivebackend.cpp
@@ -1,0 +1,87 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddrivebackend.h"
+
+#include <QLoggingCategory>
+
+#include <limits>
+
+Q_LOGGING_CATEGORY(CDDA_DRIVE_BACKEND, "fy.cdda.drivebackend")
+
+namespace Fooyin::Cdda {
+CdText CdDriveSession::readCdText(const CdToc& /*toc*/)
+{
+    return {};
+}
+
+std::expected<CdSectorRead, CdError> CdDriveSession::readAudioSectorsSecure(int firstSector, int count,
+                                                                            CdRippingSecurity security)
+{
+    if(security == CdRippingSecurity::Disabled) {
+        return readAudioSectors(firstSector, count);
+    }
+    return std::unexpected(CdError{.code         = CdDriveError::Unsupported,
+                                   .message      = tr("Secure CD extraction is unavailable for this drive backend"),
+                                   .platformCode = 0});
+}
+
+std::expected<void, CdError> CdDriveSession::setReadSpeed(int /*speed*/)
+{
+    return std::unexpected(CdError{.code         = CdDriveError::Unsupported,
+                                   .message      = tr("CD read speed control is unavailable for this drive backend"),
+                                   .platformCode = 0});
+}
+
+QStringList CdDriveSession::takeWarnings()
+{
+    return {};
+}
+
+std::expected<void, CdError> validateSectorRead(const CdSectorRead& read, int requestedSectors)
+{
+    if(requestedSectors < 0 || read.sectorsRead < 0 || read.sectorsRead > requestedSectors) {
+        qCWarning(CDDA_DRIVE_BACKEND) << "CD drive returned an invalid sector count:"
+                                      << "requested=" << requestedSectors << "returned=" << read.sectorsRead;
+        return std::unexpected(CdError{.code = CdDriveError::ReadFailed, .message = {}, .platformCode = 0});
+    }
+
+    const auto expectedBytes = static_cast<qsizetype>(read.sectorsRead) * BytesPerSector;
+    if(read.pcm.size() != expectedBytes) {
+        qCWarning(CDDA_DRIVE_BACKEND) << "CD drive returned an invalid sector buffer:"
+                                      << "sectors=" << read.sectorsRead << "actualBytes=" << read.pcm.size()
+                                      << "expectedBytes=" << expectedBytes;
+        return std::unexpected(CdError{.code = CdDriveError::ReadFailed, .message = {}, .platformCode = 0});
+    }
+
+    return {};
+}
+
+std::expected<void, CdError> validateSectorReadRequest(int firstSector, int count, int maximumSectors)
+{
+    if(firstSector < 0 || count < 0 || maximumSectors <= 0 || count > maximumSectors
+       || firstSector > std::numeric_limits<int>::max() - count) {
+        qCWarning(CDDA_DRIVE_BACKEND) << "Rejected invalid backend sector request:"
+                                      << "firstSector=" << firstSector << "count=" << count
+                                      << "maximum=" << maximumSectors;
+        return std::unexpected(CdError{.code = CdDriveError::ReadFailed, .message = {}, .platformCode = EINVAL});
+    }
+
+    return {};
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/drive/cddrivebackend.h
+++ b/src/plugins/cdda/drive/cddrivebackend.h
@@ -1,0 +1,126 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddatypes.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QString>
+#include <QStringList>
+
+#include <expected>
+#include <memory>
+
+namespace Fooyin::Cdda {
+enum class CdRippingSecurity : uint8_t
+{
+    Disabled = 0,
+    Standard,
+    Paranoid,
+};
+
+struct CdDriveInfo
+{
+    QString id; // Backend identifier passed back to CdDriveBackend::open()
+    QString displayName;
+    QString settingsKey;
+    bool supportsSpeedLimit{false};
+    QString vendor;
+    QString model;
+    QString revision;
+
+    bool operator==(const CdDriveInfo&) const = default;
+};
+
+enum class CdDriveError : uint8_t
+{
+    None = 0,
+    NoMedia,
+    TrayOpen,
+    AccessDenied,
+    NotAudioDisc,
+    MediaChanged,
+    DriveBusy,
+    ReadFailed,
+    Unsupported,
+    Cancelled,
+};
+
+struct CdError
+{
+    CdDriveError code{CdDriveError::None};
+    QString message;
+    int platformCode{0};
+
+    bool operator==(const CdError&) const = default;
+};
+
+struct CdSectorRead
+{
+    QByteArray pcm;
+    int sectorsRead{0};
+
+    bool operator==(const CdSectorRead&) const = default;
+};
+
+class CdDriveSession
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::CdDriveSession)
+
+public:
+    virtual ~CdDriveSession() = default;
+
+    virtual std::expected<CdToc, CdError> readToc() = 0;
+    virtual CdText readCdText(const CdToc& toc);
+    virtual std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count) = 0;
+    /*! Reads sectors using the requested extraction policy.
+     *  Backends without an error-correcting reader support Disabled only.
+     */
+    virtual std::expected<CdSectorRead, CdError> readAudioSectorsSecure(int firstSector, int count,
+                                                                        CdRippingSecurity security);
+
+    //! Limits reads to the requested CD speed multiplier. Zero selects the drive's maximum speed.
+    virtual std::expected<void, CdError> setReadSpeed(int speed);
+
+    virtual QStringList takeWarnings();
+    //! Requests cancellation of an active read; safe to call from another thread.
+    virtual void cancel() = 0;
+};
+
+class CdDriveBackend
+{
+public:
+    virtual ~CdDriveBackend() = default;
+
+    struct OpenedDrive
+    {
+        CdDriveInfo drive;
+        std::unique_ptr<CdDriveSession> session;
+    };
+
+    //! Enumerates stable device identifiers without opening or probing the drives.
+    virtual std::vector<CdDriveInfo> drives() = 0;
+    //! Opens a drive and returns hardware information obtained from the reserved handle.
+    virtual std::expected<OpenedDrive, CdError> open(const QString& driveId) = 0;
+};
+
+std::expected<void, CdError> validateSectorRead(const CdSectorRead& read, int requestedSectors);
+std::expected<void, CdError> validateSectorReadRequest(int firstSector, int count, int maximumSectors);
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/drive/libcdiodrivebackend.cpp
+++ b/src/plugins/cdda/drive/libcdiodrivebackend.cpp
@@ -1,0 +1,556 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libcdiodrivebackend.h"
+
+#include "cddadrivesettings.h"
+#include "cddatoc.h"
+
+#include <cdio/cdtext.h>
+#include <cdio/device.h>
+#include <cdio/paranoia/paranoia.h>
+#include <cdio/read.h>
+
+#include <atomic>
+#include <optional>
+
+using namespace Qt::StringLiterals;
+
+constexpr auto MaxSectorsPerRead = 16;
+constexpr auto StandardRetries   = 5;
+constexpr auto ParanoidRetries   = 20;
+
+namespace Fooyin::Cdda {
+namespace {
+enum class CddaError : int
+{
+    PermissionDeniedIoctl = -102,
+    PermissionDeniedData  = -103,
+    TrackNotAudio         = -402,
+    NoAudioTracks         = -403,
+    NoMedia               = -404,
+};
+
+QString cdTextValue(const cdtext_t* cdText, cdtext_field_t field, int track)
+{
+    const char* value = cdtext_get_const(cdText, field, static_cast<track_t>(track));
+    return value ? QString::fromUtf8(value).trimmed() : QString{};
+}
+
+CdTextFields cdTextFields(const cdtext_t* cdText, int track)
+{
+    return {.title     = cdTextValue(cdText, CDTEXT_FIELD_TITLE, track),
+            .performer = cdTextValue(cdText, CDTEXT_FIELD_PERFORMER, track),
+            .genre     = cdTextValue(cdText, CDTEXT_FIELD_GENRE, track),
+            .composer  = cdTextValue(cdText, CDTEXT_FIELD_COMPOSER, track),
+            .message   = cdTextValue(cdText, CDTEXT_FIELD_MESSAGE, track),
+            .isrc      = cdTextValue(cdText, CDTEXT_FIELD_ISRC, track)};
+}
+
+CdDriveInfo driveInfo(CdIo_t* cdio, const QString& device)
+{
+    QString vendor;
+    QString model;
+    QString revision;
+    bool supportsSpeedLimit{false};
+
+    cdio_hwinfo_t hardware{};
+    if(cdio_get_hwinfo(cdio, &hardware)) {
+        vendor   = QString::fromLatin1(hardware.psz_vendor).trimmed();
+        model    = QString::fromLatin1(hardware.psz_model).trimmed();
+        revision = QString::fromLatin1(hardware.psz_revision).trimmed();
+    }
+
+    cdio_drive_read_cap_t readCapabilities{};
+    cdio_drive_write_cap_t writeCapabilities{};
+    cdio_drive_misc_cap_t miscCapabilities{};
+    cdio_get_drive_cap(cdio, &readCapabilities, &writeCapabilities, &miscCapabilities);
+    supportsSpeedLimit = miscCapabilities & CDIO_DRIVE_CAP_MISC_SELECT_SPEED;
+
+    const QString label = QStringList{vendor, model}.join(u' ').simplified();
+    return {.id                 = device,
+            .displayName        = label.isEmpty() ? device : label,
+            .settingsKey        = cdDriveSettingsKey(u"libcdio"_s, vendor, model, device),
+            .supportsSpeedLimit = supportsSpeedLimit,
+            .vendor             = vendor,
+            .model              = model,
+            .revision           = revision};
+}
+
+CdError driveError(CdDriveError category, int platformCode, QString message, const QString& detail)
+{
+    if(!detail.isEmpty()) {
+        message += u'\n';
+        message += LibcdioDriveSession::tr("Details: %1").arg(detail.trimmed());
+    }
+
+    if(category == CdDriveError::AccessDenied) {
+        message += u'\n';
+        message += LibcdioDriveSession::tr("Check the disk drive device permissions.");
+    }
+
+    return {
+        .code         = category,
+        .message      = message,
+        .platformCode = platformCode,
+    };
+}
+
+CdError cdioError(driver_return_code_t code, QString message, QString detail = {})
+{
+    CdDriveError category{CdDriveError::ReadFailed};
+
+    switch(code) {
+        case DRIVER_OP_NOT_PERMITTED:
+            category = CdDriveError::AccessDenied;
+            break;
+
+        case DRIVER_OP_UNSUPPORTED:
+        case DRIVER_OP_NO_DRIVER:
+            category = CdDriveError::Unsupported;
+            break;
+
+        default:
+            break;
+    }
+
+    if(detail.isEmpty()) {
+        detail = QString::fromLocal8Bit(cdio_driver_errmsg(code));
+    }
+
+    return driveError(category, static_cast<int>(code), std::move(message), detail);
+}
+
+CdError cddaError(int code, QString message, const QString& detail = {})
+{
+    CdDriveError category{CdDriveError::ReadFailed};
+
+    switch(static_cast<CddaError>(code)) {
+        case CddaError::PermissionDeniedIoctl:
+        case CddaError::PermissionDeniedData:
+            category = CdDriveError::AccessDenied;
+            break;
+
+        case CddaError::TrackNotAudio:
+        case CddaError::NoAudioTracks:
+            category = CdDriveError::NotAudioDisc;
+            break;
+
+        case CddaError::NoMedia:
+            category = CdDriveError::NoMedia;
+            break;
+
+        default:
+            break;
+    }
+
+    return driveError(category, code, std::move(message), detail);
+}
+
+QString takeDriveMessages(cdrom_drive_t* drive)
+{
+    if(!drive) {
+        return {};
+    }
+    char* errors = cdio_cddap_errors(drive);
+    if(!errors) {
+        return {};
+    }
+    const QString result = QString::fromLocal8Bit(errors).trimmed();
+    cdio_cddap_free_messages(errors);
+    return result;
+}
+
+struct ParanoiaDiagnostics
+{
+    int corrections{0};
+    int readErrors{0};
+    int skipped{0};
+};
+
+class ScopedParanoiaDiagnostics
+{
+public:
+    explicit ScopedParanoiaDiagnostics(ParanoiaDiagnostics& diagnostics)
+        : m_previous{std::exchange(m_activeScope, this)}
+        , m_diagnostics{diagnostics}
+    { }
+
+    ~ScopedParanoiaDiagnostics()
+    {
+        m_activeScope = m_previous;
+    }
+
+    ScopedParanoiaDiagnostics(const ScopedParanoiaDiagnostics&)            = delete;
+    ScopedParanoiaDiagnostics& operator=(const ScopedParanoiaDiagnostics&) = delete;
+
+    static void callback(long /*position*/, paranoia_cb_mode_t mode)
+    {
+        if(!m_activeScope) {
+            return;
+        }
+
+        switch(mode) {
+            case PARANOIA_CB_FIXUP_EDGE:
+            case PARANOIA_CB_FIXUP_ATOM:
+            case PARANOIA_CB_FIXUP_DROPPED:
+            case PARANOIA_CB_FIXUP_DUPED:
+                ++m_activeScope->m_diagnostics.corrections;
+                break;
+            case PARANOIA_CB_READERR:
+            case PARANOIA_CB_CACHEERR:
+                ++m_activeScope->m_diagnostics.readErrors;
+                break;
+            case PARANOIA_CB_SKIP:
+                ++m_activeScope->m_diagnostics.skipped;
+                break;
+            default:
+                break;
+        }
+    }
+
+private:
+    inline static thread_local ScopedParanoiaDiagnostics* m_activeScope{nullptr};
+
+    ScopedParanoiaDiagnostics* m_previous;
+    ParanoiaDiagnostics& m_diagnostics;
+};
+} // namespace
+
+std::vector<CdDriveInfo> LibcdioDriveBackend::drives()
+{
+    std::vector<CdDriveInfo> result;
+    char** devices = cdio_get_devices(DRIVER_DEVICE);
+    if(!devices) {
+        return result;
+    }
+
+    for(char* const* current = devices; *current; ++current) {
+        const QString device = QString::fromLocal8Bit(*current);
+        result.push_back({.id                 = device,
+                          .displayName        = device,
+                          .settingsKey        = cdDriveSettingsKey(u"libcdio"_s, {}, {}, device),
+                          .supportsSpeedLimit = false,
+                          .vendor             = {},
+                          .model              = {},
+                          .revision           = {}});
+    }
+    cdio_free_device_list(devices);
+    return result;
+}
+
+std::expected<CdDriveBackend::OpenedDrive, CdError> LibcdioDriveBackend::open(const QString& driveId)
+{
+    if(driveId.isEmpty()) {
+        return std::unexpected(CdError{.code         = CdDriveError::Unsupported,
+                                       .message      = tr("The selected optical drive is unavailable"),
+                                       .platformCode = 0});
+    }
+
+    const QByteArray device = driveId.toLocal8Bit();
+    CdIo_t* cdio            = cdio_open(device.constData(), DRIVER_UNKNOWN);
+    if(!cdio) {
+        return std::unexpected(CdError{.code         = CdDriveError::Unsupported,
+                                       .message      = tr("The selected optical drive is unavailable: %1").arg(driveId),
+                                       .platformCode = 0});
+    }
+    return OpenedDrive{.drive   = driveInfo(cdio, driveId),
+                       .session = std::make_unique<LibcdioDriveSession>(cdio, driveId)};
+}
+
+LibcdioDriveSession::LibcdioDriveSession(CdIo_t* cdio, QString device)
+    : m_cdio{cdio}
+    , m_drive{nullptr}
+    , m_paranoia{nullptr}
+    , m_nextParanoiaSector{-1}
+    , m_device{std::move(device)}
+    , m_cancelled{false}
+{ }
+
+LibcdioDriveSession::~LibcdioDriveSession()
+{
+    if(m_paranoia) {
+        cdio_paranoia_free(m_paranoia);
+    }
+    if(m_drive) {
+        cdio_cddap_close(m_drive);
+    }
+    else if(m_cdio) {
+        cdio_destroy(m_cdio);
+    }
+}
+
+std::expected<CdToc, CdError> LibcdioDriveSession::readToc()
+{
+    if(m_cancelled.load()) {
+        return std::unexpected(cancelledError());
+    }
+
+    const CdIo_t* cdio = cdioHandle();
+    if(!cdio) {
+        return std::unexpected(cdioError(DRIVER_OP_ERROR, tr("Failed to access audio CD drive %1").arg(m_device)));
+    }
+
+    CdToc toc;
+    toc.firstTrackNumber = cdio_get_first_track_num(cdio);
+    toc.lastTrackNumber  = cdio_get_last_track_num(cdio);
+
+    const lsn_t leadout = cdio_get_track_lsn(cdio, CDIO_CDROM_LEADOUT_TRACK);
+    if(toc.firstTrackNumber == CDIO_INVALID_TRACK || toc.lastTrackNumber == CDIO_INVALID_TRACK
+       || leadout == CDIO_INVALID_LSN) {
+        return std::unexpected(cdioError(DRIVER_OP_ERROR, tr("Failed to read the CD TOC from %1").arg(m_device),
+                                         takeDriveMessages(m_drive)));
+    }
+
+    toc.leadoutSector = leadout;
+
+    for(int number{toc.firstTrackNumber}; number <= toc.lastTrackNumber; ++number) {
+        const auto track        = static_cast<track_t>(number);
+        const lsn_t firstSector = cdio_get_track_lsn(cdio, track);
+        const lsn_t nextSector
+            = number < toc.lastTrackNumber ? cdio_get_track_lsn(cdio, static_cast<track_t>(number + 1)) : leadout;
+        if(firstSector == CDIO_INVALID_LSN || nextSector == CDIO_INVALID_LSN) {
+            return std::unexpected(
+                cdioError(DRIVER_OP_ERROR, tr("Failed to read a CD track boundary from %1").arg(m_device)));
+        }
+        toc.tracks.push_back({.number             = number,
+                              .firstSector        = firstSector,
+                              .endSectorExclusive = nextSector,
+                              .isAudio            = cdio_get_track_format(cdio, track) == TRACK_FORMAT_AUDIO});
+    }
+
+    if(const auto valid = validateToc(toc); !valid) {
+        return std::unexpected(
+            CdError{.code = CdDriveError::NotAudioDisc, .message = invalidTocUserMessage(), .platformCode = 0});
+    }
+
+    return toc;
+}
+
+CdText LibcdioDriveSession::readCdText(const CdToc& toc)
+{
+    CdIo_t* cdio = cdioHandle();
+    if(!cdio) {
+        return {};
+    }
+
+    const cdtext_t* cdText = cdio_get_cdtext(cdio);
+    if(!cdText) {
+        return {};
+    }
+
+    CdText result;
+    result.disc = cdTextFields(cdText, 0);
+
+    for(const CdTocTrack& track : toc.tracks) {
+        CdTextFields fields = cdTextFields(cdText, track.number);
+        if(!fields.empty()) {
+            result.tracks.emplace(track.number, std::move(fields));
+        }
+    }
+
+    return result;
+}
+
+std::expected<CdSectorRead, CdError> LibcdioDriveSession::readAudioSectors(int firstSector, int count)
+{
+    if(m_cancelled.load()) {
+        return std::unexpected(cancelledError());
+    }
+    if(const auto valid = validateSectorReadRequest(firstSector, count, MaxSectorsPerRead); !valid) {
+        return std::unexpected(valid.error());
+    }
+    if(count == 0) {
+        return CdSectorRead{};
+    }
+
+    const CdIo_t* cdio = cdioHandle();
+    if(!cdio) {
+        return std::unexpected(cdioError(DRIVER_OP_ERROR, tr("Failed to access audio CD drive %1").arg(m_device)));
+    }
+
+    CdSectorRead result{.pcm = QByteArray(count * BytesPerSector, Qt::Uninitialized), .sectorsRead = count};
+
+    const driver_return_code_t status
+        = cdio_read_audio_sectors(cdio, result.pcm.data(), firstSector, static_cast<uint32_t>(count));
+    if(status != DRIVER_OP_SUCCESS) {
+        return std::unexpected(cdioError(status, tr("Failed to read CD audio sectors from %1").arg(m_device)));
+    }
+
+    return result;
+}
+
+std::expected<CdSectorRead, CdError> LibcdioDriveSession::readAudioSectorsSecure(int firstSector, int count,
+                                                                                 CdRippingSecurity security)
+{
+    if(security == CdRippingSecurity::Disabled) {
+        return readAudioSectors(firstSector, count);
+    }
+    if(m_cancelled.load()) {
+        return std::unexpected(cancelledError());
+    }
+    if(const auto valid = validateSectorReadRequest(firstSector, count, MaxSectorsPerRead); !valid) {
+        return std::unexpected(valid.error());
+    }
+    if(count == 0) {
+        return CdSectorRead{};
+    }
+    if(const auto initialized = ensureParanoiaDrive(); !initialized) {
+        return std::unexpected(initialized.error());
+    }
+
+    if(!m_paranoia) {
+        m_paranoia = cdio_paranoia_init(m_drive);
+        if(!m_paranoia) {
+            return std::unexpected(cdioError(DRIVER_OP_ERROR,
+                                             tr("Failed to initialise secure CD extraction for %1").arg(m_device),
+                                             takeDriveMessages(m_drive)));
+        }
+    }
+
+    const int mode           = security == CdRippingSecurity::Standard ? PARANOIA_MODE_VERIFY | PARANOIA_MODE_OVERLAP
+                                                                       : PARANOIA_MODE_FULL & ~PARANOIA_MODE_NEVERSKIP;
+    const int retries        = security == CdRippingSecurity::Standard ? StandardRetries : ParanoidRetries;
+    const bool policyChanged = !m_paranoiaSecurity || *m_paranoiaSecurity != security;
+    if(policyChanged) {
+        cdio_paranoia_modeset(m_paranoia, mode);
+    }
+    if(policyChanged || m_nextParanoiaSector != firstSector) {
+        if(cdio_paranoia_seek(m_paranoia, firstSector, SEEK_SET) < 0) {
+            return std::unexpected(cdioError(DRIVER_OP_ERROR,
+                                             tr("Failed to seek the secure CD reader for %1").arg(m_device),
+                                             takeDriveMessages(m_drive)));
+        }
+    }
+
+    m_paranoiaSecurity   = security;
+    m_nextParanoiaSector = firstSector;
+
+    ParanoiaDiagnostics diagnostics;
+    CdSectorRead result;
+    result.pcm.reserve(count * BytesPerSector);
+    {
+        const ScopedParanoiaDiagnostics scopedDiagnostics{diagnostics};
+        for(int index{0}; index < count; ++index) {
+            if(m_cancelled.load()) {
+                return std::unexpected(cancelledError());
+            }
+            const int16_t* pcm = cdio_paranoia_read_limited(m_paranoia, ScopedParanoiaDiagnostics::callback, retries);
+            if(!pcm) {
+                return std::unexpected(cdioError(DRIVER_OP_ERROR,
+                                                 tr("Failed to read securely from audio CD drive %1").arg(m_device),
+                                                 takeDriveMessages(m_drive)));
+            }
+            result.pcm.append(reinterpret_cast<const char*>(pcm), BytesPerSector);
+            ++result.sectorsRead;
+            ++m_nextParanoiaSector;
+        }
+    }
+
+    if(diagnostics.corrections > 0) {
+        m_warnings.push_back(
+            tr("CD extraction corrected %Ln read inconsistency event(s)", nullptr, diagnostics.corrections));
+    }
+    if(diagnostics.readErrors > 0) {
+        m_warnings.push_back(tr("CD extraction encountered %Ln read error event(s)", nullptr, diagnostics.readErrors));
+    }
+    if(diagnostics.skipped > 0) {
+        m_warnings.push_back(tr("CD extraction exhausted retries and concealed %Ln unreadable sector event(s)", nullptr,
+                                diagnostics.skipped));
+    }
+
+    return result;
+}
+
+std::expected<void, CdError> LibcdioDriveSession::setReadSpeed(int speed)
+{
+    if(speed <= 0) {
+        return std::unexpected(CdError{.code         = CdDriveError::Unsupported,
+                                       .message      = tr("The requested CD read-speed limit is invalid"),
+                                       .platformCode = EINVAL});
+    }
+
+    const CdIo_t* cdio = cdioHandle();
+    if(!cdio) {
+        return std::unexpected(
+            cdioError(DRIVER_OP_ERROR, tr("Failed to limit the CD read speed for %1").arg(m_device)));
+    }
+
+    const driver_return_code_t status = cdio_set_speed(cdio, speed);
+    if(status != DRIVER_OP_SUCCESS) {
+        return std::unexpected(cdioError(status, tr("Failed to limit the CD read speed for %1").arg(m_device)));
+    }
+
+    return {};
+}
+
+QStringList LibcdioDriveSession::takeWarnings()
+{
+    return std::exchange(m_warnings, {});
+}
+
+void LibcdioDriveSession::cancel()
+{
+    m_cancelled.store(true);
+}
+
+CdIo_t* LibcdioDriveSession::cdioHandle() const
+{
+    return m_drive ? m_drive->p_cdio : m_cdio;
+}
+
+std::expected<void, CdError> LibcdioDriveSession::ensureParanoiaDrive()
+{
+    if(m_drive) {
+        return {};
+    }
+    if(!m_cdio) {
+        return std::unexpected(cdioError(DRIVER_OP_ERROR, tr("Failed to access audio CD drive %1").arg(m_device)));
+    }
+
+    char* messages{nullptr};
+    cdrom_drive_t* drive = cdio_cddap_identify_cdio(m_cdio, CDDA_MESSAGE_LOGIT, &messages);
+    const QString detail = messages ? QString::fromLocal8Bit(messages).trimmed() : QString{};
+    if(messages) {
+        cdio_cddap_free_messages(messages);
+    }
+    if(!drive) {
+        return std::unexpected(
+            cdioError(DRIVER_OP_ERROR, tr("Failed to initialise secure CD extraction for %1").arg(m_device), detail));
+    }
+
+    // The cdda drive owns the CdIo handle after successfully identifying
+    m_cdio = nullptr;
+
+    const int opened = cdio_cddap_open(drive);
+    if(opened != 0) {
+        const QString openDetail = takeDriveMessages(drive);
+        cdio_cddap_close(drive);
+        return std::unexpected(
+            cddaError(opened, tr("Failed to initialise secure CD extraction for %1").arg(m_device), openDetail));
+    }
+
+    m_drive = drive;
+    return {};
+}
+
+CdError LibcdioDriveSession::cancelledError()
+{
+    return {.code = CdDriveError::Cancelled, .message = tr("CD operation was cancelled"), .platformCode = ECANCELED};
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/drive/libcdiodrivebackend.h
+++ b/src/plugins/cdda/drive/libcdiodrivebackend.h
@@ -1,0 +1,69 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cddrivebackend.h"
+
+#include <cdio/cdio.h>
+#include <cdio/paranoia/cdda.h>
+
+namespace Fooyin::Cdda {
+class LibcdioDriveBackend : public CdDriveBackend
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::LibcdioDriveBackend)
+
+public:
+    std::vector<CdDriveInfo> drives() override;
+    std::expected<OpenedDrive, CdError> open(const QString& driveId) override;
+};
+
+class LibcdioDriveSession : public CdDriveSession
+{
+    Q_DECLARE_TR_FUNCTIONS(Fooyin::Cdda::LibcdioDriveSession)
+
+public:
+    LibcdioDriveSession(CdIo_t* cdio, QString device);
+    ~LibcdioDriveSession() override;
+
+    std::expected<CdToc, CdError> readToc() override;
+    CdText readCdText(const CdToc& toc) override;
+    std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count) override;
+    std::expected<CdSectorRead, CdError> readAudioSectorsSecure(int firstSector, int count,
+                                                                CdRippingSecurity security) override;
+
+    std::expected<void, CdError> setReadSpeed(int speed) override;
+
+    QStringList takeWarnings() override;
+    void cancel() override;
+
+private:
+    [[nodiscard]] CdIo_t* cdioHandle() const;
+    std::expected<void, CdError> ensureParanoiaDrive();
+    static CdError cancelledError();
+
+    CdIo_t* m_cdio;
+    cdrom_drive_t* m_drive;
+    cdrom_paranoia_t* m_paranoia;
+    std::optional<CdRippingSecurity> m_paranoiaSecurity;
+    int m_nextParanoiaSector;
+    QString m_device;
+    QStringList m_warnings;
+    std::atomic_bool m_cancelled;
+};
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/openaudiocddialog.cpp
+++ b/src/plugins/cdda/openaudiocddialog.cpp
@@ -48,7 +48,7 @@ namespace {
 QString displayDuration(uint64_t milliseconds)
 {
     const uint64_t seconds = milliseconds / 1000;
-    return u"%1:%2"_s.arg(seconds / 60).arg(seconds % 60, 2, 10, u'0');
+    return u"%1:%2"_s.arg(seconds / 60).arg(seconds % 60, 2, 10, QChar{u'0'});
 }
 } // namespace
 
@@ -441,7 +441,9 @@ void OpenAudioCdDialog::startAutomaticLookup(int index)
                              return;
                          }
                          for(const ReleaseSummary& release : releases) {
-                             if(!release.id.isEmpty() && !std::ranges::contains(m_autoLookupReleaseIds, release.id)) {
+                             if(!release.id.isEmpty()
+                                && std::ranges::find(m_autoLookupReleaseIds, release.id)
+                                       == m_autoLookupReleaseIds.end()) {
                                  m_autoLookupReleaseIds.push_back(release.id);
                              }
                          }

--- a/src/plugins/cdda/openaudiocddialog.cpp
+++ b/src/plugins/cdda/openaudiocddialog.cpp
@@ -1,0 +1,711 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "openaudiocddialog.h"
+
+#include "cddadrivesettingsdialog.h"
+#include "cddareader.h"
+#include "cddatoc.h"
+
+#include <core/network/networkaccessmanager.h>
+#include <gui/metadatalookup/metadataapply.h>
+#include <gui/metadatalookup/metadatalookupdialog.h>
+#include <gui/metadatalookup/sources/musicbrainzmetadata.h>
+#include <gui/widgets/elidedlabel.h>
+#include <utils/async.h>
+
+#include <QAction>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QMenu>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+QString displayDuration(uint64_t milliseconds)
+{
+    const uint64_t seconds = milliseconds / 1000;
+    return u"%1:%2"_s.arg(seconds / 60).arg(seconds % 60, 2, 10, u'0');
+}
+} // namespace
+
+OpenAudioCdDialog::OpenAudioCdDialog(std::shared_ptr<CdDriveManager> driveManager,
+                                     std::shared_ptr<CdDriveSettingsStore> settingsStore,
+                                     std::shared_ptr<NetworkAccessManager> networkAccess,
+                                     SettingsManager* settingsManager, QWidget* parent)
+    : QDialog{parent}
+    , m_driveManager{std::move(driveManager)}
+    , m_settingsStore{std::move(settingsStore)}
+    , m_networkAccess{std::move(networkAccess)}
+    , m_settingsManager{settingsManager}
+    , m_driveRequestId{0}
+    , m_drives{new QComboBox(this)}
+    , m_status{new ElidedLabel(this)}
+    , m_trackTable{new QTableWidget(this)}
+    , m_refreshButton{new QPushButton(tr("Refresh"), this)}
+    , m_settingsButton{new QPushButton(tr("Drive settings…"), this)}
+    , m_metadataButton{new QPushButton(tr("Metadata"), this)}
+    , m_cdTextAction{new QAction(tr("Read CD-Text"), this)}
+    , m_autoLookupAction{new QAction(tr("Auto lookup metadata"), this)}
+    , m_lookupAction{new QAction(tr("Lookup metadata…"), this)}
+    , m_ripButton{new QPushButton(tr("Rip…"), this)}
+    , m_playButton{new QPushButton(tr("Play"), this)}
+    , m_addButton{new QPushButton(tr("Add to playlist"), this)}
+{
+    setWindowTitle(tr("Open Audio CD"));
+    resize(640, 430);
+
+    m_trackTable->setColumnCount(3);
+    m_trackTable->setHorizontalHeaderLabels({tr("Track"), tr("Title"), tr("Duration")});
+    m_trackTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_trackTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_trackTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_trackTable->verticalHeader()->hide();
+    m_trackTable->setAlternatingRowColors(true);
+    m_trackTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_trackTable->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_trackTable->horizontalHeaderItem(2)->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+    auto* metadataMenu = new QMenu(m_metadataButton);
+    metadataMenu->addAction(m_cdTextAction);
+    metadataMenu->addAction(m_autoLookupAction);
+    metadataMenu->addAction(m_lookupAction);
+    m_metadataButton->setMenu(metadataMenu);
+
+    const int driveControlHeight = std::max(
+        {m_drives->sizeHint().height(), m_refreshButton->sizeHint().height(), m_settingsButton->sizeHint().height()});
+    m_drives->setFixedHeight(driveControlHeight);
+    m_refreshButton->setFixedHeight(driveControlHeight);
+    m_settingsButton->setFixedHeight(driveControlHeight);
+
+    auto* driveRow = new QHBoxLayout();
+    driveRow->addWidget(new QLabel(tr("CD drive") + u""_s, this));
+    driveRow->addWidget(m_drives, 1);
+    driveRow->addWidget(m_refreshButton);
+    driveRow->addWidget(m_settingsButton);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    auto* trackButtons = new QHBoxLayout();
+    trackButtons->addWidget(m_metadataButton);
+    trackButtons->addWidget(m_ripButton);
+    trackButtons->addWidget(m_playButton);
+    trackButtons->addWidget(m_addButton);
+    trackButtons->addStretch();
+    trackButtons->addWidget(buttons);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addLayout(driveRow);
+    layout->addWidget(m_status);
+    layout->addWidget(m_trackTable, 1);
+    layout->addLayout(trackButtons);
+
+    QObject::connect(m_drives, &QComboBox::currentIndexChanged, this, &OpenAudioCdDialog::showObservation);
+    QObject::connect(m_refreshButton, &QPushButton::clicked, this, &OpenAudioCdDialog::refreshCurrentDrive);
+    QObject::connect(m_settingsButton, &QPushButton::clicked, this, &OpenAudioCdDialog::showDriveSettings);
+    QObject::connect(m_cdTextAction, &QAction::triggered, this, [this] {
+        cancelAutomaticLookup();
+        loadCdText(m_drives->currentIndex());
+    });
+    QObject::connect(m_autoLookupAction, &QAction::triggered, this,
+                     [this] { startAutomaticLookup(m_drives->currentIndex()); });
+    QObject::connect(m_lookupAction, &QAction::triggered, this, &OpenAudioCdDialog::showMetadataLookup);
+    QObject::connect(m_ripButton, &QPushButton::clicked, this, &OpenAudioCdDialog::rip);
+    QObject::connect(m_playButton, &QPushButton::clicked, this, &OpenAudioCdDialog::play);
+    QObject::connect(m_addButton, &QPushButton::clicked, this, &OpenAudioCdDialog::addToPlaylist);
+    QObject::connect(m_trackTable, &QTableWidget::itemChanged, this, &OpenAudioCdDialog::updateActions);
+    QObject::connect(m_trackTable, &QWidget::customContextMenuRequested, this, [this](const QPoint& position) {
+        auto* menu                = new QMenu(m_trackTable);
+        const QAction* checkAll   = menu->addAction(tr("Check all"));
+        const QAction* uncheckAll = menu->addAction(tr("Uncheck all"));
+
+        const auto updateCheckState = [&](Qt::CheckState state) {
+            const QSignalBlocker blocker{m_trackTable};
+            for(int row{0}; row < m_trackTable->rowCount(); ++row) {
+                if(QTableWidgetItem* item = m_trackTable->item(row, 0)) {
+                    item->setCheckState(state);
+                }
+            }
+            updateActions();
+        };
+
+        QObject::connect(checkAll, &QAction::triggered, this, [updateCheckState]() { updateCheckState(Qt::Checked); });
+        QObject::connect(uncheckAll, &QAction::triggered, this,
+                         [updateCheckState]() { updateCheckState(Qt::Unchecked); });
+
+        menu->popup(m_trackTable->viewport()->mapToGlobal(position));
+    });
+
+    enumerateDrives();
+}
+
+void OpenAudioCdDialog::enumerateDrives()
+{
+    cancelAutomaticLookup();
+
+    if(m_lookupDialog) {
+        m_lookupDialog->close();
+    }
+
+    m_refreshButton->setEnabled(false);
+    m_drives->setEnabled(false);
+    m_settingsButton->setEnabled(false);
+    m_trackTable->setEnabled(false);
+
+    setStatus(tr("Searching for CD drives…"));
+    m_tracks.clear();
+    updateActions();
+
+    const uint64_t requestId = ++m_driveRequestId;
+    Utils::asyncExec([manager = m_driveManager] {
+        return manager->drives();
+    }).then(this, [this, requestId](std::vector<CdDriveInfo> drives) {
+        if(requestId != m_driveRequestId) {
+            return;
+        }
+
+        m_driveStates.clear();
+        m_driveStates.reserve(drives.size());
+        {
+            const QSignalBlocker blocker{m_drives};
+            m_drives->clear();
+            for(CdDriveInfo& drive : drives) {
+                m_drives->addItem(drive.displayName);
+                m_driveStates.push_back({.drive = std::move(drive), .observation = std::nullopt});
+            }
+        }
+
+        m_refreshButton->setEnabled(true);
+        m_drives->setEnabled(!m_driveStates.empty());
+
+        showObservation(m_driveStates.empty() ? -1 : 0);
+    });
+}
+
+void OpenAudioCdDialog::refreshCurrentDrive()
+{
+    cancelAutomaticLookup();
+
+    if(m_lookupDialog) {
+        m_lookupDialog->close();
+    }
+
+    const int index = m_drives->currentIndex();
+    if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size())) {
+        enumerateDrives();
+        return;
+    }
+
+    m_refreshButton->setEnabled(false);
+    m_drives->setEnabled(false);
+    m_trackTable->setEnabled(false);
+
+    setStatus(tr("Reading audio CD…"));
+    m_tracks.clear();
+    updateActions();
+
+    const CdDriveInfo drive  = m_driveStates.at(index).drive;
+    const uint64_t requestId = ++m_driveRequestId;
+    Utils::asyncExec([manager = m_driveManager, drive] {
+        return manager->observeDrive(drive);
+    }).then(this, [this, requestId, index](CdDriveObservation observation) {
+        if(requestId != m_driveRequestId || std::cmp_greater_equal(index, m_driveStates.size())) {
+            return;
+        }
+
+        m_driveStates[index].drive       = observation.drive;
+        m_driveStates[index].observation = std::move(observation);
+        m_drives->setItemText(index, m_driveStates[index].drive.displayName);
+        m_refreshButton->setEnabled(true);
+        m_drives->setEnabled(!m_driveStates.empty());
+
+        showObservation(index);
+    });
+}
+
+void OpenAudioCdDialog::showObservation(int index)
+{
+    cancelAutomaticLookup();
+
+    if(m_lookupDialog) {
+        m_lookupDialog->close();
+    }
+
+    m_trackTable->setRowCount(0);
+    m_tracks.clear();
+
+    if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size())) {
+        setStatus(tr("No CD drives found."));
+        m_settingsButton->setEnabled(false);
+        m_trackTable->setEnabled(false);
+        updateActions();
+        return;
+    }
+
+    m_drives->setCurrentIndex(index);
+    const DriveState& driveState = m_driveStates.at(index);
+    m_settingsButton->setEnabled(true);
+
+    if(!driveState.observation) {
+        refreshCurrentDrive();
+        return;
+    }
+
+    const CdDriveObservation& observation = *driveState.observation;
+
+    if(observation.error) {
+        setStatus(observation.error->message);
+        m_trackTable->setEnabled(false);
+        updateActions();
+        return;
+    }
+    if(!observation.toc) {
+        setStatus(tr("No audio CD is available in this drive."));
+        m_trackTable->setEnabled(false);
+        updateActions();
+        return;
+    }
+
+    const auto tracks = tracksForDisc(*observation.toc, observation.discId, observation.cdText.value_or(CdText{}));
+    if(!tracks) {
+        setStatus(tracks.error());
+        m_trackTable->setEnabled(false);
+        updateActions();
+        return;
+    }
+
+    m_tracks = *tracks;
+
+    const auto trackCount = static_cast<int>(m_tracks.size());
+
+    setStatus(tr("Found %Ln audio track(s).", nullptr, trackCount));
+    m_trackTable->setRowCount(trackCount);
+
+    for(int row{0}; row < trackCount; ++row) {
+        const Track& track = m_tracks.at(static_cast<size_t>(row));
+
+        auto* number = new QTableWidgetItem(track.trackNumber());
+        number->setCheckState(Qt::Checked);
+        m_trackTable->setItem(row, 0, number);
+        m_trackTable->setItem(row, 1, new QTableWidgetItem(track.effectiveTitle()));
+
+        auto* duration = new QTableWidgetItem(displayDuration(track.duration()));
+        duration->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_trackTable->setItem(row, 2, duration);
+    }
+
+    m_trackTable->setEnabled(true);
+    updateActions();
+}
+
+void OpenAudioCdDialog::loadCdText(int index)
+{
+    if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size()) || !m_driveStates.at(index).observation) {
+        return;
+    }
+
+    const CdDriveObservation observation = *m_driveStates.at(index).observation;
+    if(!observation.toc || observation.discId.isEmpty() || m_cdTextLoads.contains(observation.drive.id)) {
+        return;
+    }
+
+    m_cdTextLoads.emplace(observation.drive.id);
+    setStatus(tr("Reading CD-Text…"));
+    updateActions();
+
+    const TrackList originalTracks{m_tracks};
+    Utils::asyncExec([manager = m_driveManager, observation] {
+        return manager->readCdText(observation);
+    }).then(this, [this, index, observation, originalTracks](std::expected<CdText, CdError> result) {
+        m_cdTextLoads.erase(observation.drive.id);
+
+        if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size()) || !m_driveStates.at(index).observation) {
+            updateActions();
+            return;
+        }
+
+        CdDriveObservation& current = *m_driveStates[index].observation;
+        if(current.drive.id != observation.drive.id || current.discId != observation.discId
+           || current.generation != observation.generation || !current.toc) {
+            updateActions();
+            return;
+        }
+
+        if(!result) {
+            if(m_drives->currentIndex() == index) {
+                setStatus(tr("Failed to read CD-Text: %1").arg(result.error().message));
+            }
+            updateActions();
+            return;
+        }
+
+        current.cdText = std::move(*result);
+
+        if(m_drives->currentIndex() != index) {
+            updateActions();
+            return;
+        }
+
+        if(current.cdText->empty()) {
+            setStatus(tr("No CD-Text found."));
+            updateActions();
+            return;
+        }
+
+        const bool tracksUnchanged
+            = originalTracks.size() == m_tracks.size()
+           && std::ranges::equal(originalTracks, m_tracks,
+                                 [](const Track& lhs, const Track& rhs) { return lhs.sameDataAs(rhs); });
+        if(!tracksUnchanged) {
+            setStatus(tr("CD-Text was read; existing metadata was kept."));
+            updateActions();
+            return;
+        }
+
+        const auto tracks = tracksForDisc(*current.toc, current.discId, *current.cdText);
+        if(tracks) {
+            replaceTracks(*tracks,
+                          tr("Applied CD-Text to %Ln audio track(s).", nullptr, static_cast<int>(tracks->size())));
+        }
+        else {
+            setStatus(tracks.error());
+            updateActions();
+        }
+    });
+}
+
+void OpenAudioCdDialog::startAutomaticLookup(int index)
+{
+    if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size()) || !m_driveStates.at(index).observation) {
+        return;
+    }
+
+    const CdDriveObservation observation = *m_driveStates.at(index).observation;
+    if(!observation.toc || observation.discId.isEmpty()) {
+        return;
+    }
+
+    const auto discToc = musicBrainzToc(*observation.toc);
+    if(!discToc) {
+        return;
+    }
+
+    if(m_autoLookup && m_autoLookupDiscId == observation.discId) {
+        return;
+    }
+
+    cancelAutomaticLookup();
+
+    auto* client       = new MusicBrainzMetadata(m_networkAccess.get(), this);
+    m_autoLookup       = client;
+    m_autoLookupDiscId = observation.discId;
+
+    const auto isCurrent = [this, client, index, observation] {
+        if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size()) || !m_driveStates.at(index).observation) {
+            return false;
+        }
+
+        const auto& ob = *m_driveStates.at(index).observation;
+        return m_autoLookup == client && m_drives->currentIndex() == index && ob.drive.id == observation.drive.id
+            && ob.discId == observation.discId && ob.generation == observation.generation;
+    };
+
+    QObject::connect(client, &MusicBrainzMetadata::searchFinished, this,
+                     [this, client, isCurrent](const std::vector<ReleaseSummary>& releases) {
+                         if(!isCurrent()) {
+                             finishAutomaticLookup(client);
+                             return;
+                         }
+                         for(const ReleaseSummary& release : releases) {
+                             if(!release.id.isEmpty() && !std::ranges::contains(m_autoLookupReleaseIds, release.id)) {
+                                 m_autoLookupReleaseIds.push_back(release.id);
+                             }
+                         }
+                         fetchNextAutomaticRelease(client);
+                     });
+    QObject::connect(client, &MusicBrainzMetadata::releaseFetched, this,
+                     [this, client, isCurrent, discId = observation.discId](const Release& release) {
+                         if(!isCurrent()) {
+                             finishAutomaticLookup(client);
+                             return;
+                         }
+                         const auto tracks = applyAutomaticDiscMetadata(m_tracks, release, discId);
+                         if(tracks) {
+                             if(m_autoLookupTracks) {
+                                 setStatus(tr("Automatic metadata lookup needs review."));
+                                 finishAutomaticLookup(client);
+                                 return;
+                             }
+                             m_autoLookupTracks = *tracks;
+                         }
+                         fetchNextAutomaticRelease(client);
+                     });
+    QObject::connect(client, &MusicBrainzMetadata::failed, this, [this, client, isCurrent](const QString& error) {
+        if(isCurrent()) {
+            setStatus(tr("Automatic metadata lookup failed: %1").arg(error));
+        }
+        finishAutomaticLookup(client);
+    });
+
+    setStatus(tr("Looking up audio CD metadata…"));
+    updateActions();
+    client->search({.mode       = LookupMode::DiscToc,
+                    .artist     = {},
+                    .album      = {},
+                    .discToc    = *discToc,
+                    .discId     = observation.discId,
+                    .identifier = {}});
+}
+
+void OpenAudioCdDialog::fetchNextAutomaticRelease(MusicBrainzMetadata* client)
+{
+    if(m_autoLookup != client) {
+        return;
+    }
+
+    if(!m_autoLookupReleaseIds.empty()) {
+        const QString releaseId = std::move(m_autoLookupReleaseIds.front());
+        m_autoLookupReleaseIds.erase(m_autoLookupReleaseIds.begin());
+        client->fetchRelease(releaseId);
+        return;
+    }
+
+    if(m_autoLookupTracks) {
+        replaceTracks(*m_autoLookupTracks, tr("Applied automatic metadata to %Ln audio track(s).", nullptr,
+                                              static_cast<int>(m_autoLookupTracks->size())));
+    }
+    else {
+        setStatus(tr("No automatic metadata match found."));
+    }
+
+    finishAutomaticLookup(client);
+}
+
+void OpenAudioCdDialog::cancelAutomaticLookup()
+{
+    if(m_autoLookup) {
+        m_autoLookup->cancel();
+        m_autoLookup->deleteLater();
+    }
+
+    m_autoLookupDiscId.clear();
+    m_autoLookupReleaseIds.clear();
+    m_autoLookupTracks.reset();
+
+    updateActions();
+}
+
+void OpenAudioCdDialog::finishAutomaticLookup(MusicBrainzMetadata* client)
+{
+    if(m_autoLookup != client) {
+        return;
+    }
+
+    client->deleteLater();
+
+    m_autoLookupDiscId.clear();
+    m_autoLookupReleaseIds.clear();
+    m_autoLookupTracks.reset();
+
+    updateActions();
+}
+
+void OpenAudioCdDialog::applyLookupTracks(const TrackList& tracks)
+{
+    const bool sameTracks = tracks.size() == m_tracks.size()
+                         && std::ranges::equal(tracks, m_tracks, [](const Track& lhs, const Track& rhs) {
+                                return lhs.sameIdentityAs(rhs);
+                            });
+    if(!sameTracks) {
+        return;
+    }
+
+    replaceTracks(tracks, tr("Applied metadata to %Ln audio track(s).", nullptr, static_cast<int>(tracks.size())));
+}
+
+void OpenAudioCdDialog::replaceTracks(const TrackList& tracks, const QString& status)
+{
+    m_tracks = tracks;
+
+    const QSignalBlocker blocker{m_trackTable};
+
+    for(int row{0}; row < m_trackTable->rowCount() && std::cmp_less(row, m_tracks.size()); ++row) {
+        const Track& track = m_tracks.at(row);
+        m_trackTable->item(row, 0)->setText(track.trackNumber());
+        m_trackTable->item(row, 1)->setText(track.effectiveTitle());
+        m_trackTable->item(row, 2)->setText(displayDuration(track.duration()));
+    }
+
+    setStatus(status);
+    updateActions();
+}
+
+void OpenAudioCdDialog::setStatus(const QString& status)
+{
+    m_status->setText(status);
+    m_status->setToolTip(status);
+}
+
+void OpenAudioCdDialog::updateActions()
+{
+    bool canAutoLookup = !m_tracks.empty();
+    const int index    = m_drives->currentIndex();
+
+    if(canAutoLookup && index >= 0 && std::cmp_less(index, m_driveStates.size())
+       && m_driveStates.at(index).observation) {
+        const CdDriveObservation& observation = *m_driveStates.at(index).observation;
+        canAutoLookup
+            = observation.toc && !observation.discId.isEmpty() && musicBrainzToc(*observation.toc).has_value();
+    }
+    else {
+        canAutoLookup = false;
+    }
+
+    bool canReadCdText = !m_tracks.empty();
+    if(canReadCdText && index >= 0 && std::cmp_less(index, m_driveStates.size())
+       && m_driveStates.at(index).observation) {
+        const CdDriveObservation& observation = *m_driveStates.at(index).observation;
+        canReadCdText
+            = observation.toc && !observation.discId.isEmpty() && !m_cdTextLoads.contains(observation.drive.id);
+    }
+    else {
+        canReadCdText = false;
+    }
+
+    const bool hasTracks = !checkedTracks().empty();
+
+    m_cdTextAction->setEnabled(canReadCdText);
+    m_autoLookupAction->setEnabled(canAutoLookup && !m_autoLookup);
+    m_lookupAction->setEnabled(canAutoLookup);
+    m_metadataButton->setEnabled(canReadCdText || canAutoLookup);
+    m_addButton->setEnabled(hasTracks);
+    m_playButton->setEnabled(hasTracks);
+    m_ripButton->setEnabled(hasTracks);
+}
+
+TrackList OpenAudioCdDialog::checkedTracks() const
+{
+    TrackList tracks;
+
+    for(int row{0}; row < m_trackTable->rowCount() && std::cmp_less(row, m_tracks.size()); ++row) {
+        const QTableWidgetItem* item = m_trackTable->item(row, 0);
+        if(item && item->checkState() == Qt::Checked) {
+            tracks.push_back(m_tracks.at(static_cast<size_t>(row)));
+        }
+    }
+
+    return tracks;
+}
+
+void OpenAudioCdDialog::showMetadataLookup()
+{
+    if(m_lookupDialog) {
+        m_lookupDialog->raise();
+        m_lookupDialog->activateWindow();
+        return;
+    }
+
+    const int index = m_drives->currentIndex();
+    if(m_tracks.empty() || !m_networkAccess || !m_settingsManager || index < 0
+       || std::cmp_greater_equal(index, m_driveStates.size()) || !m_driveStates.at(index).observation) {
+        return;
+    }
+
+    const CdDriveObservation& observation = *m_driveStates.at(index).observation;
+    if(!observation.toc || observation.discId.isEmpty()) {
+        return;
+    }
+
+    const auto discToc = musicBrainzToc(*observation.toc);
+    if(!discToc) {
+        return;
+    }
+
+    cancelAutomaticLookup();
+
+    m_lookupDialog = new MetadataLookupDialog(m_tracks, m_networkAccess, m_settingsManager,
+                                              {.mode       = LookupMode::DiscToc,
+                                               .artist     = {},
+                                               .album      = {},
+                                               .discToc    = *discToc,
+                                               .discId     = observation.discId,
+                                               .identifier = {}},
+                                              this);
+    m_lookupDialog->setModal(true);
+
+    QObject::connect(m_lookupDialog, &MetadataLookupDialog::tracksApplied, this, &OpenAudioCdDialog::applyLookupTracks);
+
+    m_lookupDialog->show();
+    m_lookupDialog->raise();
+    m_lookupDialog->activateWindow();
+}
+
+void OpenAudioCdDialog::addToPlaylist()
+{
+    const TrackList tracks = checkedTracks();
+    if(tracks.empty()) {
+        return;
+    }
+
+    const auto& observation = *m_driveStates.at(m_drives->currentIndex()).observation;
+    Q_EMIT addRequested(tracks, observation);
+}
+
+void OpenAudioCdDialog::play()
+{
+    const TrackList tracks = checkedTracks();
+    if(tracks.empty()) {
+        return;
+    }
+
+    const auto& observation = *m_driveStates.at(m_drives->currentIndex()).observation;
+    Q_EMIT playRequested(tracks, observation);
+    accept();
+}
+
+void OpenAudioCdDialog::rip()
+{
+    const TrackList tracks = checkedTracks();
+    if(tracks.empty()) {
+        return;
+    }
+
+    const auto& observation = *m_driveStates.at(m_drives->currentIndex()).observation;
+    Q_EMIT ripRequested(tracks, observation);
+}
+
+void OpenAudioCdDialog::showDriveSettings()
+{
+    const int index = m_drives->currentIndex();
+    if(index < 0 || std::cmp_greater_equal(index, m_driveStates.size())) {
+        return;
+    }
+
+    auto* dialog = new CdDriveSettingsDialog(m_driveStates.at(index).drive, m_settingsStore, m_networkAccess, this);
+    dialog->show();
+}
+} // namespace Fooyin::Cdda

--- a/src/plugins/cdda/openaudiocddialog.h
+++ b/src/plugins/cdda/openaudiocddialog.h
@@ -1,0 +1,123 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "cddadrivemanager.h"
+
+#include <core/track.h>
+
+#include <QDialog>
+#include <QPointer>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+class QComboBox;
+class QAction;
+class QPushButton;
+class QTableWidget;
+
+namespace Fooyin {
+class ElidedLabel;
+class MetadataLookupDialog;
+class MusicBrainzMetadata;
+class NetworkAccessManager;
+class SettingsManager;
+
+namespace Cdda {
+class CdDriveSettingsStore;
+
+class OpenAudioCdDialog final : public QDialog
+{
+    Q_OBJECT
+
+public:
+    OpenAudioCdDialog(std::shared_ptr<CdDriveManager> driveManager, std::shared_ptr<CdDriveSettingsStore> settingsStore,
+                      std::shared_ptr<NetworkAccessManager> networkAccess, SettingsManager* settingsManager,
+                      QWidget* parent = nullptr);
+
+Q_SIGNALS:
+    void addRequested(const Fooyin::TrackList& tracks, const Fooyin::Cdda::CdDriveObservation& observation);
+    void playRequested(const Fooyin::TrackList& tracks, const Fooyin::Cdda::CdDriveObservation& observation);
+    void ripRequested(const Fooyin::TrackList& tracks, const Fooyin::Cdda::CdDriveObservation& observation);
+
+private:
+    struct DriveState
+    {
+        CdDriveInfo drive;
+        std::optional<CdDriveObservation> observation;
+    };
+
+    void enumerateDrives();
+    void refreshCurrentDrive();
+
+    void showObservation(int index);
+    void loadCdText(int index);
+    void startAutomaticLookup(int index);
+    void fetchNextAutomaticRelease(MusicBrainzMetadata* client);
+    void cancelAutomaticLookup();
+    void finishAutomaticLookup(MusicBrainzMetadata* client);
+
+    void applyLookupTracks(const TrackList& tracks);
+    void replaceTracks(const TrackList& tracks, const QString& status);
+
+    void setStatus(const QString& status);
+    void updateActions();
+
+    [[nodiscard]] TrackList checkedTracks() const;
+
+    void showMetadataLookup();
+    void addToPlaylist();
+    void play();
+    void rip();
+    void showDriveSettings();
+
+    std::shared_ptr<CdDriveManager> m_driveManager;
+    std::shared_ptr<CdDriveSettingsStore> m_settingsStore;
+    std::shared_ptr<NetworkAccessManager> m_networkAccess;
+    SettingsManager* m_settingsManager;
+
+    uint64_t m_driveRequestId;
+    std::vector<DriveState> m_driveStates;
+    TrackList m_tracks;
+    std::unordered_set<QString> m_cdTextLoads;
+    QComboBox* m_drives;
+    ElidedLabel* m_status;
+    QTableWidget* m_trackTable;
+    QPushButton* m_refreshButton;
+    QPushButton* m_settingsButton;
+    QPushButton* m_metadataButton;
+    QAction* m_cdTextAction;
+    QAction* m_autoLookupAction;
+    QAction* m_lookupAction;
+    QPushButton* m_ripButton;
+    QPushButton* m_playButton;
+    QPushButton* m_addButton;
+    QPointer<MetadataLookupDialog> m_lookupDialog;
+    QPointer<MusicBrainzMetadata> m_autoLookup;
+    QString m_autoLookupDiscId;
+    std::vector<QString> m_autoLookupReleaseIds;
+    std::optional<TrackList> m_autoLookupTracks;
+};
+} // namespace Cdda
+} // namespace Fooyin

--- a/src/plugins/cdda/ripaudiocddialog.cpp
+++ b/src/plugins/cdda/ripaudiocddialog.cpp
@@ -23,6 +23,7 @@
 
 #include <core/constants.h>
 
+#include <QAction>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -31,6 +32,7 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMenu>
 #include <QPushButton>
 #include <QSignalBlocker>
 #include <QTableWidget>
@@ -217,6 +219,7 @@ RipAudioCdDialog::RipAudioCdDialog(TrackList tracks, const std::vector<Conversio
     m_trackTable->verticalHeader()->hide();
     m_trackTable->setAlternatingRowColors(true);
     m_trackTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_trackTable->setContextMenuPolicy(Qt::CustomContextMenu);
 
     for(int row{0}; std::cmp_less(row, m_tracks.size()); ++row) {
         const Track& track = m_tracks.at(static_cast<size_t>(row));
@@ -267,6 +270,27 @@ RipAudioCdDialog::RipAudioCdDialog(TrackList tracks, const std::vector<Conversio
 
     QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
     QObject::connect(m_trackTable, &QTableWidget::itemChanged, this, &RipAudioCdDialog::updateActions);
+    QObject::connect(m_trackTable, &QWidget::customContextMenuRequested, this, [this](const QPoint& position) {
+        auto* menu                = new QMenu(m_trackTable);
+        const QAction* checkAll   = menu->addAction(tr("Check all"));
+        const QAction* uncheckAll = menu->addAction(tr("Uncheck all"));
+
+        const auto updateCheckState = [&](Qt::CheckState state) {
+            const QSignalBlocker blocker{m_trackTable};
+            for(int row{0}; row < m_trackTable->rowCount(); ++row) {
+                if(QTableWidgetItem* item = m_trackTable->item(row, 0)) {
+                    item->setCheckState(state);
+                }
+            }
+            updateActions();
+        };
+
+        QObject::connect(checkAll, &QAction::triggered, this, [updateCheckState]() { updateCheckState(Qt::Checked); });
+        QObject::connect(uncheckAll, &QAction::triggered, this,
+                         [updateCheckState]() { updateCheckState(Qt::Unchecked); });
+
+        menu->popup(m_trackTable->viewport()->mapToGlobal(position));
+    });
     QObject::connect(m_presets, &QComboBox::currentIndexChanged, this, &RipAudioCdDialog::updateActions);
     QObject::connect(m_lookupButton, &QPushButton::clicked, this, &RipAudioCdDialog::showMetadataLookup);
     QObject::connect(m_setupButton, &QPushButton::clicked, this, &RipAudioCdDialog::showConverterSetup);

--- a/src/plugins/cdda/ripaudiocddialog.cpp
+++ b/src/plugins/cdda/ripaudiocddialog.cpp
@@ -1,0 +1,416 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ripaudiocddialog.h"
+
+#include "accuraterip.h"
+
+#include <core/constants.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+QString displayMetadataValues(const QStringList& values)
+{
+    return values.join(u"; "_s);
+}
+
+QString displayAlbumArtists(const Track& track)
+{
+    return displayMetadataValues(track.hasAlbumArtists() ? track.albumArtists() : track.artists());
+}
+
+QStringList metadataValues(QString value)
+{
+    value.replace(QLatin1StringView{Constants::UnitSeparator}, ";"_L1);
+
+    QStringList values = value.split(u';', Qt::SkipEmptyParts);
+    for(QString& metadataValue : values) {
+        metadataValue = metadataValue.trimmed();
+    }
+    values.removeAll(QString{});
+    return values;
+}
+
+QString accurateRipCrc(uint32_t crc)
+{
+    return QString::number(crc, 16).rightJustified(8, u'0').toUpper();
+}
+
+QString accurateRipVerdict(AccurateRipVerifyStatus status)
+{
+    switch(status) {
+        case AccurateRipVerifyStatus::Verified:
+            return RipAudioCdDialog::tr("Accurately ripped");
+        case AccurateRipVerifyStatus::Mismatch:
+            return RipAudioCdDialog::tr("Mismatch");
+        case AccurateRipVerifyStatus::Incomplete:
+            return RipAudioCdDialog::tr("Incomplete");
+        case AccurateRipVerifyStatus::InvalidFormat:
+            return RipAudioCdDialog::tr("Unsupported format");
+    }
+    return {};
+}
+
+} // namespace
+
+void showAccurateRipResults(QWidget* parent, const std::vector<AccurateRipTrackResult>& results, const QString& message)
+{
+    auto* dialog = new QDialog(parent);
+    dialog->setWindowTitle(RipAudioCdDialog::tr("AccurateRip Verification"));
+    dialog->resize(1000, 420);
+
+    int verified{0};
+    int mismatched{0};
+    for(const auto& result : results) {
+        verified += result.status == AccurateRipVerifyStatus::Verified ? 1 : 0;
+        mismatched += result.status == AccurateRipVerifyStatus::Mismatch ? 1 : 0;
+    }
+
+    QStringList summaryParts;
+    if(!results.empty()) {
+        summaryParts.push_back(RipAudioCdDialog::tr("Verified: %1").arg(verified));
+        summaryParts.push_back(RipAudioCdDialog::tr("Mismatched: %1").arg(mismatched));
+    }
+    if(!message.isEmpty()) {
+        summaryParts.push_back(message);
+    }
+
+    auto* summary = new QLabel(summaryParts.join(u" | "_s), dialog);
+    summary->setWordWrap(true);
+
+    auto* table = new QTableWidget(static_cast<int>(results.size()), 7, dialog);
+    table->setHorizontalHeaderLabels({RipAudioCdDialog::tr("Track"), RipAudioCdDialog::tr("Title"),
+                                      RipAudioCdDialog::tr("Result"), RipAudioCdDialog::tr("Confidence"),
+                                      RipAudioCdDialog::tr("AR v1 CRC"), RipAudioCdDialog::tr("AR v2 CRC"),
+                                      RipAudioCdDialog::tr("Database CRCs")});
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setAlternatingRowColors(true);
+    table->verticalHeader()->hide();
+    table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    table->horizontalHeader()->setSectionResizeMode(6, QHeaderView::Stretch);
+
+    for(int row{0}; std::cmp_less(row, results.size()); ++row) {
+        const auto& result = results.at(row);
+
+        QStringList databaseCrcs;
+        for(const uint32_t crc : result.databaseCrcs) {
+            databaseCrcs.push_back(accurateRipCrc(crc));
+        }
+
+        table->setItem(row, 0, new QTableWidgetItem(result.track.trackNumber()));
+        table->setItem(row, 1, new QTableWidgetItem(result.track.effectiveTitle()));
+        table->setItem(row, 2, new QTableWidgetItem(accurateRipVerdict(result.status)));
+        table->setItem(row, 3,
+                       new QTableWidgetItem(result.status == AccurateRipVerifyStatus::Verified
+                                                ? QString::number(result.confidence)
+                                                : QString{}));
+        table->setItem(row, 4, new QTableWidgetItem(accurateRipCrc(result.crcV1)));
+        table->setItem(row, 5, new QTableWidgetItem(accurateRipCrc(result.crcV2)));
+        table->setItem(row, 6, new QTableWidgetItem(databaseCrcs.join(u", "_s)));
+    }
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, dialog);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::accept);
+
+    auto* layout = new QVBoxLayout(dialog);
+    layout->addWidget(summary);
+    layout->addWidget(table, 1);
+    layout->addWidget(buttons);
+
+    dialog->show();
+}
+
+RipAudioCdDialog::RipAudioCdDialog(TrackList tracks, const std::vector<ConversionPresetInfo>& presets,
+                                   bool metadataLookupAvailable, bool driveOffsetConfigured, QWidget* parent)
+    : QDialog{parent}
+    , m_tracks{std::move(tracks)}
+    , m_metadataLookupAvailable{metadataLookupAvailable}
+    , m_metadataLookupPending{false}
+    , m_ripPending{false}
+    , m_albumArtist{new QLineEdit(this)}
+    , m_albumTitle{new QLineEdit(this)}
+    , m_discNumber{new QLineEdit(this)}
+    , m_genre{new QLineEdit(this)}
+    , m_date{new QLineEdit(this)}
+    , m_trackTable{new QTableWidget(this)}
+    , m_presets{new QComboBox(this)}
+    , m_verifyAccurateRip{new QCheckBox(tr("Verify with AccurateRip"), this)}
+    , m_accurateRipStatus{new QLabel(this)}
+    , m_lookupButton{new QPushButton(tr("Lookup metadata…"), this)}
+    , m_setupButton{new QPushButton(tr("Converter Setup…"), this)}
+    , m_ripButton{new QPushButton(tr("Rip"), this)}
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(tr("Rip Audio CD"));
+    resize(700, 650);
+    setModal(false);
+
+    auto* albumGroup  = new QGroupBox(tr("Album information"), this);
+    auto* albumLayout = new QGridLayout(albumGroup);
+
+    const Track firstTrack = m_tracks.empty() ? Track{} : m_tracks.front();
+    m_albumArtist->setText(displayAlbumArtists(firstTrack));
+    m_albumTitle->setText(firstTrack.album());
+    m_discNumber->setText(firstTrack.discNumber());
+    m_genre->setText(displayMetadataValues(firstTrack.genres()));
+    m_date->setText(firstTrack.date());
+
+    const auto addAlbumField = [albumGroup, albumLayout](const QString& text, QLineEdit* field, int row, int column) {
+        auto* label = new QLabel(text + u":"_s, albumGroup);
+        albumLayout->addWidget(label, row, column);
+        albumLayout->addWidget(field, row, column + 1);
+    };
+
+    addAlbumField(tr("Album artist"), m_albumArtist, 0, 0);
+    addAlbumField(tr("Album title"), m_albumTitle, 0, 2);
+    addAlbumField(tr("Genre"), m_genre, 1, 0);
+    addAlbumField(tr("Date"), m_date, 1, 2);
+
+    auto* discNumberLabel = new QLabel(tr("Disc number") + u":"_s, albumGroup);
+    m_discNumber->setMaximumWidth(100);
+    albumLayout->addWidget(discNumberLabel, 2, 0);
+    albumLayout->addWidget(m_discNumber, 2, 1, Qt::AlignLeft);
+    albumLayout->addWidget(m_lookupButton, 2, 2, 1, 2, Qt::AlignRight);
+    albumLayout->setColumnStretch(1, 1);
+    albumLayout->setColumnStretch(3, 1);
+
+    auto* trackGroup = new QGroupBox(tr("Track information"), this);
+    m_trackTable->setColumnCount(4);
+    m_trackTable->setRowCount(static_cast<int>(m_tracks.size()));
+    m_trackTable->setHorizontalHeaderLabels({QString{}, tr("#"), tr("Title"), tr("Artist")});
+    m_trackTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_trackTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_trackTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_trackTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    m_trackTable->verticalHeader()->hide();
+    m_trackTable->setAlternatingRowColors(true);
+    m_trackTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+    for(int row{0}; std::cmp_less(row, m_tracks.size()); ++row) {
+        const Track& track = m_tracks.at(static_cast<size_t>(row));
+
+        auto* selected = new QTableWidgetItem();
+        selected->setCheckState(Qt::Checked);
+        selected->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable);
+        selected->setTextAlignment(Qt::AlignCenter);
+
+        auto* number = new QTableWidgetItem(track.trackNumber());
+        number->setFlags(number->flags() & ~Qt::ItemIsEditable);
+        number->setTextAlignment(Qt::AlignCenter);
+
+        m_trackTable->setItem(row, 0, selected);
+        m_trackTable->setItem(row, 1, number);
+        m_trackTable->setItem(row, 2, new QTableWidgetItem(track.effectiveTitle()));
+        m_trackTable->setItem(row, 3, new QTableWidgetItem(displayMetadataValues(track.artists())));
+    }
+
+    auto* trackLayout = new QVBoxLayout(trackGroup);
+    trackLayout->addWidget(m_trackTable);
+
+    m_accurateRipStatus->setWordWrap(true);
+    m_accurateRipStatus->hide();
+
+    auto* buttons = new QDialogButtonBox(this);
+    buttons->addButton(m_setupButton, QDialogButtonBox::ActionRole);
+    buttons->addButton(m_ripButton, QDialogButtonBox::AcceptRole);
+    buttons->addButton(QDialogButtonBox::Close);
+
+    auto* layout = new QGridLayout(this);
+    layout->setVerticalSpacing(8);
+
+    layout->addWidget(albumGroup, 0, 0, 1, 3);
+    layout->addWidget(trackGroup, 1, 0, 1, 3);
+    layout->addWidget(m_verifyAccurateRip, 2, 0);
+    layout->addWidget(new QLabel(tr("Preset") + u":"_s, this), 2, 1, Qt::AlignRight);
+    layout->addWidget(m_presets, 2, 2);
+    layout->addWidget(m_accurateRipStatus, 3, 0, 1, 3);
+    layout->addWidget(buttons, 4, 0, 1, 3);
+    layout->setRowStretch(1, 1);
+    layout->setColumnStretch(0, 1);
+    layout->setColumnStretch(2, 1);
+
+    for(const auto& preset : presets) {
+        m_presets->addItem(preset.name, preset.id);
+    }
+
+    QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    QObject::connect(m_trackTable, &QTableWidget::itemChanged, this, &RipAudioCdDialog::updateActions);
+    QObject::connect(m_presets, &QComboBox::currentIndexChanged, this, &RipAudioCdDialog::updateActions);
+    QObject::connect(m_lookupButton, &QPushButton::clicked, this, &RipAudioCdDialog::showMetadataLookup);
+    QObject::connect(m_setupButton, &QPushButton::clicked, this, &RipAudioCdDialog::showConverterSetup);
+    QObject::connect(m_ripButton, &QPushButton::clicked, this, &RipAudioCdDialog::ripWithPreset);
+
+    m_verifyAccurateRip->setChecked(true);
+    m_lookupButton->setAutoDefault(false);
+    m_ripButton->setDefault(m_presets->count() > 0);
+    m_setupButton->setDefault(m_presets->count() == 0);
+    if(!driveOffsetConfigured) {
+        m_accurateRipStatus->setText(tr("Drive offset has not been configured. Check Drive settings before ripping."));
+        m_accurateRipStatus->show();
+    }
+
+    updateActions();
+}
+
+TrackList RipAudioCdDialog::selectedTracks() const
+{
+    return tracksFromTable(true);
+}
+
+TrackList RipAudioCdDialog::tracksFromTable(bool selectedOnly) const
+{
+    TrackList selected;
+
+    const QString albumArtist = m_albumArtist->text().trimmed();
+    const QString album       = m_albumTitle->text().trimmed();
+    const QString discNumber  = m_discNumber->text().trimmed();
+    const QString genre       = m_genre->text().trimmed();
+    const QString date        = m_date->text().trimmed();
+
+    for(int row{0}; row < m_trackTable->rowCount() && std::cmp_less(row, m_tracks.size()); ++row) {
+        if(selectedOnly && m_trackTable->item(row, 0)->checkState() != Qt::Checked) {
+            continue;
+        }
+
+        Track track = m_tracks.at(row);
+
+        track.setAlbumArtists(metadataValues(albumArtist));
+        track.setAlbum(album);
+        track.setDiscNumber(discNumber);
+        track.setGenres(metadataValues(genre));
+        track.setDate(date);
+        track.setTitle(m_trackTable->item(row, 2)->text().trimmed());
+        track.setArtists(metadataValues(m_trackTable->item(row, 3)->text().trimmed()));
+
+        selected.push_back(std::move(track));
+    }
+
+    return selected;
+}
+
+void RipAudioCdDialog::applyLookupTracks(const TrackList& tracks)
+{
+    const bool sameTracks = tracks.size() == m_tracks.size()
+                         && std::ranges::equal(tracks, m_tracks, [](const Track& lhs, const Track& rhs) {
+                                return lhs.sameIdentityAs(rhs);
+                            });
+    if(!sameTracks) {
+        return;
+    }
+
+    m_tracks = tracks;
+
+    const QSignalBlocker trackBlocker{m_trackTable};
+
+    const Track firstTrack = m_tracks.empty() ? Track{} : m_tracks.front();
+    m_albumArtist->setText(displayAlbumArtists(firstTrack));
+    m_albumTitle->setText(firstTrack.album());
+    m_discNumber->setText(firstTrack.discNumber());
+    m_genre->setText(displayMetadataValues(firstTrack.genres()));
+    m_date->setText(firstTrack.date());
+
+    for(int row{0}; std::cmp_less(row, m_tracks.size()); ++row) {
+        const Track& track = m_tracks.at(row);
+        m_trackTable->item(row, 1)->setText(track.trackNumber());
+        m_trackTable->item(row, 2)->setText(track.effectiveTitle());
+        m_trackTable->item(row, 3)->setText(displayMetadataValues(track.artists()));
+    }
+    updateActions();
+}
+
+void RipAudioCdDialog::updateActions()
+{
+    const bool hasTracks = !selectedTracks().empty();
+
+    m_lookupButton->setEnabled(!m_tracks.empty() && m_metadataLookupAvailable && !m_metadataLookupPending);
+    m_setupButton->setEnabled(hasTracks && !m_ripPending);
+    m_ripButton->setEnabled(hasTracks && m_presets->currentIndex() >= 0 && !m_ripPending);
+    m_presets->setEnabled(m_presets->count() > 0 && !m_ripPending);
+}
+
+void RipAudioCdDialog::showMetadataLookup()
+{
+    const TrackList tracks = tracksFromTable(false);
+    if(tracks.empty() || !m_metadataLookupAvailable || m_metadataLookupPending) {
+        return;
+    }
+
+    m_metadataLookupPending = true;
+    updateActions();
+    Q_EMIT metadataLookupRequested(tracks);
+}
+
+void RipAudioCdDialog::showConverterSetup()
+{
+    requestRip(true);
+}
+
+void RipAudioCdDialog::ripWithPreset()
+{
+    requestRip(false);
+}
+
+void RipAudioCdDialog::requestRip(bool showSetup)
+{
+    const TrackList tracks = selectedTracks();
+    if(tracks.empty() || m_ripPending) {
+        return;
+    }
+
+    m_ripPending = true;
+    updateActions();
+
+    const QString status = m_verifyAccurateRip->isChecked() ? tr("Looking up disc in AccurateRip…") : QString{};
+    m_accurateRipStatus->setText(status);
+    m_accurateRipStatus->setVisible(!status.isEmpty());
+
+    Q_EMIT ripRequested(tracks, showSetup ? QString{} : m_presets->currentData().toString(), showSetup,
+                        m_verifyAccurateRip->isChecked());
+}
+
+void RipAudioCdDialog::metadataLookupFinished()
+{
+    m_metadataLookupPending = false;
+    updateActions();
+}
+
+void RipAudioCdDialog::ripStartFailed()
+{
+    m_ripPending = false;
+    updateActions();
+}
+} // namespace Fooyin::Cdda
+
+#include "moc_ripaudiocddialog.cpp"

--- a/src/plugins/cdda/ripaudiocddialog.h
+++ b/src/plugins/cdda/ripaudiocddialog.h
@@ -1,0 +1,88 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/track.h>
+#include <gui/conversion/conversionservice.h>
+
+#include <QDialog>
+
+#include <vector>
+
+class QComboBox;
+class QCheckBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QTableWidget;
+
+namespace Fooyin::Cdda {
+struct AccurateRipTrackResult;
+
+void showAccurateRipResults(QWidget* parent, const std::vector<AccurateRipTrackResult>& results,
+                            const QString& message);
+
+class RipAudioCdDialog final : public QDialog
+{
+    Q_OBJECT
+
+public:
+    RipAudioCdDialog(TrackList tracks, const std::vector<ConversionPresetInfo>& presets, bool metadataLookupAvailable,
+                     bool driveOffsetConfigured, QWidget* parent = nullptr);
+
+    void applyLookupTracks(const TrackList& tracks);
+    void metadataLookupFinished();
+    void ripStartFailed();
+
+Q_SIGNALS:
+    void metadataLookupRequested(const Fooyin::TrackList& tracks);
+    void ripRequested(const Fooyin::TrackList& tracks, const QString& presetId, bool showSetup, bool verifyAccurateRip);
+
+private:
+    [[nodiscard]] TrackList selectedTracks() const;
+    [[nodiscard]] TrackList tracksFromTable(bool selectedOnly) const;
+
+    void updateActions();
+
+    void showMetadataLookup();
+    void showConverterSetup();
+
+    void ripWithPreset();
+    void requestRip(bool showSetup);
+
+    TrackList m_tracks;
+    bool m_metadataLookupAvailable;
+    bool m_metadataLookupPending;
+    bool m_ripPending;
+
+    QLineEdit* m_albumArtist;
+    QLineEdit* m_albumTitle;
+    QLineEdit* m_discNumber;
+    QLineEdit* m_genre;
+    QLineEdit* m_date;
+    QTableWidget* m_trackTable;
+    QComboBox* m_presets;
+    QCheckBox* m_verifyAccurateRip;
+    QLabel* m_accurateRipStatus;
+    QPushButton* m_lookupButton;
+    QPushButton* m_setupButton;
+    QPushButton* m_ripButton;
+};
+} // namespace Fooyin::Cdda

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,3 +132,66 @@ target_include_directories(test_lyricsparser PRIVATE ${CMAKE_SOURCE_DIR}/src/plu
 
 fooyin_add_test(test_metadatamatcher gui/metadatalookup/metadatamatchertest.cpp)
 fooyin_add_test(test_metadataapply gui/metadatalookup/metadataapplytest.cpp)
+
+if(TARGET cdda)
+    fooyin_add_test(
+        test_cddadomain plugins/cdda/cddadomaintest.cpp ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+                        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddaurl.cpp
+    )
+    target_include_directories(test_cddadomain PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_accuraterip plugins/cdda/accurateriptest.cpp ${CMAKE_SOURCE_DIR}/src/plugins/cdda/accuraterip.cpp
+                         ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+    )
+    target_include_directories(test_accuraterip PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_cddrivebackend plugins/cdda/cddrivebackendtest.cpp
+                            ${CMAKE_SOURCE_DIR}/src/plugins/cdda/drive/cddrivebackend.cpp
+    )
+    target_include_directories(test_cddrivebackend PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_cddasectorreader
+        plugins/cdda/cddasectorreadertest.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddasectorreader.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/drive/cddrivebackend.cpp
+    )
+    target_include_directories(test_cddasectorreader PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_cddrivemanager
+        plugins/cdda/cddadrivemanagertest.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddadrivemanager.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddaurl.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/drive/cddrivebackend.cpp
+    )
+    target_include_directories(test_cddrivemanager PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_cddareader
+        plugins/cdda/cddareadertest.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddareader.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddadrivemanager.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddaurl.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/drive/cddrivebackend.cpp
+    )
+    target_include_directories(test_cddareader PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+
+    fooyin_add_test(
+        test_cddadecoder
+        plugins/cdda/cddadecodertest.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddadecoder.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddadrivesettings.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddadrivemanager.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddasectorreader.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddatoc.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/cddaurl.cpp
+        ${CMAKE_SOURCE_DIR}/src/plugins/cdda/drive/cddrivebackend.cpp
+    )
+    target_include_directories(test_cddadecoder PRIVATE ${CMAKE_SOURCE_DIR}/src/plugins/cdda)
+endif()

--- a/tests/core/engine/audioenginetest.cpp
+++ b/tests/core/engine/audioenginetest.cpp
@@ -265,6 +265,16 @@ public:
         return true;
     }
 
+    [[nodiscard]] bool allowsConcurrentDecoding() const override
+    {
+        return !m_track.filepath().contains(u"exclusive"_s);
+    }
+
+    [[nodiscard]] int playbackPrebufferMs() const override
+    {
+        return m_track.filepath().contains(u"slow-prebuffer"_s) ? 1000 : 0;
+    }
+
     [[nodiscard]] int bitrate() const override
     {
         return m_stats->bitrate.load(std::memory_order_relaxed);
@@ -288,10 +298,11 @@ public:
         ++m_stats->initCalls;
         m_track = track;
         m_format.setSampleRate(track.filenameExt().contains(u"sr2000"_s) ? 2000 : 1000);
-        m_position  = track.offset();
-        m_sourceEnd = m_stats->sourceEndMs.load(std::memory_order_relaxed);
-        m_started   = false;
-        m_initValid = true;
+        m_position         = track.offset();
+        m_sourceEnd        = m_stats->sourceEndMs.load(std::memory_order_relaxed);
+        m_started          = false;
+        m_initValid        = true;
+        m_delayedFirstRead = false;
         return m_format;
     }
 
@@ -336,6 +347,11 @@ public:
             return {};
         }
 
+        if(!m_delayedFirstRead && m_track.filepath().contains(u"slow-prebuffer"_s)) {
+            m_delayedFirstRead = true;
+            std::this_thread::sleep_for(150ms);
+        }
+
         AudioBuffer buffer{m_format, m_position};
         buffer.resize(frameCount * static_cast<size_t>(bytesPerFrame));
 
@@ -357,6 +373,7 @@ private:
     uint64_t m_sourceEnd{0};
     bool m_started{false};
     bool m_initValid{false};
+    bool m_delayedFirstRead{false};
     std::optional<TimedTrackChange> m_timedTrackChange;
 };
 
@@ -656,10 +673,15 @@ public:
         engine.m_fadingEnabled         = true;
         engine.m_fadingValues.stop.out = 1000;
         engine.m_decoder.stopDecodeTimer();
-        engine.m_remoteBuffering.active     = true;
-        engine.m_remoteBuffering.generation = engine.m_trackGeneration;
-        engine.m_remoteBuffering.streamId   = stream->id();
+        engine.m_inputBuffering.active     = true;
+        engine.m_inputBuffering.generation = engine.m_trackGeneration;
+        engine.m_inputBuffering.streamId   = stream->id();
         engine.m_pipeline.setBufferingPaused(true);
+    }
+
+    static bool inputBufferingActive(const AudioEngine& engine)
+    {
+        return engine.m_inputBuffering.active;
     }
 
     static int streamBufferLengthMs(const AudioEngine& engine, const Track& track)
@@ -771,6 +793,13 @@ public:
     static Engine::PlaybackItem upcomingTrackCandidate(const AudioEngine& engine)
     {
         return engine.upcomingTrackCandidateItem();
+    }
+
+    static const char* autoTransitionRejectionReason(const AudioEngine& engine, const Track& track)
+    {
+        const char* reason{nullptr};
+        engine.evaluateAutoTransitionEligibility(track, false, false, &reason);
+        return reason;
     }
 };
 
@@ -1176,6 +1205,48 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, SeekDiscontinuityPublishesNea
     EXPECT_NE(postSeekPositionMs, preSeekPositionMs);
     EXPECT_GE(postSeekPositionMs, seekPositionMs > 1000 ? seekPositionMs - 1000 : 0);
     EXPECT_LE(postSeekPositionMs, seekPositionMs + 1800);
+}
+
+FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, InitialRestoreSeeksBeforeTrackPrefill)
+{
+    ensureCoreApplication();
+    EngineHarness harness{false};
+
+    const Track track                           = harness.createTrack(u"initial-restore.fyt"_s, 0, 120000);
+    static constexpr uint64_t restorePositionMs = 32000;
+
+    harness.engine.queueInitialRestore(restorePositionMs, track.id());
+    harness.engine.loadTrack(makePlaybackItem(track, 1), false);
+
+    ASSERT_EQ(harness.engine.trackStatus(), Engine::TrackStatus::Loaded);
+    ASSERT_EQ(harness.decoderStats->seekCalls.load(), 1);
+    EXPECT_EQ(harness.engine.position(), restorePositionMs);
+
+    harness.engine.restorePosition(restorePositionMs, false);
+    EXPECT_EQ(harness.decoderStats->seekCalls.load(), 1);
+    EXPECT_EQ(harness.engine.position(), restorePositionMs);
+}
+
+FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, DecoderPrebufferHoldsPlaybackUntilPcmReady)
+{
+    ensureCoreApplication();
+    EngineHarness harness{false};
+
+    const Track track = harness.createTrack(u"slow-prebuffer.fyt"_s, 0, 120000);
+    harness.engine.loadTrack(makePlaybackItem(track, 1), false);
+    harness.engine.play();
+
+    EXPECT_EQ(harness.engine.playbackState(), Engine::PlaybackState::Playing);
+    EXPECT_EQ(harness.engine.trackStatus(), Engine::TrackStatus::Buffering);
+    EXPECT_TRUE(AudioEngineTestAccessor::inputBufferingActive(harness.engine));
+
+    ASSERT_TRUE(pumpUntil(
+        [&harness]() {
+            return harness.engine.trackStatus() == Engine::TrackStatus::Buffered
+                && !AudioEngineTestAccessor::inputBufferingActive(harness.engine);
+        },
+        2000ms));
+    ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.position() > 0; }, 1000ms));
 }
 
 FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, SeekWithRequestPublishesMatchingRequestIds)
@@ -1813,6 +1884,49 @@ FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, FormatMismatchPreparationDisc
     ASSERT_TRUE(AudioEngineTestAccessor::hasPreparedNext(harness.engine));
     EXPECT_FALSE(AudioEngineTestAccessor::preparedNextHasStream(harness.engine));
     EXPECT_GT(AudioEngineTestAccessor::preparedDecodePositionMs(harness.engine), 0U);
+}
+
+FOOYIN_AUDIOENGINE_SENSITIVE_TEST(AudioEngineTest, ExclusiveDecodersRejectOverlappingAutoTransitions)
+{
+    ensureCoreApplication();
+
+    {
+        EngineHarness harness{false};
+        AudioEngineTestAccessor::setGaplessEnabled(harness.engine, true);
+
+        const Track currentTrack = harness.createTrack(u"exclusive-current.fyt"_s, 0, 120000);
+        const Track nextTrack    = harness.createTrack(u"ordinary-target.fyt"_s, 0, 120000);
+        const auto nextItem      = makePlaybackItem(nextTrack, 2);
+
+        harness.engine.loadTrack(makePlaybackItem(currentTrack, 1), false);
+        ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.trackStatus() == Engine::TrackStatus::Loaded; }));
+        harness.engine.play();
+        ASSERT_TRUE(
+            pumpUntil([&harness]() { return harness.engine.playbackState() == Engine::PlaybackState::Playing; }));
+
+        EXPECT_FALSE(AudioEngineTestAccessor::prepareNextTrackImmediate(harness.engine, nextItem, 1200));
+        EXPECT_STREQ("current-decoder-exclusive",
+                     AudioEngineTestAccessor::autoTransitionRejectionReason(harness.engine, nextTrack));
+    }
+
+    {
+        EngineHarness harness{false};
+        AudioEngineTestAccessor::setGaplessEnabled(harness.engine, true);
+
+        const Track currentTrack = harness.createTrack(u"ordinary-current.fyt"_s, 0, 120000);
+        const Track nextTrack    = harness.createTrack(u"exclusive-target.fyt"_s, 0, 120000);
+        const auto nextItem      = makePlaybackItem(nextTrack, 2);
+
+        harness.engine.loadTrack(makePlaybackItem(currentTrack, 1), false);
+        ASSERT_TRUE(pumpUntil([&harness]() { return harness.engine.trackStatus() == Engine::TrackStatus::Loaded; }));
+        harness.engine.play();
+        ASSERT_TRUE(
+            pumpUntil([&harness]() { return harness.engine.playbackState() == Engine::PlaybackState::Playing; }));
+
+        ASSERT_TRUE(AudioEngineTestAccessor::prepareNextTrackImmediate(harness.engine, nextItem, 1200));
+        EXPECT_STREQ("target-decoder-exclusive",
+                     AudioEngineTestAccessor::autoTransitionRejectionReason(harness.engine, nextTrack));
+    }
 }
 
 FOOYIN_AUDIOENGINE_REGULAR_TEST(AudioEngineTest, SetAnalysisDataSubscriptionsAcceptsRuntimeChanges)

--- a/tests/core/engine/audioloadertest.cpp
+++ b/tests/core/engine/audioloadertest.cpp
@@ -130,6 +130,7 @@ struct DecoderState
     QString label;
     QStringList extensions;
     QStringList preferredExtensions;
+    QStringList supportedSchemes;
     bool supportsRemoteSources{false};
     bool initSucceeds{true};
     bool requireDevice{false};
@@ -174,6 +175,11 @@ public:
     QStringList preferredExtensions() const override
     {
         return m_state->preferredExtensions;
+    }
+
+    QStringList supportedSchemes() const override
+    {
+        return m_state->supportedSchemes;
     }
 
     bool supportsRemoteSources() const override
@@ -236,6 +242,7 @@ struct ReaderState
     QString label;
     QStringList extensions;
     QStringList preferredExtensions;
+    QStringList supportedSchemes;
     bool supportsRemoteSources{false};
     bool canReadCover{false};
     bool canWriteMetadata{false};
@@ -291,6 +298,11 @@ public:
     QStringList preferredExtensions() const override
     {
         return m_state->preferredExtensions;
+    }
+
+    QStringList supportedSchemes() const override
+    {
+        return m_state->supportedSchemes;
     }
 
     bool supportsRemoteSources() const override
@@ -592,11 +604,13 @@ protected:
     }
 
     std::shared_ptr<DecoderState> addDecoder(AudioLoader& loader, const QString& label, const QStringList& extensions,
-                                             int priority = -1, bool isArchiveWrapper = false)
+                                             int priority = -1, bool isArchiveWrapper = false,
+                                             const QStringList& supportedSchemes = {})
     {
-        auto state        = std::make_shared<DecoderState>();
-        state->label      = label;
-        state->extensions = extensions;
+        auto state              = std::make_shared<DecoderState>();
+        state->label            = label;
+        state->extensions       = extensions;
+        state->supportedSchemes = supportedSchemes;
 
         loader.addDecoder(
             label,
@@ -609,11 +623,13 @@ protected:
     }
 
     std::shared_ptr<ReaderState> addReader(AudioLoader& loader, const QString& label, const QStringList& extensions,
-                                           int priority = -1, bool isArchiveWrapper = false)
+                                           int priority = -1, bool isArchiveWrapper = false,
+                                           const QStringList& supportedSchemes = {})
     {
-        auto state        = std::make_shared<ReaderState>();
-        state->label      = label;
-        state->extensions = extensions;
+        auto state              = std::make_shared<ReaderState>();
+        state->label            = label;
+        state->extensions       = extensions;
+        state->supportedSchemes = supportedSchemes;
 
         loader.addReader(
             label,
@@ -900,6 +916,64 @@ TEST_F(AudioLoaderTest, LoadsDecoderAndReaderForRegularTracks)
     EXPECT_TRUE(readerTwo->lastDeviceOpen);
     EXPECT_FALSE(readerTwo->lastHadArchiveReader);
     EXPECT_EQ(3, loadedReader.reader->subsongCount());
+}
+
+TEST_F(AudioLoaderTest, LoadsDecoderAndReaderForRegisteredUriSchemeWithoutOpeningAFile)
+{
+    AudioLoader loader;
+    const Track track{u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s};
+    const auto provider = std::make_shared<FakeRemoteSourceProvider>();
+    loader.setRemoteSourceProvider(provider);
+
+    addDecoder(loader, u"extension-only-decoder"_s, {u"cdda"_s});
+    const auto decoder = addDecoder(loader, u"cdda-decoder"_s, {}, -1, false, {u" CDDA "_s});
+
+    addReader(loader, u"extension-only-reader"_s, {u"cdda"_s});
+    const auto reader        = addReader(loader, u"cdda-reader"_s, {}, -1, false, {u"cDdA"_s});
+    reader->title            = u"Audio CD"_s;
+    reader->canReadCover     = true;
+    reader->coverData        = "disc-cover";
+    reader->canWriteMetadata = true;
+
+    EXPECT_EQ((QStringList{u"cdda-decoder"_s}), decoderLabels(loader.decodersForTrack(track)));
+    EXPECT_EQ((QStringList{u"cdda-reader"_s}), readerLabels(loader.readersForTrack(track)));
+
+    const auto loadedDecoder = loader.loadDecoderForTrack(track);
+    ASSERT_NE(loadedDecoder.decoder, nullptr);
+    EXPECT_EQ(track.filepath(), loadedDecoder.input.source.filepath);
+    EXPECT_EQ(nullptr, loadedDecoder.input.source.device);
+    EXPECT_EQ(nullptr, loadedDecoder.input.device.get());
+    EXPECT_FALSE(decoder->lastHadDevice);
+
+    const auto loadedReader = loader.loadReaderForTrack(track);
+    ASSERT_NE(loadedReader.reader, nullptr);
+    EXPECT_EQ(track.filepath(), loadedReader.input.source.filepath);
+    EXPECT_EQ(nullptr, loadedReader.input.source.device);
+    EXPECT_EQ(nullptr, loadedReader.input.device.get());
+    EXPECT_FALSE(reader->lastHadDevice);
+
+    Track metadataTrack{track};
+    ASSERT_TRUE(loader.readTrackMetadata(metadataTrack));
+    EXPECT_EQ(u"Audio CD"_s, metadataTrack.title());
+    EXPECT_EQ(QByteArray{"disc-cover"}, loader.readTrackCover(track, Track::Cover::Front));
+    EXPECT_FALSE(loader.canWriteMetadata(track));
+    EXPECT_FALSE(loader.writeTrackMetadata(track, AudioReader::Metadata));
+    EXPECT_FALSE(loader.writeTrackCover(track, {}, AudioReader::None));
+    EXPECT_EQ(0, provider->calls);
+}
+
+TEST_F(AudioLoaderTest, UriSchemeSelectionHonoursDisabledStateAndDoesNotMisclassifyWindowsPaths)
+{
+    AudioLoader loader;
+    addDecoder(loader, u"windows-file-decoder"_s, {u"mp3"_s});
+    addDecoder(loader, u"drive-letter-scheme-decoder"_s, {}, -1, false, {u"c"_s});
+    addDecoder(loader, u"cdda-decoder"_s, {}, -1, false, {u"cdda"_s});
+
+    EXPECT_EQ((QStringList{u"windows-file-decoder"_s}),
+              decoderLabels(loader.decodersForFile(uR"(C:\music\song.mp3)"_s)));
+
+    loader.setDecoderEnabled(u"cdda-decoder"_s, false);
+    EXPECT_TRUE(loader.decodersForFile(u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s).empty());
 }
 
 TEST_F(AudioLoaderTest, LoadsDecoderAndReaderForRemoteTracksWithoutOpeningDevices)

--- a/tests/core/engine/conversion/conversionrunnertest.cpp
+++ b/tests/core/engine/conversion/conversionrunnertest.cpp
@@ -187,22 +187,24 @@ public:
         profile.extension     = u"wav"_s;
         profile.containerName = u"wav"_s;
         profile.codecName     = u"capture"_s;
-        return {{.id               = profile.id,
-                 .backendId        = u"capture"_s,
-                 .name             = profile.name,
-                 .description      = {},
-                 .profile          = profile,
-                 .supportsMetadata = false,
-                 .supportsPictures = false}};
+        return {{.id                  = profile.id,
+                 .backendId           = u"capture"_s,
+                 .name                = profile.name,
+                 .description         = {},
+                 .profile             = profile,
+                 .estimateBitrateKbps = {},
+                 .supportsMetadata    = false,
+                 .supportsPictures    = false}};
     }
 
-    Result init(const QString&, const AudioFormat&, const AudioEncoderSettings& settings) override
+    Result init(const QString& /*outputPath*/, const AudioFormat& /*inputFormat*/,
+                const AudioEncoderSettings& settings) override
     {
         m_ditherModes->push_back(settings.ditherMode);
         return Result::success();
     }
 
-    Result write(const AudioBuffer&) override
+    Result write(const AudioBuffer& /*buffer*/) override
     {
         return Result::success();
     }
@@ -214,6 +216,66 @@ public:
 
 private:
     std::shared_ptr<std::vector<DitherMode>> m_ditherModes;
+};
+
+struct WarningDecoderState
+{
+    AudioDecoder::DecoderOptions options{AudioDecoder::None};
+    int warningDrains{0};
+};
+
+class WarningDecoder : public AudioDecoder
+{
+public:
+    explicit WarningDecoder(std::shared_ptr<WarningDecoderState> state)
+        : m_state{std::move(state)}
+    { }
+
+    [[nodiscard]] QStringList extensions() const override
+    {
+        return {u"warning"_s};
+    }
+
+    [[nodiscard]] bool isSeekable() const override
+    {
+        return true;
+    }
+
+    std::optional<AudioFormat> init(const AudioSource& /*source*/, const Track& /*track*/,
+                                    DecoderOptions options) override
+    {
+        m_state->options = options;
+        m_emitted        = false;
+        m_warningPending = true;
+        return m_format;
+    }
+
+    void seek(uint64_t /*pos*/) override { }
+    void stop() override { }
+
+    AudioBuffer readBuffer(size_t bytes) override
+    {
+        if(m_emitted || std::cmp_less(bytes, m_format.bytesPerFrame())) {
+            return {};
+        }
+        m_emitted = true;
+        AudioBuffer buffer{m_format, 0};
+        buffer.resize(100 * static_cast<size_t>(m_format.bytesPerFrame()));
+        buffer.fillSilence();
+        return buffer;
+    }
+
+    QStringList takeWarnings() override
+    {
+        ++m_state->warningDrains;
+        return std::exchange(m_warningPending, false) ? QStringList{u"Recovered source read"_s} : QStringList{};
+    }
+
+private:
+    std::shared_ptr<WarningDecoderState> m_state;
+    AudioFormat m_format{SampleFormat::S16, 44100, 2};
+    bool m_emitted{false};
+    bool m_warningPending{false};
 };
 
 class CountingDsp : public DspNode
@@ -229,8 +291,8 @@ public:
         return u"test.dsp.counting"_s;
     }
 
-    void prepare(const AudioFormat&) override { }
-    void process(ProcessingBufferList&) override { }
+    void prepare(const AudioFormat& /*format*/) override { }
+    void process(ProcessingBufferList& /*chunks*/) override { }
 };
 } // namespace
 
@@ -241,7 +303,7 @@ TEST(ConversionRunnerTest, ConvertsTrackToFlac)
         GTEST_SKIP() << "Runtime FFmpeg FLAC encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -321,7 +383,7 @@ TEST(ConversionRunnerTest, ConvertsTrackToFlac)
 
 TEST(ConversionRunnerTest, ReportsFailedDecode)
 {
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -364,9 +426,55 @@ TEST(ConversionRunnerTest, ReportsFailedDecode)
     EXPECT_EQ(existingOutput.readAll(), originalContents);
 }
 
+TEST(ConversionRunnerTest, MarksSourceAsConversionAndForwardsDecoderWarnings)
+{
+    const QTemporaryDir outputDir;
+    ASSERT_TRUE(outputDir.isValid());
+    const QString sourcePath = outputDir.filePath(u"source.warning"_s);
+    QFile source{sourcePath};
+    ASSERT_TRUE(source.open(QIODevice::WriteOnly));
+    source.close();
+
+    auto decoderState = std::make_shared<WarningDecoderState>();
+    AudioLoader loader;
+    loader.addDecoder(u"Warning"_s, [decoderState] { return std::make_unique<WarningDecoder>(decoderState); });
+
+    auto ditherModes = std::make_shared<std::vector<DitherMode>>();
+    AudioEncoderRegistry encoderRegistry;
+    encoderRegistry.addEncoderBackend(u"capture"_s, u"Capture"_s,
+                                      [ditherModes] { return std::make_unique<CapturingAudioEncoder>(ditherModes); });
+
+    Track track{sourcePath};
+    track.setTitle(u"Warning Source"_s);
+    ConversionPreset preset;
+    preset.encoder.profile.id            = u"capture-wav"_s;
+    preset.encoder.profile.extension     = u"wav"_s;
+    preset.encoder.profile.containerName = u"wav"_s;
+    preset.encoder.profile.codecName     = u"capture"_s;
+    preset.destination.mode              = DestinationMode::FixedFolder;
+    preset.destination.fixedFolder       = outputDir.path();
+    preset.destination.filenamePattern   = u"%title%"_s;
+    preset.destination.existingFileMode  = ExistingFileMode::Overwrite;
+    preset.processing.transferMetadata   = false;
+
+    ConversionRunner::Request request;
+    request.audioLoader     = &loader;
+    request.encoderRegistry = &encoderRegistry;
+    request.job.tracks      = {track};
+    request.job.preset      = preset;
+
+    const auto results = ConversionRunner::run(request);
+    ASSERT_EQ(1, results.size());
+    ASSERT_EQ(ConversionResultStatus::Succeeded, results.front().status) << results.front().error.toStdString();
+    EXPECT_TRUE(decoderState->options.testFlag(AudioDecoder::ForConversion));
+    EXPECT_TRUE(decoderState->options.testFlag(AudioDecoder::NoLooping));
+    EXPECT_EQ(1, results.front().warnings.count(u"Recovered source read"_s));
+    EXPECT_EQ(1, decoderState->warningDrains);
+}
+
 TEST(ConversionRunnerTest, CancelsAtTrackBoundary)
 {
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
     QFile existing{outputDir.filePath(u"First.wav"_s)};
     ASSERT_TRUE(existing.open(QIODevice::WriteOnly));
@@ -416,7 +524,7 @@ TEST(ConversionRunnerTest, AppliesTrackReplayGainBeforeEncoding)
         GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -472,7 +580,7 @@ TEST(ConversionRunnerTest, AppliesIndependentDspChainBeforeEncoding)
         GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -514,7 +622,7 @@ TEST(ConversionRunnerTest, AppliesIndependentDspChainBeforeEncoding)
 
 TEST(ConversionRunnerTest, ResolvesLossySourceDitherPerTrack)
 {
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -564,7 +672,7 @@ TEST(ConversionRunnerTest, ResolvesLossySourceDitherPerTrack)
 
 TEST(ConversionRunnerTest, EnablesAutomaticDitherWhenReducingBitDepth)
 {
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -613,7 +721,7 @@ TEST(ConversionRunnerTest, GeneratesPercentagePreview)
         GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -663,7 +771,7 @@ TEST(ConversionRunnerTest, CopiesMatchingSidecarFiles)
         GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
     }
 
-    QTemporaryDir tempDir;
+    const QTemporaryDir tempDir;
     ASSERT_TRUE(tempDir.isValid());
     const QDir root{tempDir.path()};
     ASSERT_TRUE(root.mkpath(u"source"_s));
@@ -721,7 +829,7 @@ TEST(ConversionRunnerTest, GeneratesGroupedMultiTrackOutputs)
         GTEST_SKIP() << "Runtime FFmpeg FLAC encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;
@@ -789,7 +897,7 @@ TEST(ConversionRunnerTest, PreservesDspStateAcrossCombinedOutputWhenRequested)
         GTEST_SKIP() << "Runtime FFmpeg WAV encoder is unavailable";
     }
 
-    QTemporaryDir outputDir;
+    const QTemporaryDir outputDir;
     ASSERT_TRUE(outputDir.isValid());
 
     AudioLoader loader;

--- a/tests/core/playlist/plsparsertest.cpp
+++ b/tests/core/playlist/plsparsertest.cpp
@@ -180,4 +180,31 @@ TEST_F(PlsParserTest, SavesPlaylist)
                            "Version=2\n"_s};
     EXPECT_EQ(expected, saved);
 }
+
+TEST_F(PlsParserTest, RoundTripsVirtualTracksWithoutResolvingThemAsLocalFiles)
+{
+    const QString filepath = u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s;
+    const Track source{filepath, 4};
+
+    QByteArray output;
+    QBuffer writeBuffer{&output};
+    ASSERT_TRUE(writeBuffer.open(QIODevice::WriteOnly | QIODevice::Text));
+    m_parser->savePlaylist(&writeBuffer, u"pls"_s, {source}, QDir{u"/music"_s}, PlaylistParser::PathType::Relative,
+                           false);
+    EXPECT_TRUE(QString::fromUtf8(output).contains(u"File1=%1#4"_s.arg(filepath)));
+
+    QBuffer readBuffer{&output};
+    ASSERT_TRUE(readBuffer.open(QIODevice::ReadOnly | QIODevice::Text));
+    PlaylistParser::ReadPlaylistEntry readEntry;
+    readEntry.readTrack = [](const Track& track) {
+        return track;
+    };
+
+    const TrackList tracks
+        = m_parser->readPlaylist(&readBuffer, u"/music/disc.pls"_s, QDir{u"/music"_s}, readEntry, true);
+    ASSERT_EQ(1, tracks.size());
+    EXPECT_EQ(filepath, tracks.front().filepath());
+    EXPECT_EQ(4, tracks.front().subsong());
+    EXPECT_TRUE(tracks.front().isVirtual());
+}
 } // namespace Fooyin::Testing

--- a/tests/core/tracktest.cpp
+++ b/tests/core/tracktest.cpp
@@ -100,6 +100,39 @@ TEST(TrackTest, PreservesRatingStarSteps)
     EXPECT_EQ(track.ratingStars(), 7);
 }
 
+TEST(TrackTest, DerivesPathFieldsForVirtualUrls)
+{
+    const QString filepath = u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s;
+    const Track track{filepath, 3};
+
+    EXPECT_TRUE(track.isVirtual());
+    EXPECT_FALSE(track.isRemote());
+    EXPECT_FALSE(track.isInArchive());
+    EXPECT_TRUE(track.exists());
+    EXPECT_TRUE(track.url().isEmpty());
+    EXPECT_EQ(u"I5l9cCSFccLKFEKS.7wqSZAorPU-"_s, track.filename());
+    EXPECT_EQ(u"I5l9cCSFccLKFEKS.7wqSZAorPU-"_s, track.filenameExt());
+    EXPECT_EQ(u"cdda://"_s, track.directory());
+    EXPECT_EQ(u"cdda"_s, track.extension());
+    EXPECT_EQ(u"cdda://"_s, track.path());
+    EXPECT_EQ(u"cdda://I5l9cCSFccLKFEKS.7wqSZAorPU-"_s, track.prettyFilepath());
+    EXPECT_EQ(filepath, track.filepath());
+    EXPECT_EQ(3, track.subsong());
+}
+
+TEST(TrackTest, RejectsLocalNetworkArchiveAndMalformedPathsAsVirtual)
+{
+    EXPECT_FALSE(Track::isVirtualPath(uR"(C:\music\song.mp3)"_s));
+    EXPECT_FALSE(Track::isVirtualPath(uR"(\\server\music\song.mp3)"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"//server/music/song.mp3"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"/music/song.mp3"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"file:///music/song.mp3"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"https://radio.example.com/live"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"unpack://zip|1|file:///a!b.mp3"_s));
+    EXPECT_FALSE(Track::isVirtualPath(u"not a uri"_s));
+    EXPECT_TRUE(Track::isVirtualPath(u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s));
+}
+
 TEST(TrackTest, UsesCompactMetadataAccessors)
 {
     Track track;

--- a/tests/plugins/cdda/accurateriptest.cpp
+++ b/tests/plugins/cdda/accurateriptest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "accuraterip.h"
+
+#include <QByteArray>
+#include <QtEndian>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc simpleToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 3,
+            .leadoutSector    = 3,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 1, .isAudio = true},
+                                 {.number = 2, .firstSector = 1, .endSectorExclusive = 2, .isAudio = true},
+                                 {.number = 3, .firstSector = 2, .endSectorExclusive = 3, .isAudio = true}}};
+}
+
+void appendLe32(QByteArray& data, uint32_t value)
+{
+    const uint32_t little = qToLittleEndian(value);
+    data.append(reinterpret_cast<const char*>(&little), sizeof(little));
+}
+} // namespace
+
+TEST(AccurateRipTest, CalculatesDiscIdAndUrl)
+{
+    const CdToc toc{.firstTrackNumber = 1,
+                    .lastTrackNumber  = 3,
+                    .leadoutSector    = 300,
+                    .tracks = {{.number = 1, .firstSector = 0, .endSectorExclusive = 100, .isAudio = true},
+                               {.number = 2, .firstSector = 100, .endSectorExclusive = 200, .isAudio = true},
+                               {.number = 3, .firstSector = 200, .endSectorExclusive = 300, .isAudio = true}}};
+
+    const auto id = accurateRipDiscId(toc);
+    ASSERT_TRUE(id.has_value()) << id.error().toStdString();
+    EXPECT_EQ(600, id->id1);
+    EXPECT_EQ(2001, id->id2);
+    EXPECT_EQ(0x09000403, id->cddbId);
+    EXPECT_EQ(u"https://www.accuraterip.com/accuraterip/8/5/2/dBAR-003-00000258-000007d1-09000403.bin"_s,
+              accurateRipDiscUrl(*id).toString());
+}
+
+TEST(AccurateRipTest, CalculatesPublishedDiscRecordAddress)
+{
+    const std::vector<int> offsets{0,      22617,  41737,  58167,  71952,  91225,
+                                   104502, 115230, 132015, 143782, 159720, 174447};
+    CdToc toc{.firstTrackNumber = 1, .lastTrackNumber = 12, .leadoutSector = 267107, .tracks = {}};
+    for(int index{0}; std::cmp_less(index, offsets.size()); ++index) {
+        toc.tracks.push_back(
+            {.number             = index + 1,
+             .firstSector        = offsets.at(index),
+             .endSectorExclusive = std::cmp_less(index + 1, offsets.size()) ? offsets.at(index + 1) : 267107,
+             .isAudio            = true});
+    }
+
+    const auto id = accurateRipDiscId(toc);
+    ASSERT_TRUE(id.has_value()) << id.error().toStdString();
+    EXPECT_EQ(0x00151865, id->id1);
+    EXPECT_EQ(0x00c50650, id->id2);
+    EXPECT_EQ(0xa70de90c, id->cddbId);
+    EXPECT_EQ(u"https://www.accuraterip.com/accuraterip/5/6/8/dBAR-012-00151865-00c50650-a70de90c.bin"_s,
+              accurateRipDiscUrl(*id).toString());
+}
+
+TEST(AccurateRipTest, ParsesMatchingBinaryRecords)
+{
+    const AccurateRipDiscId id{.id1 = 1, .id2 = 2, .cddbId = 3, .trackCount = 2};
+    QByteArray data;
+    data.append(char{2});
+    appendLe32(data, 1);
+    appendLe32(data, 2);
+    appendLe32(data, 3);
+    data.append(char{7});
+    appendLe32(data, 0x11223344);
+    appendLe32(data, 0x55667788);
+    data.append(char{9});
+    appendLe32(data, 0xaabbccdd);
+    appendLe32(data, 0x01020304);
+
+    const auto records = parseAccurateRipResponse(data, id);
+    ASSERT_TRUE(records.has_value()) << records.error().toStdString();
+    ASSERT_EQ(1, records->size());
+    EXPECT_EQ(7, records->front().front().confidence);
+    EXPECT_EQ(0x11223344, records->front().front().crc);
+    EXPECT_EQ(0x01020304, records->front().back().crc2);
+}
+
+TEST(AccurateRipTest, ParsesAndMatchesDriveOffsetsExactly)
+{
+    const QByteArray html
+        = R"(<table><tr><td>LG Electronics - DVDRAM GH24NSD5</td><td>+6</td><td>42</td><td>100%</td></tr></table>)";
+    const auto offsets = parseAccurateRipDriveOffsets(html);
+    ASSERT_EQ(1, offsets.size());
+    const auto match = findAccurateRipDriveOffset(offsets, u"HL-DT-ST"_s, u"DVDRAM GH24NSD5"_s);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(6, match->correctionSampleFrames);
+    EXPECT_EQ(42, match->submissions);
+}
+
+TEST(AccurateRipTest, VerifiesOffsetCorrectedSourcePcm)
+{
+    AccurateRipPressing pressing(3);
+    pressing[1] = {.confidence = 5, .crc = 14, .crc2 = 0};
+    AccurateRipVerifier verifier{simpleToc(), {pressing}};
+    Track track{u"cdda:///abcdefghijklmnopqrstuvwx1234"_s, 1};
+    track.setTrackNumber(u"2"_s);
+
+    QByteArray pcm(FramesPerSector * 4LL, '\0');
+    const uint32_t values[]{qToLittleEndian(1), qToLittleEndian(2), qToLittleEndian(3)};
+    std::memcpy(pcm.data(), values, sizeof(values));
+    const AudioFormat format{SampleFormat::S16, 44100, 2};
+    const AudioBuffer buffer{reinterpret_cast<const uint8_t*>(pcm.constData()), static_cast<size_t>(pcm.size()), format,
+                             0};
+
+    verifier.trackStarted(track, format);
+    verifier.sourceAudio(track, buffer);
+    verifier.trackFinished(track, true);
+
+    const auto results = verifier.results();
+    ASSERT_EQ(1, results.size());
+    EXPECT_EQ(AccurateRipVerifyStatus::Verified, results.front().status);
+    EXPECT_EQ(14U, results.front().crcV1);
+    EXPECT_EQ(5, results.front().confidence);
+    EXPECT_EQ((std::vector<uint32_t>{14U}), results.front().databaseCrcs);
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddadecodertest.cpp
+++ b/tests/plugins/cdda/cddadecodertest.cpp
@@ -1,0 +1,390 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddadecoder.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <gtest/gtest.h>
+
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc testToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 3,
+            .leadoutSector    = 155,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 2, .isAudio = false},
+                                 {.number = 2, .firstSector = 2, .endSectorExclusive = 5, .isAudio = true},
+                                 {.number = 3, .firstSector = 5, .endSectorExclusive = 155, .isAudio = true}}};
+}
+
+struct BackendState
+{
+    CdToc toc{testToc()};
+    std::optional<CdError> audioError;
+    bool returnInvalidBuffer{false};
+    int openCalls{0};
+    int tocCalls{0};
+    int cancelCalls{0};
+    std::vector<std::pair<int, int>> reads;
+    std::vector<int> readSpeeds;
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool blockAudio{false};
+    bool audioEntered{false};
+    bool cancelled{false};
+};
+
+class FakeSession : public CdDriveSession
+{
+public:
+    explicit FakeSession(std::shared_ptr<BackendState> state)
+        : m_state{std::move(state)}
+    { }
+
+    std::expected<CdToc, CdError> readToc() override
+    {
+        ++m_state->tocCalls;
+        return m_state->toc;
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count) override
+    {
+        {
+            std::unique_lock lock{m_state->mutex};
+
+            m_state->reads.emplace_back(firstSector, count);
+            m_state->audioEntered = true;
+            m_state->condition.notify_all();
+            m_state->condition.wait(lock, [&] { return !m_state->blockAudio || m_state->cancelled; });
+
+            if(m_state->cancelled) {
+                return std::unexpected(
+                    CdError{.code = CdDriveError::Cancelled, .message = u"Cancelled by test"_s, .platformCode = 0});
+            }
+        }
+
+        if(m_state->audioError) {
+            return std::unexpected(*m_state->audioError);
+        }
+        if(m_state->returnInvalidBuffer) {
+            return CdSectorRead{.pcm = QByteArray(BytesPerSector, '\0'), .sectorsRead = count};
+        }
+
+        QByteArray pcm;
+        pcm.reserve(static_cast<qsizetype>(count) * BytesPerSector);
+
+        for(int sector{firstSector}; sector < firstSector + count; ++sector) {
+            pcm.append(QByteArray(BytesPerSector, static_cast<char>(sector & 0xFF)));
+        }
+
+        return CdSectorRead{.pcm = std::move(pcm), .sectorsRead = count};
+    }
+
+    std::expected<void, CdError> setReadSpeed(int speed) override
+    {
+        m_state->readSpeeds.push_back(speed);
+        return {};
+    }
+
+    void cancel() override
+    {
+        const std::scoped_lock lock{m_state->mutex};
+
+        ++m_state->cancelCalls;
+        m_state->cancelled = true;
+        m_state->condition.notify_all();
+    }
+
+private:
+    std::shared_ptr<BackendState> m_state;
+};
+
+class FakeBackend : public CdDriveBackend
+{
+public:
+    explicit FakeBackend(std::shared_ptr<BackendState> state)
+        : m_state{std::move(state)}
+    { }
+
+    std::vector<CdDriveInfo> drives() override
+    {
+        return {{.id                 = u"drive-a"_s,
+                 .displayName        = u"Test drive"_s,
+                 .settingsKey        = u"test-drive"_s,
+                 .supportsSpeedLimit = true,
+                 .vendor             = {},
+                 .model              = {},
+                 .revision           = {}}};
+    }
+
+    std::expected<OpenedDrive, CdError> open(const QString& driveId) override
+    {
+        if(driveId != u"drive-a"_s) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Unsupported, .message = u"Unknown drive"_s, .platformCode = 0});
+        }
+
+        ++m_state->openCalls;
+        return OpenedDrive{.drive = drives().front(), .session = std::make_unique<FakeSession>(m_state)};
+    }
+
+private:
+    std::shared_ptr<BackendState> m_state;
+};
+
+class FakeSettingsProvider : public CdDriveSettingsProvider
+{
+public:
+    CdDriveSettings settings;
+    mutable std::vector<CdDriveInfo> requests;
+
+    CdDriveSettings settingsForDrive(const CdDriveInfo& drive) const override
+    {
+        requests.push_back(drive);
+        return settings;
+    }
+};
+
+struct DecoderFixture
+{
+    DecoderFixture()
+        : state{std::make_shared<BackendState>()}
+        , discId{musicBrainzDiscId(state->toc).value()}
+        , filepath{cddaUrl(discId)}
+        , manager{std::make_shared<CdDriveManager>(std::make_unique<FakeBackend>(state))}
+        , decoder{manager}
+    { }
+
+    bool init(int subsong)
+    {
+        return decoder.init({.filepath = filepath}, Track{filepath, subsong}, AudioDecoder::None).has_value();
+    }
+
+    std::shared_ptr<BackendState> state;
+    QString discId;
+    QString filepath;
+    std::shared_ptr<CdDriveManager> manager;
+    CddaDecoder decoder;
+};
+} // namespace
+
+TEST(CddaDecoderTest, InitialisesWithoutTakingReadLease)
+{
+    DecoderFixture fixture;
+    EXPECT_TRUE(fixture.decoder.extensions().isEmpty());
+    EXPECT_EQ((QStringList{u"cdda"_s}), fixture.decoder.supportedSchemes());
+    EXPECT_FALSE(fixture.decoder.isSeekable());
+    EXPECT_FALSE(fixture.decoder.allowsConcurrentDecoding());
+
+    ASSERT_TRUE(fixture.init(0));
+    EXPECT_TRUE(fixture.decoder.isSeekable());
+    EXPECT_EQ(1, fixture.state->openCalls);
+
+    const auto format
+        = fixture.decoder.init({.filepath = fixture.filepath}, Track{fixture.filepath, 0}, AudioDecoder::None);
+    ASSERT_TRUE(format.has_value());
+    EXPECT_EQ((AudioFormat{SampleFormat::S16, 44100, 2}), *format);
+    EXPECT_EQ(1, fixture.state->openCalls);
+}
+
+TEST(CddaDecoderTest, RequestsPlaybackReserveForReads)
+{
+    const DecoderFixture fixture;
+
+    EXPECT_EQ(1000, fixture.decoder.playbackPrebufferMs());
+    EXPECT_FALSE(fixture.decoder.allowsConcurrentDecoding());
+}
+
+TEST(CddaDecoderTest, BuffersPartialReadsAndStopsAtTrackBoundary)
+{
+    DecoderFixture fixture;
+    ASSERT_TRUE(fixture.init(0));
+
+    auto first = fixture.decoder.readAudio(1000);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, first.status);
+    EXPECT_EQ(1000, first.buffer.byteCount());
+    EXPECT_EQ(0, first.buffer.startTime());
+    EXPECT_EQ(2, fixture.state->openCalls);
+    ASSERT_EQ(1, fixture.state->reads.size());
+    EXPECT_EQ(std::pair(2, 1), fixture.state->reads.front());
+    EXPECT_EQ(std::byte{2}, first.buffer.constData().front());
+
+    auto second = fixture.decoder.readAudio(2000);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, second.status);
+    EXPECT_EQ(2000, second.buffer.byteCount());
+    EXPECT_EQ(5, second.buffer.startTime());
+    EXPECT_EQ(std::byte{2}, second.buffer.constData().front());
+    EXPECT_EQ(std::byte{3}, second.buffer.constData().back());
+
+    auto remainder = fixture.decoder.readAudio(10000);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, remainder.status);
+    EXPECT_EQ((3 * BytesPerSector) - 3000, remainder.buffer.byteCount());
+    EXPECT_EQ(std::byte{4}, remainder.buffer.constData().back());
+    EXPECT_EQ(AudioDecoder::ReadStatus::EndOfStream, fixture.decoder.readAudio(4096).status);
+
+    CddaDecoder next{fixture.manager};
+    ASSERT_TRUE(next.init({.filepath = fixture.filepath}, Track{fixture.filepath, 1}, AudioDecoder::None));
+    EXPECT_EQ(AudioDecoder::ReadStatus::DecodedAudio, next.readAudio(4096).status);
+    EXPECT_TRUE(std::ranges::all_of(fixture.state->reads,
+                                    [](const auto& read) { return read.second > 0 && read.second <= 16; }));
+}
+
+TEST(CddaDecoderTest, SeeksAtSectorGranularityAndClampsToTrackEnd)
+{
+    DecoderFixture fixture;
+    ASSERT_TRUE(fixture.init(1));
+
+    fixture.decoder.seek(1000);
+    auto result = fixture.decoder.readAudio(BytesPerSector);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, result.status);
+    EXPECT_EQ(1000, result.buffer.startTime());
+    ASSERT_FALSE(fixture.state->reads.empty());
+    EXPECT_EQ(80, fixture.state->reads.front().first);
+
+    fixture.decoder.seek(999999);
+    EXPECT_EQ(AudioDecoder::ReadStatus::EndOfStream, fixture.decoder.readAudio(4096).status);
+}
+
+TEST(CddaDecoderTest, ReportsBackendAndBufferFailures)
+{
+    DecoderFixture fixture;
+    ASSERT_TRUE(fixture.init(0));
+    fixture.state->audioError
+        = CdError{.code = CdDriveError::ReadFailed, .message = u"Synthetic read failure"_s, .platformCode = 5};
+
+    auto result = fixture.decoder.readAudio(4096);
+    EXPECT_EQ(AudioDecoder::ReadStatus::Error, result.status);
+    EXPECT_EQ(u"Synthetic read failure"_s, result.error);
+
+    DecoderFixture invalidBuffer;
+    ASSERT_TRUE(invalidBuffer.init(0));
+    invalidBuffer.state->returnInvalidBuffer = true;
+    result                                   = invalidBuffer.decoder.readAudio(4096);
+    EXPECT_EQ(AudioDecoder::ReadStatus::Error, result.status);
+    EXPECT_TRUE(result.error.isEmpty());
+}
+
+TEST(CddaDecoderTest, AbortInterruptsBlockedSectorRead)
+{
+    using namespace std::chrono_literals;
+
+    DecoderFixture fixture;
+    ASSERT_TRUE(fixture.init(0));
+    fixture.state->blockAudio = true;
+
+    auto pending = std::async(std::launch::async, [&] { return fixture.decoder.readAudio(4096); });
+    bool audioEntered{false};
+    {
+        std::unique_lock lock{fixture.state->mutex};
+        audioEntered = fixture.state->condition.wait_for(lock, 1s, [&] { return fixture.state->audioEntered; });
+    }
+    if(!audioEntered) {
+        fixture.decoder.requestAbort();
+    }
+    ASSERT_TRUE(audioEntered);
+
+    fixture.decoder.requestAbort();
+    ASSERT_EQ(std::future_status::ready, pending.wait_for(1s));
+    const auto result = pending.get();
+    EXPECT_EQ(AudioDecoder::ReadStatus::Error, result.status);
+    EXPECT_EQ(u"Cancelled by test"_s, result.error);
+    EXPECT_EQ(1, fixture.state->cancelCalls);
+}
+
+TEST(CddaDecoderTest, StopReleasesDriveLease)
+{
+    auto state             = std::make_shared<BackendState>();
+    const QString discId   = musicBrainzDiscId(state->toc).value();
+    const QString filepath = cddaUrl(discId);
+    auto manager           = std::make_shared<CdDriveManager>(std::make_unique<FakeBackend>(state));
+
+    CddaDecoder first{manager};
+    CddaDecoder second{manager};
+    ASSERT_TRUE(first.init({.filepath = filepath}, Track{filepath, 0}, AudioDecoder::None));
+    ASSERT_TRUE(second.init({.filepath = filepath}, Track{filepath, 1}, AudioDecoder::None));
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, first.readAudio(4096).status);
+    EXPECT_EQ(AudioDecoder::ReadStatus::Error, second.readAudio(4096).status);
+
+    first.stop();
+    CddaDecoder retry{manager};
+    ASSERT_TRUE(retry.init({.filepath = filepath}, Track{filepath, 1}, AudioDecoder::None));
+    EXPECT_EQ(AudioDecoder::ReadStatus::DecodedAudio, retry.readAudio(4096).status);
+}
+
+TEST(CddaDecoderTest, AppliesDriveSettingsOnlyForConversion)
+{
+    auto state             = std::make_shared<BackendState>();
+    const QString discId   = musicBrainzDiscId(state->toc).value();
+    const QString filepath = cddaUrl(discId);
+    auto manager           = std::make_shared<CdDriveManager>(std::make_unique<FakeBackend>(state));
+    auto settings          = std::make_shared<FakeSettingsProvider>();
+    settings->settings     = {.readOffsetFrames = -10, .security = CdRippingSecurity::Disabled, .readSpeedLimit = 4};
+
+    CddaDecoder playback{manager, settings};
+    ASSERT_TRUE(playback.init({.filepath = filepath}, Track{filepath, 0}, AudioDecoder::None));
+    auto playbackResult = playback.readAudio(80);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, playbackResult.status);
+    EXPECT_EQ(std::byte{2}, playbackResult.buffer.constData().front());
+    EXPECT_TRUE(settings->requests.empty());
+    EXPECT_TRUE(state->readSpeeds.empty());
+    playback.stop();
+
+    state->reads.clear();
+    CddaDecoder conversion{manager, settings};
+    ASSERT_TRUE(conversion.init({.filepath = filepath}, Track{filepath, 0}, AudioDecoder::ForConversion));
+    auto conversionResult = conversion.readAudio(80);
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, conversionResult.status);
+    ASSERT_EQ(80, conversionResult.buffer.byteCount());
+    EXPECT_TRUE(std::ranges::all_of(conversionResult.buffer.constData().first(40),
+                                    [](std::byte value) { return value == std::byte{0}; }));
+    EXPECT_EQ(std::byte{2}, conversionResult.buffer.constData()[40]);
+    ASSERT_EQ(1, settings->requests.size());
+    EXPECT_EQ(u"test-drive"_s, settings->requests.front().settingsKey);
+    EXPECT_EQ((std::vector<int>{4}), state->readSpeeds);
+}
+
+TEST(CddaDecoderTest, PropagatesExtractionWarningsOnce)
+{
+    auto state             = std::make_shared<BackendState>();
+    const QString discId   = musicBrainzDiscId(state->toc).value();
+    const QString filepath = cddaUrl(discId);
+    auto manager           = std::make_shared<CdDriveManager>(std::make_unique<FakeBackend>(state));
+    auto settings          = std::make_shared<FakeSettingsProvider>();
+    settings->settings     = {.readOffsetFrames = -10, .security = CdRippingSecurity::Disabled};
+
+    CddaDecoder decoder{manager, settings};
+    ASSERT_TRUE(decoder.init({.filepath = filepath}, Track{filepath, 0}, AudioDecoder::ForConversion));
+    ASSERT_EQ(AudioDecoder::ReadStatus::DecodedAudio, decoder.readAudio(80).status);
+    const QStringList warnings = decoder.takeWarnings();
+    ASSERT_FALSE(warnings.isEmpty());
+    EXPECT_TRUE(std::ranges::any_of(warnings, [](const QString& warning) { return warning.contains(u"silence"_s); }));
+    EXPECT_TRUE(decoder.takeWarnings().isEmpty());
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddadomaintest.cpp
+++ b/tests/plugins/cdda/cddadomaintest.cpp
@@ -1,0 +1,152 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc tocFromMusicBrainzOffsets(const std::vector<int>& offsets, int leadoutOffset)
+{
+    CdToc toc;
+    toc.firstTrackNumber = 1;
+    toc.lastTrackNumber  = static_cast<int>(offsets.size());
+    toc.leadoutSector    = leadoutOffset - LeadInSectors;
+
+    for(int index{0}; std::cmp_less(index, offsets.size()); ++index) {
+        const int endOffset = std::cmp_less(index + 1, offsets.size()) ? offsets.at(index + 1) : leadoutOffset;
+        toc.tracks.push_back({.number             = index + 1,
+                              .firstSector        = offsets.at(index) - LeadInSectors,
+                              .endSectorExclusive = endOffset - LeadInSectors,
+                              .isAudio            = true});
+    }
+
+    return toc;
+}
+
+CdToc simpleToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 3,
+            .leadoutSector    = 300,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 100, .isAudio = true},
+                                 {.number = 2, .firstSector = 100, .endSectorExclusive = 200, .isAudio = true},
+                                 {.number = 3, .firstSector = 200, .endSectorExclusive = 300, .isAudio = true}}};
+}
+} // namespace
+
+TEST(CddaTocTest, CalculatesPublishedMusicBrainzDiscIdAndToc)
+{
+    const CdToc toc = tocFromMusicBrainzOffsets(
+        {150, 22767, 41887, 58317, 72102, 91375, 104652, 115380, 132165, 143932, 159870, 174597}, 267257);
+
+    const auto discId = musicBrainzDiscId(toc);
+    ASSERT_TRUE(discId.has_value());
+    EXPECT_EQ(u"I5l9cCSFccLKFEKS.7wqSZAorPU-"_s, *discId);
+
+    const auto queryToc = musicBrainzToc(toc);
+    ASSERT_TRUE(queryToc.has_value());
+    EXPECT_EQ(u"1+12+267257+150+22767+41887+58317+72102+91375+104652+115380+132165+143932+159870+174597"_s, *queryToc);
+}
+
+TEST(CddaTocTest, MapsSubsongsAcrossMixedModeTracks)
+{
+    const CdToc toc{
+        .firstTrackNumber = 1,
+        .lastTrackNumber  = 4,
+        .leadoutSector    = 400,
+        .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 100, .isAudio = false},
+                             {.number = 2, .firstSector = 100, .endSectorExclusive = 200, .isAudio = true},
+                             {.number = 3, .firstSector = 200, .endSectorExclusive = 300, .isAudio = false},
+                             {.number = 4, .firstSector = 300, .endSectorExclusive = 400, .isAudio = true}},
+    };
+
+    ASSERT_TRUE(validateToc(toc).has_value());
+    EXPECT_EQ((std::vector<CdTocTrack>{{2, 100, 200, true}, {4, 300, 400, true}}), audioTracks(toc));
+    EXPECT_EQ((CdTocTrack{2, 100, 200, true}), audioTrackForSubsong(toc, 0));
+    EXPECT_EQ((CdTocTrack{4, 300, 400, true}), audioTrackForSubsong(toc, 1));
+    EXPECT_FALSE(audioTrackForSubsong(toc, -1).has_value());
+    EXPECT_FALSE(audioTrackForSubsong(toc, 2).has_value());
+}
+
+TEST(CddaTocTest, RejectsMalformedTocs)
+{
+    CdToc toc            = simpleToc();
+    toc.tracks[1].number = 1;
+    EXPECT_EQ(std::unexpected(CdTocError::InvalidTrackNumbers), validateToc(toc));
+
+    toc                       = simpleToc();
+    toc.tracks[1].firstSector = 101;
+    EXPECT_EQ(std::unexpected(CdTocError::NoncontiguousTrackSectorRanges), validateToc(toc));
+
+    toc               = simpleToc();
+    toc.leadoutSector = 301;
+    EXPECT_EQ(std::unexpected(CdTocError::FinalTrackBeforeLeadout), validateToc(toc));
+
+    toc = simpleToc();
+    for(auto& track : toc.tracks) {
+        track.isAudio = false;
+    }
+    EXPECT_EQ(std::unexpected(CdTocError::NoAudioTracks), validateToc(toc));
+}
+
+TEST(CddaTocTest, ConvertsSectorUnitsAndDetectsOverflow)
+{
+    EXPECT_EQ(588, framesForSectors(1).value());
+    EXPECT_EQ(2352, bytesForSectors(1).value());
+    EXPECT_EQ(1000, durationForSectors(75).value());
+    EXPECT_EQ(13, durationForSectors(1).value());
+
+    EXPECT_FALSE(framesForSectors(std::numeric_limits<uint64_t>::max()).has_value());
+    EXPECT_FALSE(bytesForSectors(std::numeric_limits<uint64_t>::max()).has_value());
+    EXPECT_FALSE(durationForSectors(std::numeric_limits<uint64_t>::max()).has_value());
+}
+
+TEST(CddaUrlTest, RoundTripsCaseSensitiveDiscId)
+{
+    const QString discId = u"I5l9cCSFccLKFEKS.7wqSZAorPU-"_s;
+    const QString path   = cddaUrl(discId);
+    EXPECT_EQ(u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-"_s, path);
+
+    const auto parsed = discIdFromCddaUrl(path);
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(discId, *parsed);
+
+    const auto differentlyCased = discIdFromCddaUrl(path.toLower());
+    ASSERT_TRUE(differentlyCased.has_value());
+    EXPECT_NE(discId, *differentlyCased);
+}
+
+TEST(CddaUrlTest, RejectsMalformedOrNonCanonicalUrls)
+{
+    EXPECT_TRUE(cddaUrl({}).isEmpty());
+    EXPECT_FALSE(discIdFromCddaUrl(u"/music/disc.cdda"_s).has_value());
+    EXPECT_FALSE(discIdFromCddaUrl(u"https://example.com/disc/I5l9cCSFccLKFEKS.7wqSZAorPU-/disc.cdda"_s).has_value());
+    EXPECT_FALSE(discIdFromCddaUrl(u"cdda:///too-short"_s).has_value());
+    EXPECT_FALSE(discIdFromCddaUrl(u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-?track=1"_s).has_value());
+    EXPECT_FALSE(discIdFromCddaUrl(u"cdda:///I5l9cCSFccLKFEKS.7wqSZAorPU-/track"_s).has_value());
+    EXPECT_FALSE(discIdFromCddaUrl(u"cdda://I5l9cCSFccLKFEKS.7wqSZAorPU-"_s).has_value());
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddadrivemanagertest.cpp
+++ b/tests/plugins/cdda/cddadrivemanagertest.cpp
@@ -1,0 +1,471 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddadrivemanager.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <barrier>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <thread>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc makeToc(int secondTrackStart = 100, int leadout = 200)
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 2,
+            .leadoutSector    = leadout,
+            .tracks = {{.number = 1, .firstSector = 0, .endSectorExclusive = secondTrackStart, .isAudio = true},
+                       {.number = 2, .firstSector = secondTrackStart, .endSectorExclusive = leadout, .isAudio = true}}};
+}
+
+struct FakeDriveState
+{
+    CdDriveInfo info;
+    CdToc toc;
+    CdText cdText;
+    std::optional<CdError> error;
+    int openCalls{0};
+    int tocCalls{0};
+    int cdTextCalls{0};
+    std::function<void()> sessionDestroyed;
+    std::function<void()> tocReadStarted;
+};
+
+class FakeSession : public CdDriveSession
+{
+public:
+    explicit FakeSession(std::shared_ptr<FakeDriveState> state)
+        : m_state{std::move(state)}
+    { }
+
+    ~FakeSession() override
+    {
+        if(m_state->sessionDestroyed) {
+            m_state->sessionDestroyed();
+        }
+    }
+
+    std::expected<CdToc, CdError> readToc() override
+    {
+        if(m_state->tocReadStarted) {
+            m_state->tocReadStarted();
+        }
+        ++m_state->tocCalls;
+        if(m_state->error) {
+            return std::unexpected(*m_state->error);
+        }
+        return m_state->toc;
+    }
+
+    CdText readCdText(const CdToc& /*toc*/) override
+    {
+        ++m_state->cdTextCalls;
+        return m_state->cdText;
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectors(int /*firstSector*/, int count) override
+    {
+        return CdSectorRead{.pcm = QByteArray(count * BytesPerSector, '\0'), .sectorsRead = count};
+    }
+
+    void cancel() override { }
+
+private:
+    std::shared_ptr<FakeDriveState> m_state;
+};
+
+class FakeBackend : public CdDriveBackend
+{
+public:
+    FakeDriveState& addDrive(const QString& id, const CdToc& toc)
+    {
+        auto state          = std::make_shared<FakeDriveState>();
+        state->info         = {.id                 = id,
+                               .displayName        = id,
+                               .settingsKey        = id,
+                               .supportsSpeedLimit = false,
+                               .vendor             = {},
+                               .model              = {},
+                               .revision           = {}};
+        state->toc          = toc;
+        FakeDriveState* ptr = state.get();
+        m_drives.emplace(id, state);
+        return *ptr;
+    }
+
+    std::vector<CdDriveInfo> drives() override
+    {
+        std::vector<CdDriveInfo> result;
+        for(const auto& [id, state] : std::as_const(m_drives)) {
+            Q_UNUSED(id);
+            result.push_back(state->info);
+        }
+        std::ranges::sort(result, {}, &CdDriveInfo::id);
+        return result;
+    }
+
+    std::expected<OpenedDrive, CdError> open(const QString& driveId) override
+    {
+        const auto it = m_drives.find(driveId);
+        if(it == m_drives.end()) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Unsupported, .message = u"Missing drive"_s, .platformCode = 0});
+        }
+        ++it->second->openCalls;
+        return OpenedDrive{.drive = it->second->info, .session = std::make_unique<FakeSession>(it->second)};
+    }
+
+private:
+    std::map<QString, std::shared_ptr<FakeDriveState>> m_drives;
+};
+
+struct ManagerFixture
+{
+    ManagerFixture()
+    {
+        auto ownedBackend = std::make_unique<FakeBackend>();
+        backend           = ownedBackend.get();
+        manager           = std::make_unique<CdDriveManager>(std::move(ownedBackend), std::chrono::hours{1});
+    }
+
+    FakeBackend* backend{nullptr};
+    std::unique_ptr<CdDriveManager> manager;
+};
+} // namespace
+
+TEST(CdDriveManagerTest, ObservesDiscsErrorsAndStableMediaGenerations)
+{
+    ManagerFixture fixture;
+    auto& ready             = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    ready.cdText.disc.title = u"Album title"_s;
+    auto& empty             = fixture.backend->addDrive(u"drive-b"_s, makeToc());
+    empty.error             = CdError{.code = CdDriveError::NoMedia, .message = u"No disc"_s, .platformCode = 0};
+
+    const auto first = fixture.manager->observations(true);
+    ASSERT_EQ(2, first.size());
+    const auto readyIt = std::ranges::find(first, u"drive-a"_s, [](const auto& item) { return item.drive.id; });
+    ASSERT_NE(first.end(), readyIt);
+    EXPECT_TRUE(readyIt->toc.has_value());
+    EXPECT_TRUE(isValidDiscId(readyIt->discId));
+    EXPECT_FALSE(readyIt->cdText.has_value());
+    EXPECT_EQ(0, ready.cdTextCalls);
+
+    const uint64_t generation = readyIt->generation;
+
+    const auto cdText = fixture.manager->readCdText(*readyIt);
+    ASSERT_TRUE(cdText.has_value());
+    EXPECT_EQ(u"Album title"_s, cdText->disc.title);
+    EXPECT_EQ(1, ready.cdTextCalls);
+
+    const auto unchanged   = fixture.manager->observations(true);
+    const auto unchangedIt = std::ranges::find(unchanged, u"drive-a"_s, [](const auto& item) { return item.drive.id; });
+    ASSERT_NE(unchanged.end(), unchangedIt);
+    EXPECT_EQ(generation, unchangedIt->generation);
+    ASSERT_TRUE(unchangedIt->cdText.has_value());
+    EXPECT_EQ(u"Album title"_s, unchangedIt->cdText->disc.title);
+    EXPECT_EQ(1, ready.cdTextCalls);
+
+    ready.toc            = makeToc(120, 240);
+    const auto changed   = fixture.manager->observations(true);
+    const auto changedIt = std::ranges::find(changed, u"drive-a"_s, [](const auto& item) { return item.drive.id; });
+    ASSERT_NE(changed.end(), changedIt);
+    EXPECT_NE(generation, changedIt->generation);
+    EXPECT_FALSE(changedIt->cdText.has_value());
+}
+
+TEST(CdDriveManagerTest, EnumeratesWithoutOpeningDrivesAndInspectsOnlyTheSelection)
+{
+    ManagerFixture fixture;
+    auto& first  = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    auto& second = fixture.backend->addDrive(u"drive-b"_s, makeToc(120, 240));
+
+    const std::vector<CdDriveInfo> drives = fixture.manager->drives();
+    ASSERT_EQ(2, drives.size());
+    EXPECT_EQ(0, first.openCalls);
+    EXPECT_EQ(0, second.openCalls);
+
+    const CdDriveObservation observation = fixture.manager->observeDrive(drives.front());
+    EXPECT_EQ(u"drive-a"_s, observation.drive.id);
+    EXPECT_TRUE(observation.toc.has_value());
+    EXPECT_GT(observation.generation, 0U);
+    EXPECT_EQ(1, first.openCalls);
+    EXPECT_EQ(0, second.openCalls);
+}
+
+TEST(CdDriveManagerTest, UsesShortCacheAndInvalidationRefreshesTheCompleteDriveSet)
+{
+    ManagerFixture fixture;
+    auto& first  = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    auto& second = fixture.backend->addDrive(u"drive-b"_s, makeToc(120, 240));
+
+    ASSERT_EQ(2, fixture.manager->observations().size());
+    EXPECT_EQ(1, first.openCalls);
+    EXPECT_EQ(1, second.openCalls);
+
+    ASSERT_EQ(2, fixture.manager->observations().size());
+    EXPECT_EQ(1, first.openCalls);
+    EXPECT_EQ(1, second.openCalls);
+
+    fixture.manager->invalidateDrive(u"drive-a"_s);
+    ASSERT_EQ(2, fixture.manager->observations().size());
+    EXPECT_EQ(2, first.openCalls);
+    EXPECT_EQ(2, second.openCalls);
+}
+
+TEST(CdDriveManagerTest, ResolvesPreferredDriveAndFallsBackToAnotherMatchingDrive)
+{
+    ManagerFixture fixture;
+    const CdToc toc = makeToc();
+    fixture.backend->addDrive(u"drive-a"_s, toc);
+    auto& second         = fixture.backend->addDrive(u"drive-b"_s, toc);
+    const QString discId = musicBrainzDiscId(toc).value();
+
+    fixture.manager->setPreferredDrive(discId, u"drive-b"_s);
+    auto resolved = fixture.manager->resolveDisc(discId, true);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(u"drive-b"_s, resolved->drive.id);
+
+    second.error = CdError{.code = CdDriveError::NoMedia, .message = u"Removed"_s, .platformCode = 0};
+    resolved     = fixture.manager->resolveDisc(discId, true);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(u"drive-a"_s, resolved->drive.id);
+}
+
+TEST(CdDriveManagerTest, ResolvesKnownDiscWithoutReprobingAfterDiscoveryCacheExpires)
+{
+    auto ownedBackend = std::make_unique<FakeBackend>();
+    auto* backend     = ownedBackend.get();
+    auto& drive       = backend->addDrive(u"drive-a"_s, makeToc());
+    CdDriveManager manager{std::move(ownedBackend), std::chrono::milliseconds{0}};
+
+    const auto observed = manager.observations(true);
+    ASSERT_EQ(1, observed.size());
+    ASSERT_FALSE(observed.front().discId.isEmpty());
+    EXPECT_EQ(1, drive.openCalls);
+
+    const auto resolved = manager.resolveDisc(observed.front().discId);
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(u"drive-a"_s, resolved->drive.id);
+    EXPECT_EQ(1, drive.openCalls);
+}
+
+TEST(CdDriveManagerTest, LeaseIsExclusiveAndReleasesWithRaii)
+{
+    ManagerFixture fixture;
+    const CdToc toc = makeToc();
+    fixture.backend->addDrive(u"drive-a"_s, toc);
+    const QString discId = musicBrainzDiscId(toc).value();
+
+    {
+        auto lease = fixture.manager->acquire(discId);
+        ASSERT_TRUE(lease.has_value()) << lease.error().message.toStdString();
+        EXPECT_TRUE(static_cast<bool>(*lease));
+        EXPECT_NE(nullptr, lease->session());
+        EXPECT_EQ(discId, lease->discId());
+
+        const auto busy = fixture.manager->acquire(discId);
+        ASSERT_FALSE(busy.has_value());
+        EXPECT_EQ(CdDriveError::DriveBusy, busy.error().code);
+    }
+
+    EXPECT_TRUE(fixture.manager->acquire(discId).has_value());
+}
+
+TEST(CdDriveManagerTest, LeaseBlocksObservationCdTextAndRefreshWithoutDiscardingCache)
+{
+    ManagerFixture fixture;
+    auto& leasedDrive             = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    leasedDrive.cdText.disc.title = u"Cached title"_s;
+    auto& otherDrive              = fixture.backend->addDrive(u"drive-b"_s, makeToc(120, 240));
+
+    const auto observed = fixture.manager->observations(true);
+    const auto leasedObservation
+        = std::ranges::find(observed, u"drive-a"_s, [](const auto& item) { return item.drive.id; });
+    ASSERT_NE(observed.end(), leasedObservation);
+
+    const auto cdText = fixture.manager->readCdText(*leasedObservation);
+    ASSERT_TRUE(cdText.has_value());
+    const uint64_t generation = leasedObservation->generation;
+
+    auto lease = fixture.manager->acquire(leasedObservation->discId);
+    ASSERT_TRUE(lease.has_value()) << lease.error().message.toStdString();
+    const int leasedOpenCalls = leasedDrive.openCalls;
+    const int otherOpenCalls  = otherDrive.openCalls;
+
+    const auto busyObservation = fixture.manager->observeDrive(leasedObservation->drive);
+    ASSERT_TRUE(busyObservation.error.has_value());
+    EXPECT_EQ(CdDriveError::DriveBusy, busyObservation.error->code);
+    EXPECT_EQ(leasedOpenCalls, leasedDrive.openCalls);
+
+    const auto busyCdText = fixture.manager->readCdText(*leasedObservation);
+    ASSERT_FALSE(busyCdText.has_value());
+    EXPECT_EQ(CdDriveError::DriveBusy, busyCdText.error().code);
+    EXPECT_EQ(leasedOpenCalls, leasedDrive.openCalls);
+
+    const auto refreshed = fixture.manager->observations(true);
+    const auto refreshedLeased
+        = std::ranges::find(refreshed, u"drive-a"_s, [](const auto& item) { return item.drive.id; });
+    ASSERT_NE(refreshed.end(), refreshedLeased);
+    EXPECT_EQ(generation, refreshedLeased->generation);
+    ASSERT_TRUE(refreshedLeased->cdText.has_value());
+    EXPECT_EQ(u"Cached title"_s, refreshedLeased->cdText->disc.title);
+    EXPECT_EQ(leasedOpenCalls, leasedDrive.openCalls);
+    EXPECT_EQ(otherOpenCalls + 1, otherDrive.openCalls);
+}
+
+TEST(CdDriveManagerTest, SessionIsDestroyedBeforeLeaseReservationIsReleased)
+{
+    ManagerFixture fixture;
+    auto& drive          = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    const QString discId = musicBrainzDiscId(drive.toc).value();
+
+    auto acquired = fixture.manager->acquire(discId);
+    ASSERT_TRUE(acquired.has_value()) << acquired.error().message.toStdString();
+    std::optional<CdDriveLease> lease{std::move(*acquired)};
+
+    std::optional<CdError> destructionAcquireError;
+    drive.sessionDestroyed = [&] {
+        auto duringDestruction = fixture.manager->acquire(discId);
+        if(!duringDestruction) {
+            destructionAcquireError = duringDestruction.error();
+        }
+    };
+
+    lease.reset();
+    drive.sessionDestroyed = {};
+
+    ASSERT_TRUE(destructionAcquireError.has_value());
+    EXPECT_EQ(CdDriveError::DriveBusy, destructionAcquireError->code);
+    EXPECT_TRUE(fixture.manager->acquire(discId).has_value());
+}
+
+TEST(CdDriveManagerTest, ConcurrentAcquisitionCreatesOnlyOneLeasePerDrive)
+{
+    ManagerFixture fixture;
+    const CdToc toc = makeToc();
+    fixture.backend->addDrive(u"drive-a"_s, toc);
+    const QString discId = musicBrainzDiscId(toc).value();
+    ASSERT_TRUE(fixture.manager->resolveDisc(discId, true).has_value());
+
+    std::barrier start{3};
+    std::barrier acquired{3};
+    std::atomic_int successes{0};
+    std::atomic_int busyFailures{0};
+
+    auto acquire = [&] {
+        start.arrive_and_wait();
+        auto lease = fixture.manager->acquire(discId);
+        if(lease) {
+            ++successes;
+        }
+        else if(lease.error().code == CdDriveError::DriveBusy) {
+            ++busyFailures;
+        }
+        acquired.arrive_and_wait();
+    };
+
+    std::jthread first{acquire};
+    std::jthread second{acquire};
+    start.arrive_and_wait();
+    acquired.arrive_and_wait();
+
+    EXPECT_EQ(1, successes.load());
+    EXPECT_EQ(1, busyFailures.load());
+}
+
+TEST(CdDriveManagerTest, DifferentDrivesCanBeInspectedConcurrently)
+{
+    ManagerFixture fixture;
+    auto& firstDrive                      = fixture.backend->addDrive(u"drive-a"_s, makeToc());
+    auto& secondDrive                     = fixture.backend->addDrive(u"drive-b"_s, makeToc(120, 240));
+    const std::vector<CdDriveInfo> drives = fixture.manager->drives();
+    ASSERT_EQ(2, drives.size());
+
+    std::barrier readsStarted{3};
+    firstDrive.tocReadStarted = [&] {
+        readsStarted.arrive_and_wait();
+    };
+    secondDrive.tocReadStarted = [&] {
+        readsStarted.arrive_and_wait();
+    };
+
+    std::jthread first{[&] { [[maybe_unused]] const auto observed = fixture.manager->observeDrive(drives.at(0)); }};
+    std::jthread second{[&] { [[maybe_unused]] const auto observed = fixture.manager->observeDrive(drives.at(1)); }};
+    readsStarted.arrive_and_wait();
+}
+
+TEST(CdDriveManagerTest, LeaseCanOutliveManager)
+{
+    std::optional<CdDriveLease> lease;
+    {
+        ManagerFixture fixture;
+        const CdToc toc = makeToc();
+        fixture.backend->addDrive(u"drive-a"_s, toc);
+
+        auto acquired = fixture.manager->acquire(musicBrainzDiscId(toc).value());
+        ASSERT_TRUE(acquired.has_value()) << acquired.error().message.toStdString();
+        lease.emplace(std::move(*acquired));
+    }
+
+    EXPECT_TRUE(static_cast<bool>(*lease));
+    lease.reset();
+}
+
+TEST(CdDriveManagerTest, AcquireRevalidatesMediaAfterResolution)
+{
+    ManagerFixture fixture;
+    const CdToc original = makeToc();
+    auto& drive          = fixture.backend->addDrive(u"drive-a"_s, original);
+    const QString discId = musicBrainzDiscId(original).value();
+
+    ASSERT_TRUE(fixture.manager->resolveDisc(discId, true).has_value());
+    drive.toc = makeToc(140, 260);
+
+    const auto lease = fixture.manager->acquire(discId);
+    ASSERT_FALSE(lease.has_value());
+    EXPECT_EQ(CdDriveError::MediaChanged, lease.error().code);
+}
+
+TEST(CdDriveManagerTest, AcquireFallsBackWhenPreferredDriveLosesTheDisc)
+{
+    ManagerFixture fixture;
+    const CdToc toc = makeToc();
+    fixture.backend->addDrive(u"drive-a"_s, toc);
+    auto& preferred      = fixture.backend->addDrive(u"drive-b"_s, toc);
+    const QString discId = musicBrainzDiscId(toc).value();
+
+    fixture.manager->setPreferredDrive(discId, u"drive-b"_s);
+    ASSERT_EQ(u"drive-b"_s, fixture.manager->resolveDisc(discId, true)->drive.id);
+    preferred.error = CdError{.code = CdDriveError::NoMedia, .message = u"Removed"_s, .platformCode = 0};
+
+    auto lease = fixture.manager->acquire(discId);
+    ASSERT_TRUE(lease.has_value()) << lease.error().message.toStdString();
+    EXPECT_EQ(u"drive-a"_s, lease->drive().id);
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddareadertest.cpp
+++ b/tests/plugins/cdda/cddareadertest.cpp
@@ -1,0 +1,265 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddareader.h"
+
+#include "cddatoc.h"
+#include "cddaurl.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc mixedModeToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 4,
+            .leadoutSector    = 450,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 75, .isAudio = false},
+                                 {.number = 2, .firstSector = 75, .endSectorExclusive = 150, .isAudio = true},
+                                 {.number = 3, .firstSector = 150, .endSectorExclusive = 300, .isAudio = false},
+                                 {.number = 4, .firstSector = 300, .endSectorExclusive = 450, .isAudio = true}}};
+}
+
+struct BackendState
+{
+    CdToc toc{mixedModeToc()};
+    CdText cdText;
+    std::optional<CdError> error;
+    int openCalls{0};
+    int tocCalls{0};
+};
+
+class FakeSession : public CdDriveSession
+{
+public:
+    explicit FakeSession(std::shared_ptr<BackendState> state)
+        : m_state{std::move(state)}
+    { }
+
+    std::expected<CdToc, CdError> readToc() override
+    {
+        ++m_state->tocCalls;
+        if(m_state->error) {
+            return std::unexpected(*m_state->error);
+        }
+        return m_state->toc;
+    }
+
+    CdText readCdText(const CdToc& /*toc*/) override
+    {
+        return m_state->cdText;
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectors(int /*firstSector*/, int count) override
+    {
+        return CdSectorRead{.pcm = QByteArray(count * BytesPerSector, '\0'), .sectorsRead = count};
+    }
+
+    void cancel() override { }
+
+private:
+    std::shared_ptr<BackendState> m_state;
+};
+
+class FakeBackend : public CdDriveBackend
+{
+public:
+    explicit FakeBackend(std::shared_ptr<BackendState> state)
+        : m_state{std::move(state)}
+    { }
+
+    std::vector<CdDriveInfo> drives() override
+    {
+        return {{.id                 = u"drive-a"_s,
+                 .displayName        = u"Test drive"_s,
+                 .settingsKey        = u"test-drive"_s,
+                 .supportsSpeedLimit = false,
+                 .vendor             = {},
+                 .model              = {},
+                 .revision           = {}}};
+    }
+
+    std::expected<OpenedDrive, CdError> open(const QString& driveId) override
+    {
+        if(driveId != u"drive-a"_s) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Unsupported, .message = u"Unknown drive"_s, .platformCode = 0});
+        }
+        ++m_state->openCalls;
+        return OpenedDrive{.drive = drives().front(), .session = std::make_unique<FakeSession>(m_state)};
+    }
+
+private:
+    std::shared_ptr<BackendState> m_state;
+};
+
+struct ReaderFixture
+{
+    ReaderFixture()
+        : state{std::make_shared<BackendState>()}
+        , discId{musicBrainzDiscId(state->toc).value()}
+        , filepath{cddaUrl(discId)}
+        , manager{std::make_shared<CdDriveManager>(std::make_unique<FakeBackend>(state))}
+        , reader{manager}
+    { }
+
+    std::shared_ptr<BackendState> state;
+    QString discId;
+    QString filepath;
+    std::shared_ptr<CdDriveManager> manager;
+    CddaReader reader;
+};
+} // namespace
+
+TEST(CddaReaderTest, AdvertisesOnlyCddaSchemeAndNoWriteCapabilities)
+{
+    const ReaderFixture fixture;
+
+    EXPECT_TRUE(fixture.reader.extensions().isEmpty());
+    EXPECT_EQ((QStringList{u"cdda"_s}), fixture.reader.supportedSchemes());
+    EXPECT_FALSE(fixture.reader.canReadCover());
+    EXPECT_FALSE(fixture.reader.canWriteCover());
+    EXPECT_FALSE(fixture.reader.canWriteMetaData());
+    EXPECT_EQ(0, fixture.reader.subsongCount());
+}
+
+TEST(CddaReaderTest, MapsSubsongsAcrossMixedModePhysicalTracks)
+{
+    ReaderFixture fixture;
+    const AudioSource source{.filepath = fixture.filepath};
+    ASSERT_TRUE(fixture.reader.init(source)) << fixture.reader.lastError().toStdString();
+    EXPECT_EQ(2, fixture.reader.subsongCount());
+    EXPECT_EQ(1, fixture.state->openCalls);
+    EXPECT_EQ(1, fixture.state->tocCalls);
+
+    Track first{fixture.filepath, 0};
+    ASSERT_TRUE(fixture.reader.readTrack(source, first)) << fixture.reader.lastError().toStdString();
+    EXPECT_EQ(u"Track 02"_s, first.title());
+    EXPECT_EQ(u"Audio CD"_s, first.album());
+    EXPECT_EQ(u"2"_s, first.trackNumber());
+    EXPECT_EQ(u"2"_s, first.trackTotal());
+    EXPECT_EQ(1000, first.duration());
+
+    Track second{fixture.filepath, 1};
+    ASSERT_TRUE(fixture.reader.readTrack(source, second)) << fixture.reader.lastError().toStdString();
+    EXPECT_EQ(u"Track 04"_s, second.title());
+    EXPECT_EQ(u"4"_s, second.trackNumber());
+    EXPECT_EQ(2000, second.duration());
+    EXPECT_EQ(44100, second.sampleRate());
+    EXPECT_EQ(2, second.channels());
+    EXPECT_EQ(16, second.bitDepth());
+    EXPECT_EQ(1411, second.bitrate());
+    EXPECT_EQ(u"CDDA"_s, second.codec());
+    EXPECT_EQ(u"Lossless"_s, second.encoding());
+    const auto properties = second.extraProperties();
+    EXPECT_EQ(fixture.discId, properties.value(u"_CDDA_DISC_ID"_s));
+    EXPECT_EQ(u"4"_s, properties.value(u"_CDDA_TRACK_NUMBER"_s));
+
+    // Reading metadata doesn't takes a drive lease or read audio sectors
+    EXPECT_EQ(1, fixture.state->openCalls);
+}
+
+TEST(CddaReaderTest, AppliesCdTextBeforeGenericFallbacks)
+{
+    ReaderFixture fixture;
+    fixture.state->cdText.disc = {.title     = u"Disc title"_s,
+                                  .performer = u"Album artist"_s,
+                                  .genre     = u"Disc genre"_s,
+                                  .composer  = u"Disc composer"_s,
+                                  .message   = u"Disc message"_s,
+                                  .isrc      = {}};
+    fixture.state->cdText.tracks.emplace(2, CdTextFields{.title     = u"Track title"_s,
+                                                         .performer = u"Track artist"_s,
+                                                         .genre     = {},
+                                                         .composer  = u"Track composer"_s,
+                                                         .message   = u"Track message"_s,
+                                                         .isrc      = u"GBTEST0000001"_s});
+
+    const auto observations = fixture.manager->observations(true);
+    ASSERT_EQ(1, observations.size());
+    ASSERT_TRUE(fixture.manager->readCdText(observations.front()).has_value());
+
+    const AudioSource source{.filepath = fixture.filepath};
+    ASSERT_TRUE(fixture.reader.init(source)) << fixture.reader.lastError().toStdString();
+
+    Track first{fixture.filepath, 0};
+    ASSERT_TRUE(fixture.reader.readTrack(source, first));
+    EXPECT_EQ(u"Track title"_s, first.title());
+    EXPECT_EQ(u"Disc title"_s, first.album());
+    EXPECT_EQ((QStringList{u"Track artist"_s}), first.artists());
+    EXPECT_EQ((QStringList{u"Album artist"_s}), first.albumArtists());
+    EXPECT_EQ((QStringList{u"Disc genre"_s}), first.genres());
+    EXPECT_EQ((QStringList{u"Track composer"_s}), first.composers());
+    EXPECT_EQ(u"Track message"_s, first.comment());
+    EXPECT_EQ((QStringList{u"GBTEST0000001"_s}), first.extraTag(u"ISRC"_s));
+
+    Track second{fixture.filepath, 1};
+    ASSERT_TRUE(fixture.reader.readTrack(source, second));
+    EXPECT_EQ(u"Track 04"_s, second.title());
+    EXPECT_EQ((QStringList{u"Album artist"_s}), second.artists());
+    EXPECT_EQ((QStringList{u"Disc composer"_s}), second.composers());
+    EXPECT_EQ(u"Disc message"_s, second.comment());
+}
+
+TEST(CddaReaderTest, KeepsExistingFallbackFields)
+{
+    ReaderFixture fixture;
+    const AudioSource source{.filepath = fixture.filepath};
+    ASSERT_TRUE(fixture.reader.init(source));
+
+    Track track{fixture.filepath, 0};
+    track.setTitle(u"Known title"_s);
+    track.setAlbum(u"Known album"_s);
+    track.setTrackNumber(u"A1"_s);
+    track.setTrackTotal(u"9"_s);
+    ASSERT_TRUE(fixture.reader.readTrack(source, track));
+
+    EXPECT_EQ(u"Known title"_s, track.title());
+    EXPECT_EQ(u"Known album"_s, track.album());
+    EXPECT_EQ(u"A1"_s, track.trackNumber());
+    EXPECT_EQ(u"9"_s, track.trackTotal());
+    EXPECT_EQ(1000, track.duration());
+}
+
+TEST(CddaReaderTest, RejectsMissingMediaAndOutOfRangeSubsongs)
+{
+    ReaderFixture fixture;
+    EXPECT_FALSE(fixture.reader.init({.filepath = u"cdda:///invalid"_s}));
+    EXPECT_FALSE(fixture.reader.lastError().isEmpty());
+
+    fixture.state->error = CdError{.code = CdDriveError::NoMedia, .message = u"No disc"_s, .platformCode = 0};
+    fixture.manager->invalidateAll();
+    EXPECT_FALSE(fixture.reader.init({.filepath = fixture.filepath}));
+    EXPECT_TRUE(fixture.reader.lastError().contains(u"not inserted"_s));
+
+    fixture.state->error.reset();
+    fixture.manager->invalidateAll();
+    const AudioSource source{.filepath = fixture.filepath};
+    ASSERT_TRUE(fixture.reader.init(source));
+
+    Track invalidSubsong{fixture.filepath, 2};
+    EXPECT_FALSE(fixture.reader.readTrack(source, invalidSubsong));
+    Track wrongSource{u"cdda:///AAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s, 0};
+    EXPECT_FALSE(fixture.reader.readTrack(source, wrongSource));
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddasectorreadertest.cpp
+++ b/tests/plugins/cdda/cddasectorreadertest.cpp
@@ -1,0 +1,381 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cddasectorreader.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <expected>
+#include <functional>
+#include <stop_token>
+#include <vector>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+QByteArray sector(char value)
+{
+    return {BytesPerSector, value};
+}
+
+QByteArray sectors(std::initializer_list<char> values)
+{
+    QByteArray pcm;
+    pcm.reserve(static_cast<qsizetype>(values.size()) * BytesPerSector);
+    for(const char value : values) {
+        pcm.append(sector(value));
+    }
+    return pcm;
+}
+
+class FakeSession : public CdDriveSession
+{
+public:
+    using ReadHandler = std::function<std::expected<CdSectorRead, CdError>(int, int, int)>;
+
+    explicit FakeSession(ReadHandler handler)
+        : m_handler{std::move(handler)}
+    { }
+
+    std::expected<CdToc, CdError> readToc() override
+    {
+        return std::unexpected(CdError{
+            .code = CdDriveError::Unsupported, .message = u"Not used by sector reader tests"_s, .platformCode = 0});
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count) override
+    {
+        requests.emplace_back(firstSector, count);
+        policies.push_back(CdRippingSecurity::Disabled);
+        return m_handler(firstSector, count, requests.size() - 1);
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectorsSecure(int firstSector, int count,
+                                                                CdRippingSecurity security) override
+    {
+        requests.emplace_back(firstSector, count);
+        policies.push_back(security);
+        return m_handler(firstSector, count, requests.size() - 1);
+    }
+
+    void cancel() override
+    {
+        ++cancelCalls;
+    }
+
+    QStringList takeWarnings() override
+    {
+        return std::exchange(warnings, {});
+    }
+
+    std::vector<std::pair<int, int>> requests;
+    std::vector<CdRippingSecurity> policies;
+    QStringList warnings;
+    int cancelCalls{0};
+
+private:
+    ReadHandler m_handler;
+};
+
+CdSectorRead patternedRead(int firstSector, int count)
+{
+    QByteArray pcm;
+    pcm.reserve(static_cast<qsizetype>(count) * BytesPerSector);
+    for(int current = firstSector; current < firstSector + count; ++current) {
+        pcm.append(sector(static_cast<char>(current)));
+    }
+    return {.pcm = std::move(pcm), .sectorsRead = count};
+}
+
+CdToc mixedModeToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 5,
+            .leadoutSector    = 10,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 2, .isAudio = false},
+                                 {.number = 2, .firstSector = 2, .endSectorExclusive = 4, .isAudio = true},
+                                 {.number = 3, .firstSector = 4, .endSectorExclusive = 6, .isAudio = true},
+                                 {.number = 4, .firstSector = 6, .endSectorExclusive = 8, .isAudio = false},
+                                 {.number = 5, .firstSector = 8, .endSectorExclusive = 10, .isAudio = true}}};
+}
+
+CdToc audioOnlyToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 1,
+            .leadoutSector    = 2,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 2, .isAudio = true}}};
+}
+
+CdSectorRead indexedRead(int firstSector, int count)
+{
+    QByteArray pcm(static_cast<qsizetype>(count) * BytesPerSector, Qt::Uninitialized);
+    for(int sectorIndex{0}; sectorIndex < count; ++sectorIndex) {
+        for(int frame{0}; frame < FramesPerSector; ++frame) {
+            const int32_t value = ((firstSector + sectorIndex) * FramesPerSector) + frame;
+            const qsizetype byteOffset
+                = ((static_cast<qsizetype>(sectorIndex) * FramesPerSector) + frame) * sizeof(value);
+            std::memcpy(pcm.data() + byteOffset, &value, sizeof(value));
+        }
+    }
+    return {.pcm = std::move(pcm), .sectorsRead = count};
+}
+
+std::vector<int32_t> frameValues(const QByteArray& pcm)
+{
+    std::vector<int32_t> result(static_cast<size_t>(pcm.size() / static_cast<qsizetype>(sizeof(int32_t))));
+    std::memcpy(result.data(), pcm.constData(), static_cast<size_t>(pcm.size()));
+    return result;
+}
+} // namespace
+
+TEST(CddaSectorReaderTest, DisabledModeCompletesPartialBackendReadsWithoutUnboundedRequests)
+{
+    auto session = std::make_unique<FakeSession>([](int firstSector, int /*count*/, int /*request*/) {
+        return std::expected<CdSectorRead, CdError>{patternedRead(firstSector, 1)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto result = reader.readAudioSectors(10, 3);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(3, result->sectorsRead);
+    EXPECT_EQ(sectors({10, 11, 12}), result->pcm);
+    EXPECT_EQ((std::vector<std::pair<int, int>>{{10, 3}, {11, 2}, {12, 1}}), session->requests);
+    EXPECT_TRUE(reader.takeWarnings().empty());
+}
+
+TEST(CddaSectorReaderTest, RejectsInvalidAndUnboundedRequestsBeforeCallingBackend)
+{
+    auto session = std::make_unique<FakeSession>(
+        [](int, int, int) { return std::expected<CdSectorRead, CdError>{CdSectorRead{}}; });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto negativeSector = reader.readAudioSectors(-1, 1);
+    ASSERT_FALSE(negativeSector.has_value());
+    EXPECT_EQ(CdDriveError::ReadFailed, negativeSector.error().code);
+    EXPECT_TRUE(negativeSector.error().message.isEmpty());
+
+    const auto unbounded = reader.readAudioSectors(0, MaximumSectorsPerPolicyRead + 1);
+    ASSERT_FALSE(unbounded.has_value());
+    EXPECT_EQ(CdDriveError::ReadFailed, unbounded.error().code);
+    EXPECT_TRUE(unbounded.error().message.isEmpty());
+    EXPECT_TRUE(reader.readAudioSectors(0, 0).has_value());
+    EXPECT_TRUE(session->requests.empty());
+}
+
+TEST(CddaSectorReaderTest, DelegatesSecurityPolicyAndWarningsToBackend)
+{
+    auto session = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{patternedRead(firstSector, count)};
+    });
+
+    for(const CdRippingSecurity security :
+        {CdRippingSecurity::Disabled, CdRippingSecurity::Standard, CdRippingSecurity::Paranoid}) {
+        CddaSectorReader reader{session.get(), security};
+        session->warnings.push_back(u"Recovery diagnostic"_s);
+
+        const auto result = reader.readAudioSectors(10, 3);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(patternedRead(10, 3).pcm, result->pcm);
+        EXPECT_EQ(security, session->policies.back());
+        EXPECT_EQ((QStringList{u"Recovery diagnostic"_s}), reader.takeWarnings());
+        EXPECT_TRUE(reader.takeWarnings().empty());
+    }
+}
+
+TEST(CddaSectorReaderTest, PropagatesBackendPolicyFailureWithoutRetrying)
+{
+    auto session = std::make_unique<FakeSession>([](int, int, int) -> std::expected<CdSectorRead, CdError> {
+        return std::unexpected(
+            CdError{.code = CdDriveError::ReadFailed, .message = u"Secure reader failed"_s, .platformCode = 5});
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Paranoid};
+
+    const auto result = reader.readAudioSectors(20, 4);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(CdDriveError::ReadFailed, result.error().code);
+    EXPECT_EQ(1, session->requests.size());
+    EXPECT_EQ(CdRippingSecurity::Paranoid, session->policies.front());
+}
+
+TEST(CddaSectorReaderTest, CancellationIsObservedBetweenBackendRequests)
+{
+    std::stop_source cancel;
+    auto session = std::make_unique<FakeSession>([&cancel](int firstSector, int count, int) {
+        cancel.request_stop();
+        return std::expected<CdSectorRead, CdError>{patternedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Paranoid, cancel.get_token()};
+
+    const auto result = reader.readAudioSectors(0, 4);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(CdDriveError::Cancelled, result.error().code);
+    EXPECT_EQ(1, session->requests.size());
+}
+
+TEST(CddaSectorReaderTest, CorrectedReadPreservesRequestedFrameCount)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(1), 100, 700, 0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(700, result->framesRead);
+    EXPECT_EQ(700 * static_cast<int>(sizeof(int32_t)), result->pcm.size());
+
+    const auto values = frameValues(result->pcm);
+    ASSERT_EQ(700, values.size());
+    EXPECT_EQ((2 * FramesPerSector) + 100, values.front());
+    EXPECT_EQ((2 * FramesPerSector) + 799, values.back());
+    EXPECT_TRUE(reader.takeWarnings().empty());
+}
+
+TEST(CddaSectorReaderTest, PositiveOffsetReadsLaterFramesAcrossAdjacentAudioTrack)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+    const int trackFrames = 2 * FramesPerSector;
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(1), trackFrames - 5, 5, 10);
+    ASSERT_TRUE(result.has_value());
+
+    const auto values = frameValues(result->pcm);
+    ASSERT_EQ(5, values.size());
+    EXPECT_EQ((4 * FramesPerSector) + 5, values.front());
+    EXPECT_EQ((4 * FramesPerSector) + 9, values.back());
+    EXPECT_TRUE(reader.takeWarnings().empty());
+}
+
+TEST(CddaSectorReaderTest, NegativeOffsetReadsEarlierFramesAcrossAdjacentAudioTrack)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(2), 0, 10, -5);
+    ASSERT_TRUE(result.has_value());
+
+    const auto values = frameValues(result->pcm);
+    ASSERT_EQ(10, values.size());
+    EXPECT_EQ((4 * FramesPerSector) - 5, values.front());
+    EXPECT_EQ((4 * FramesPerSector) + 4, values.back());
+    EXPECT_TRUE(reader.takeWarnings().empty());
+}
+
+TEST(CddaSectorReaderTest, OffsetNeverReadsAcrossPrecedingDataTrack)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(1), 0, 20, -10);
+    ASSERT_TRUE(result.has_value());
+
+    const auto values = frameValues(result->pcm);
+    ASSERT_EQ(20, values.size());
+    EXPECT_TRUE(std::ranges::all_of(values.begin(), values.begin() + 10, [](int32_t value) { return value == 0; }));
+    EXPECT_EQ(2 * FramesPerSector, values.at(10));
+    EXPECT_EQ((2 * FramesPerSector) + 9, values.back());
+    ASSERT_EQ(1, reader.takeWarnings().size());
+    ASSERT_FALSE(session->requests.empty());
+    EXPECT_GE(session->requests.front().first, 2);
+}
+
+TEST(CddaSectorReaderTest, OffsetNeverReadsAcrossFollowingDataTrack)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+    const int trackFrames = 2 * FramesPerSector;
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(2), trackFrames - 10, 10, 5);
+    ASSERT_TRUE(result.has_value());
+
+    const auto values = frameValues(result->pcm);
+    ASSERT_EQ(10, values.size());
+    EXPECT_EQ((6 * FramesPerSector) - 5, values.front());
+    EXPECT_EQ((6 * FramesPerSector) - 1, values.at(4));
+    EXPECT_TRUE(std::ranges::all_of(values.begin() + 5, values.end(), [](int32_t value) { return value == 0; }));
+    ASSERT_EQ(1, reader.takeWarnings().size());
+    ASSERT_FALSE(session->requests.empty());
+    EXPECT_LE(session->requests.back().first + session->requests.back().second, 6);
+}
+
+TEST(CddaSectorReaderTest, UnavailableCorrectionReturnsExactSilenceWithoutDriveRead)
+{
+    const CdToc toc = mixedModeToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+
+    const auto result = reader.readCorrectedFrames(toc, toc.tracks.at(4), 0, 32, -100000);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(32, result->framesRead);
+    EXPECT_EQ(QByteArray(32 * static_cast<int>(sizeof(int32_t)), '\0'), result->pcm);
+    EXPECT_TRUE(session->requests.empty());
+    ASSERT_EQ(1, reader.takeWarnings().size());
+}
+
+TEST(CddaSectorReaderTest, CorrectionPadsAtDiscBeginningAndEnd)
+{
+    const CdToc toc = audioOnlyToc();
+    auto session    = std::make_unique<FakeSession>([](int firstSector, int count, int) {
+        return std::expected<CdSectorRead, CdError>{indexedRead(firstSector, count)};
+    });
+    CddaSectorReader reader{session.get(), CdRippingSecurity::Disabled};
+    const int trackFrames = 2 * FramesPerSector;
+
+    const auto beginning = reader.readCorrectedFrames(toc, toc.tracks.front(), 0, 10, -5);
+    ASSERT_TRUE(beginning.has_value());
+    const auto beginningValues = frameValues(beginning->pcm);
+    ASSERT_EQ(10, beginningValues.size());
+    EXPECT_TRUE(std::ranges::all_of(beginningValues.begin(), beginningValues.begin() + 5,
+                                    [](int32_t value) { return value == 0; }));
+    EXPECT_EQ(0, beginningValues.at(5));
+    EXPECT_EQ(4, beginningValues.back());
+
+    const auto ending = reader.readCorrectedFrames(toc, toc.tracks.front(), trackFrames - 10, 10, 5);
+    ASSERT_TRUE(ending.has_value());
+    const auto endingValues = frameValues(ending->pcm);
+    ASSERT_EQ(10, endingValues.size());
+    EXPECT_EQ(trackFrames - 5, endingValues.front());
+    EXPECT_EQ(trackFrames - 1, endingValues.at(4));
+    EXPECT_TRUE(
+        std::ranges::all_of(endingValues.begin() + 5, endingValues.end(), [](int32_t value) { return value == 0; }));
+
+    const QStringList warnings = reader.takeWarnings();
+    ASSERT_EQ(2, warnings.size());
+    EXPECT_TRUE(warnings.at(0).contains(u"before"_s));
+    EXPECT_TRUE(warnings.at(1).contains(u"after"_s));
+}
+} // namespace Fooyin::Cdda

--- a/tests/plugins/cdda/cddrivebackendtest.cpp
+++ b/tests/plugins/cdda/cddrivebackendtest.cpp
@@ -1,0 +1,185 @@
+/*
+ * Fooyin
+ * Copyright © 2026, Luke Taylor <luket@pm.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "drive/cddrivebackend.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <tuple>
+
+using namespace Qt::StringLiterals;
+
+namespace Fooyin::Cdda {
+namespace {
+CdToc testToc()
+{
+    return {.firstTrackNumber = 1,
+            .lastTrackNumber  = 2,
+            .leadoutSector    = 150,
+            .tracks           = {{.number = 1, .firstSector = 0, .endSectorExclusive = 75, .isAudio = true},
+                                 {.number = 2, .firstSector = 75, .endSectorExclusive = 150, .isAudio = true}}};
+}
+
+class FakeDriveSession : public CdDriveSession
+{
+public:
+    explicit FakeDriveSession(CdToc toc)
+        : m_toc{std::move(toc)}
+    { }
+
+    std::expected<CdToc, CdError> readToc() override
+    {
+        if(m_cancelled) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Cancelled, .message = u"Cancelled"_s, .platformCode = 0});
+        }
+        return m_toc;
+    }
+
+    std::expected<CdSectorRead, CdError> readAudioSectors(int firstSector, int count) override
+    {
+        if(m_cancelled) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Cancelled, .message = u"Cancelled"_s, .platformCode = 0});
+        }
+        if(firstSector < 0 || count < 0 || firstSector > m_toc.leadoutSector) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::ReadFailed, .message = u"Invalid range"_s, .platformCode = 0});
+        }
+
+        const int available = std::max(m_toc.leadoutSector - firstSector, 0);
+        const int sectors   = std::min(count, available);
+        return CdSectorRead{.pcm = QByteArray(sectors * BytesPerSector, '\x5a'), .sectorsRead = sectors};
+    }
+
+    void cancel() override
+    {
+        m_cancelled = true;
+    }
+
+private:
+    CdToc m_toc;
+    bool m_cancelled{false};
+};
+
+class FakeDriveBackend : public CdDriveBackend
+{
+public:
+    std::vector<CdDriveInfo> drives() override
+    {
+        return {{.id                 = u"drive-0"_s,
+                 .displayName        = u"Test optical drive"_s,
+                 .settingsKey        = u"test:model:serial"_s,
+                 .supportsSpeedLimit = true,
+                 .vendor             = {},
+                 .model              = {},
+                 .revision           = {}}};
+    }
+
+    std::expected<OpenedDrive, CdError> open(const QString& driveId) override
+    {
+        if(driveId != u"drive-0"_s) {
+            return std::unexpected(
+                CdError{.code = CdDriveError::Unsupported, .message = u"Unknown drive"_s, .platformCode = 404});
+        }
+        return OpenedDrive{.drive = drives().front(), .session = std::make_unique<FakeDriveSession>(testToc())};
+    }
+};
+} // namespace
+
+TEST(CdDriveBackendTest, OpenedSessionReadsTocAndAudioUntilCancelled)
+{
+    FakeDriveBackend backend;
+
+    const std::vector<CdDriveInfo> drives = backend.drives();
+    ASSERT_EQ(1, drives.size());
+    EXPECT_EQ(u"drive-0"_s, drives.front().id);
+    EXPECT_TRUE(drives.front().supportsSpeedLimit);
+
+    auto opened = backend.open(drives.front().id);
+    ASSERT_TRUE(opened.has_value()) << opened.error().message.toStdString();
+    EXPECT_EQ(drives.front(), opened->drive);
+    std::unique_ptr<CdDriveSession> session = std::move(opened->session);
+
+    const auto toc = session->readToc();
+    ASSERT_TRUE(toc.has_value()) << toc.error().message.toStdString();
+    EXPECT_EQ(testToc(), *toc);
+
+    const auto read = session->readAudioSectors(149, 4);
+    ASSERT_TRUE(read.has_value()) << read.error().message.toStdString();
+    EXPECT_EQ(1, read->sectorsRead);
+    EXPECT_EQ(BytesPerSector, read->pcm.size());
+    EXPECT_TRUE(validateSectorRead(*read, 4).has_value());
+
+    const auto secure = session->readAudioSectorsSecure(0, 1, CdRippingSecurity::Standard);
+    ASSERT_FALSE(secure.has_value());
+    EXPECT_EQ(CdDriveError::Unsupported, secure.error().code);
+
+    const auto speed = session->setReadSpeed(4);
+    ASSERT_FALSE(speed.has_value());
+    EXPECT_EQ(CdDriveError::Unsupported, speed.error().code);
+
+    session->cancel();
+    const auto cancelledRead = session->readAudioSectors(0, 1);
+    ASSERT_FALSE(cancelledRead.has_value());
+    EXPECT_EQ(CdDriveError::Cancelled, cancelledRead.error().code);
+}
+
+TEST(CdDriveBackendTest, OpenPreservesStableErrors)
+{
+    FakeDriveBackend backend;
+    const auto opened = backend.open(u"missing"_s);
+
+    ASSERT_FALSE(opened.has_value());
+    EXPECT_EQ(CdDriveError::Unsupported, opened.error().code);
+    EXPECT_EQ(u"Unknown drive"_s, opened.error().message);
+    EXPECT_EQ(404, opened.error().platformCode);
+}
+
+TEST(CdDriveBackendTest, ValidatesSectorCountAndCompleteBuffers)
+{
+    EXPECT_TRUE(validateSectorRead({QByteArray(2 * BytesPerSector, '\0'), 2}, 2).has_value());
+    EXPECT_TRUE(validateSectorRead({}, 0).has_value());
+
+    const auto invalidBuffer = validateSectorRead({QByteArray(BytesPerSector, '\0'), 2}, 2);
+    ASSERT_FALSE(invalidBuffer.has_value());
+    EXPECT_TRUE(invalidBuffer.error().message.isEmpty());
+    EXPECT_FALSE(validateSectorRead({QByteArray(2 * BytesPerSector, '\0'), 2}, 1).has_value());
+    EXPECT_FALSE(validateSectorRead({}, -1).has_value());
+}
+
+TEST(CdDriveBackendTest, ValidatesBoundedSectorReadRequests)
+{
+    EXPECT_TRUE(validateSectorReadRequest(0, 0, 16).has_value());
+    EXPECT_TRUE(validateSectorReadRequest(1234, 16, 16).has_value());
+
+    for(const auto& [firstSector, count, maximum] : {
+            std::tuple{-1, 1, 16},
+            std::tuple{0, -1, 16},
+            std::tuple{0, 17, 16},
+            std::tuple{0, 1, 0},
+            std::tuple{std::numeric_limits<int>::max(), 1, 16},
+        }) {
+        const auto result = validateSectorReadRequest(firstSector, count, maximum);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(CdDriveError::ReadFailed, result.error().code);
+        EXPECT_TRUE(result.error().message.isEmpty());
+    }
+}
+} // namespace Fooyin::Cdda


### PR DESCRIPTION
Adds functionality to open and read audio CDs, including playback and ripping using the existing metadata lookup and converter workflows.

A new `File -> Open audio CD` menu option opens the initial dialog. This supports reading CD-Text and looking up metadata before adding the CD tracks to a playlist and/or playing.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6a0221c7-d362-494b-8844-a9a21f7c838f" />

Each drive's individual settings used for ripping can also be configured:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/1c530399-9648-44fb-8b21-a0dbe075f272" />

Using the `Rip` button opens the `Rip Audio CD` dialog, from which metadata can be edited and looked up again. The ripping process uses the saved converter presets, or the converter can be opened directly.

<img width="660" alt="image" src="https://github.com/user-attachments/assets/5b0fce3e-f2cc-419d-9f61-226e85630d51" />

If `Verify with AccurateRip` is checked, a verification report will be shown at the end of the ripping process:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/e4b311ba-3508-425d-a16a-cdaf7f6c3f35" />

Closes #834
